### PR TITLE
Remove fixed WR width, bigger margin for better QR reading

### DIFF
--- a/apps/web-app/src/pages/CashuTokenPage.tsx
+++ b/apps/web-app/src/pages/CashuTokenPage.tsx
@@ -115,8 +115,7 @@ export const CashuTokenPage: FC<CashuTokenPageProps> = ({
         const QRCode = await import("qrcode");
         const qr = await QRCode.toDataURL(tokenText, {
           errorCorrectionLevel: "M",
-          margin: 1,
-          width: 420,
+          margin: 2
         });
         if (!cancelled) {
           setTokenQr(qr);


### PR DESCRIPTION
This fixes reading big QR codes, which gets malformed due fixed width. It allows downlod original size, which can be zoomed in gallery later or picked up by file picker.