### PR TITLE
Fix broken Back up keys onboarding guide (blinking screen, dead Back button)

### DIFF
--- a/apps/web-app/src/App.css
+++ b/apps/web-app/src/App.css
@@ -1120,6 +1120,11 @@
   font-weight: 900;
 }
 
+.guide-actions .guide-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 .pay-method-toggle {
   border: none;
   background: rgba(148, 163, 184, 0.12);

--- a/apps/web-app/src/app/hooks/guide/useContactsGuide.ts
+++ b/apps/web-app/src/app/hooks/guide/useContactsGuide.ts
@@ -11,6 +11,7 @@ import type {
 interface UseContactsGuideParams {
   cashuBalance: number;
   contacts: readonly ContactRowLike[];
+  contactsOnboardingHasBackedUpKeys: boolean;
   contactsOnboardingHasPaid: boolean;
   contactsOnboardingHasSentMessage: boolean;
   openNewContactPage: () => void;
@@ -33,6 +34,7 @@ const getRouteContactId = (route: Route): ContactId | null => {
 export const useContactsGuide = ({
   cashuBalance,
   contacts,
+  contactsOnboardingHasBackedUpKeys,
   contactsOnboardingHasPaid,
   contactsOnboardingHasSentMessage,
   openNewContactPage,
@@ -90,6 +92,10 @@ export const useContactsGuide = ({
 
       if (kind === "contacts") navigateTo({ route: "contacts" });
       if (kind === "wallet") navigateTo({ route: "wallet" });
+      if (kind === "settings") navigateTo({ route: "settings" });
+      if (kind === "settingsMasterKeys") {
+        navigateTo({ route: "settingsMasterKeys" });
+      }
       if (kind === "advanced") navigateTo({ route: "advanced" });
       if (kind === "topup") navigateTo({ route: "topup" });
       if (kind === "topupInvoice") navigateTo({ route: "topupInvoice" });
@@ -207,10 +213,17 @@ export const useContactsGuide = ({
         },
         {
           id: "backup_keys_2",
+          selector: '[data-guide="open-master-keys"]',
+          titleKey: "guideBackupKeysStep2Title",
+          bodyKey: "guideBackupKeysStep2Body",
+          ensure: () => ensureRoute("settings"),
+        },
+        {
+          id: "backup_keys_3",
           selector: '[data-guide="copy-seed"]',
           titleKey: "guideBackupKeysStep3Title",
           bodyKey: "guideBackupKeysStep3Body",
-          ensure: () => ensureRoute("settings"),
+          ensure: () => ensureRoute("settingsMasterKeys"),
         },
       ],
     };
@@ -239,9 +252,21 @@ export const useContactsGuide = ({
     };
   }, [contactsGuide, contactsGuideSteps]);
 
+  // Ensure the step's route only when the step becomes active. Re-running
+  // ensure on every route change would fight user navigation: following the
+  // step instruction (or pressing the system Back button) would immediately
+  // navigate back to the previous step's route before the step advances.
+  const contactsGuideLastEnsuredStepIdRef = React.useRef<string | null>(null);
+
   React.useEffect(() => {
     const active = contactsGuideActiveStep?.step ?? null;
-    if (!contactsGuide || !active) return;
+    if (!contactsGuide || !active) {
+      contactsGuideLastEnsuredStepIdRef.current = null;
+      return;
+    }
+
+    if (contactsGuideLastEnsuredStepIdRef.current === active.id) return;
+    contactsGuideLastEnsuredStepIdRef.current = active.id;
 
     try {
       active.ensure?.();
@@ -321,6 +346,23 @@ export const useContactsGuide = ({
     }
     if (id === "message_2" && transition("contact", "chat")) goToStep(2);
 
+    if (id === "backup_keys_1" && transition("contacts", "settings")) {
+      goToStep(1);
+    }
+    if (
+      id === "backup_keys_2" &&
+      transition("settings", "settingsMasterKeys")
+    ) {
+      goToStep(2);
+    }
+
+    if (
+      contactsGuide.task === "backup_keys" &&
+      contactsOnboardingHasBackedUpKeys
+    ) {
+      stopContactsGuide();
+    }
+
     if (contactsGuide.task === "topup" && cashuBalance > 0) stopContactsGuide();
     if (contactsGuide.task === "pay" && contactsOnboardingHasPaid) {
       stopContactsGuide();
@@ -332,6 +374,7 @@ export const useContactsGuide = ({
     cashuBalance,
     contactsGuide,
     contactsGuideActiveStep?.step,
+    contactsOnboardingHasBackedUpKeys,
     contactsOnboardingHasPaid,
     contactsOnboardingHasSentMessage,
     route,

--- a/apps/web-app/src/app/hooks/useGuideScannerDomain.ts
+++ b/apps/web-app/src/app/hooks/useGuideScannerDomain.ts
@@ -14,6 +14,7 @@ import { useContactsGuide } from "./guide/useContactsGuide";
 interface UseGuideScannerDomainParams {
   cashuBalance: number;
   contacts: readonly ContactRowLike[];
+  contactsOnboardingHasBackedUpKeys: boolean;
   contactsOnboardingHasPaid: boolean;
   contactsOnboardingHasSentMessage: boolean;
   openNewContactPage: () => void;
@@ -51,6 +52,7 @@ const formatScanDebugDetails = (details?: Record<string, unknown>) => {
 export const useGuideScannerDomain = ({
   cashuBalance,
   contacts,
+  contactsOnboardingHasBackedUpKeys,
   contactsOnboardingHasPaid,
   contactsOnboardingHasSentMessage,
   openNewContactPage,
@@ -62,6 +64,7 @@ export const useGuideScannerDomain = ({
   const contactsGuideDomain = useContactsGuide({
     cashuBalance,
     contacts,
+    contactsOnboardingHasBackedUpKeys,
     contactsOnboardingHasPaid,
     contactsOnboardingHasSentMessage,
     openNewContactPage,

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -6390,6 +6390,7 @@ export const useAppShellComposition = () => {
   } = useGuideScannerDomain({
     cashuBalance,
     contacts,
+    contactsOnboardingHasBackedUpKeys,
     contactsOnboardingHasPaid,
     contactsOnboardingHasSentMessage,
     openNewContactPage,

--- a/apps/web-app/src/i18n/cs.ts
+++ b/apps/web-app/src/i18n/cs.ts
@@ -482,8 +482,7 @@ export const cs = {
   guideBackupKeysStep2Title: "Pokročilé",
   guideBackupKeysStep2Body: "Otevřete Pokročilé nastavení.",
   guideBackupKeysStep3Title: "Záloha klíče",
-  guideBackupKeysStep3Body:
-    "Zkopírujte svůj Nostr privátní klíč a uložte ho někam bezpečně, třeba do poznámek.",
+  guideBackupKeysStep3Body: "Zkopírujte své hlavní klíče a bezpečně je uložte.",
   contactsOnboardingTaskAddContact: "Přidat kontakt",
   contactsOnboardingTaskBackupKeys: "Zálohovat klíče",
   contactsOnboardingTaskTopup: "Přijmout bitcoin",

--- a/apps/web-app/src/i18n/en.ts
+++ b/apps/web-app/src/i18n/en.ts
@@ -479,7 +479,7 @@ export const en = {
   guideBackupKeysStep2Body: "Open Advanced settings.",
   guideBackupKeysStep3Title: "Backup keys",
   guideBackupKeysStep3Body:
-    "Copy your Nostr private key and save it somewhere safe, like your notes.",
+    "Copy your masterkeys and save them somewhere safe.",
   contactsOnboardingTaskAddContact: "Add  contact",
   contactsOnboardingTaskBackupKeys: "Back up keys",
   contactsOnboardingTaskTopup: "Receive bitcoin",

--- a/apps/web-app/src/pages/AdvancedPage.tsx
+++ b/apps/web-app/src/pages/AdvancedPage.tsx
@@ -674,6 +674,7 @@ export function AdvancedPage({
           className="settings-row settings-link"
           onClick={() => navigateTo({ route: "settingsMasterKeys" })}
           disabled={!hasSeedMnemonic}
+          data-guide="open-master-keys"
         >
           <span className="settings-left">
             <span className="settings-icon" aria-hidden="true">

--- a/apps/web-app/src/pages/MasterKeysPage.tsx
+++ b/apps/web-app/src/pages/MasterKeysPage.tsx
@@ -101,7 +101,12 @@ export function MasterKeysPage({
           <span>{isVisible ? t("masterKeysHide") : t("masterKeysShow")}</span>
         </button>
 
-        <button type="button" onClick={copySeed} disabled={!hasSeedMnemonic}>
+        <button
+          type="button"
+          onClick={copySeed}
+          disabled={!hasSeedMnemonic}
+          data-guide="copy-seed"
+        >
           <Copy size={18} />
           <span>{t("copy")}</span>
         </button>

--- a/apps/web-app/tests/contactsGuideBackupKeys.test.tsx
+++ b/apps/web-app/tests/contactsGuideBackupKeys.test.tsx
@@ -1,0 +1,173 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { navigateToMock } = vi.hoisted(() => ({
+  navigateToMock: vi.fn(),
+}));
+
+vi.mock("../src/hooks/useRouting", () => ({
+  navigateTo: navigateToMock,
+  useNavigation: () => navigateToMock,
+}));
+
+import { useContactsGuide } from "../src/app/hooks/guide/useContactsGuide";
+import type { Route } from "../src/types/route";
+
+type GuideApi = ReturnType<typeof useContactsGuide>;
+
+interface HarnessProps {
+  contactsOnboardingHasBackedUpKeys: boolean;
+  onRender: (api: GuideApi) => void;
+  route: Route;
+}
+
+const Harness = ({
+  contactsOnboardingHasBackedUpKeys,
+  onRender,
+  route,
+}: HarnessProps): null => {
+  const api = useContactsGuide({
+    cashuBalance: 0,
+    contacts: [],
+    contactsOnboardingHasBackedUpKeys,
+    contactsOnboardingHasPaid: false,
+    contactsOnboardingHasSentMessage: false,
+    openNewContactPage: () => {},
+    route,
+  });
+
+  onRender(api);
+  return null;
+};
+
+const setup = () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  let api: GuideApi | null = null;
+
+  const render = (
+    route: Route,
+    contactsOnboardingHasBackedUpKeys = false,
+  ): void => {
+    act(() => {
+      root.render(
+        <Harness
+          contactsOnboardingHasBackedUpKeys={contactsOnboardingHasBackedUpKeys}
+          onRender={(value) => {
+            api = value;
+          }}
+          route={route}
+        />,
+      );
+    });
+  };
+
+  const getApi = (): GuideApi => {
+    if (!api) throw new Error("Guide harness has not rendered yet.");
+    return api;
+  };
+
+  const cleanup = (): void => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  };
+
+  return { cleanup, getApi, render };
+};
+
+afterEach(() => {
+  navigateToMock.mockReset();
+  document.body.innerHTML = "";
+});
+
+describe("useContactsGuide backup_keys task", () => {
+  it("advances to the master keys step when the user opens settings", () => {
+    const { cleanup, getApi, render } = setup();
+
+    render({ kind: "contacts" });
+    act(() => {
+      getApi().startContactsGuide("backup_keys");
+    });
+
+    expect(getApi().contactsGuideActiveStep?.step?.id).toBe("backup_keys_1");
+
+    // The user follows the instruction and taps the menu (gear) button,
+    // which navigates to the settings route.
+    render({ kind: "settings" });
+
+    expect(getApi().contactsGuideActiveStep?.step?.id).toBe("backup_keys_2");
+
+    cleanup();
+  });
+
+  it("does not navigate the user away from settings while on the menu step", () => {
+    const { cleanup, getApi, render } = setup();
+
+    render({ kind: "contacts" });
+    act(() => {
+      getApi().startContactsGuide("backup_keys");
+    });
+
+    navigateToMock.mockClear();
+    render({ kind: "settings" });
+
+    expect(navigateToMock).not.toHaveBeenCalledWith({ route: "contacts" });
+
+    cleanup();
+  });
+
+  it("advances to the copy step when the user opens master keys", () => {
+    const { cleanup, getApi, render } = setup();
+
+    render({ kind: "contacts" });
+    act(() => {
+      getApi().startContactsGuide("backup_keys");
+    });
+    render({ kind: "settings" });
+    render({ kind: "settingsMasterKeys" });
+
+    expect(getApi().contactsGuideActiveStep?.step?.id).toBe("backup_keys_3");
+
+    cleanup();
+  });
+
+  it("ensures the settings route when the master keys step is reached via Next", () => {
+    const { cleanup, getApi, render } = setup();
+
+    render({ kind: "contacts" });
+    act(() => {
+      getApi().startContactsGuide("backup_keys");
+    });
+
+    navigateToMock.mockClear();
+    act(() => {
+      getApi().contactsGuideNav.next();
+    });
+
+    expect(navigateToMock).toHaveBeenCalledWith({ route: "settings" });
+
+    cleanup();
+  });
+
+  it("stops the guide once the keys have been backed up", () => {
+    const { cleanup, getApi, render } = setup();
+
+    render({ kind: "contacts" });
+    act(() => {
+      getApi().startContactsGuide("backup_keys");
+    });
+
+    expect(getApi().contactsGuide).not.toBeNull();
+
+    render({ kind: "settingsMasterKeys" }, true);
+
+    expect(getApi().contactsGuide).toBeNull();
+
+    cleanup();
+  });
+});


### PR DESCRIPTION
## Problem

After receiving bitcoin, the Getting started checklist asks the user to **Back up keys**. Following the guide's own instruction dead-ends it:

1. The guide shows "1 / 2 — Menu — Open the menu to access advanced settings." and highlights the gear button. Tapping the gear opens `#settings` for a split second and the app immediately navigates back to contacts — the screen just blinks and the same dialog stays.
2. The dialog's **Back** button does nothing (it is functionally disabled on the first step but styled like an active button).

Reproduced on a Pixel 6 emulator (API 36) with a fresh debug APK.

## Root cause

The "settings cleanup" commit (d92cb60) moved the menu from a modal to the `#settings` route and moved seed backup to `#settings/master-keys`, but the `backup_keys` guided tour in `useContactsGuide.ts` was left half-migrated:

- No route-transition handler ever advances `backup_keys` past step 1 (unlike `topup`/`pay`/`message`), and the active step's `ensure()` re-runs on every route change — so `ensureRoute("contacts")` instantly yanks the user back from settings. That is the "blink".
- Step 2 targeted `[data-guide="copy-seed"]`, which exists nowhere in the codebase, and called `ensureRoute("settings")`, which was a no-op because `ensureRoute` had no `settings` branch.

## Fix

- Rebuild the task as **3 steps**: menu gear → **Master keys** row on settings → **Copy** button on the master keys page, with route-transition handlers (`contacts→settings`, `settings→settingsMasterKeys`) and `ensureRoute` support for `settings` / `settingsMasterKeys`.
- Add the missing `data-guide` anchors: `open-master-keys` on the AdvancedPage security row, `copy-seed` on the MasterKeysPage Copy button.
- Stop the guide automatically once `contactsOnboardingHasBackedUpKeys` becomes true, matching how the other tasks complete.
- Run a step's `ensure()` only when the step becomes active instead of on every route change, so the guide no longer fights user navigation (this also made the Back button appear dead: every backward navigation was immediately reverted).
- Give disabled guide buttons a visibly dimmed style, so the inactive Back button on the first step reads as disabled.
- Update the en/cs guide texts to the current settings navigation.

## Verification

- New unit tests in `apps/web-app/tests/contactsGuideBackupKeys.test.tsx` (fail on `main`, pass here): step advancement on `contacts→settings` and `settings→settingsMasterKeys`, no yank-back to contacts, `ensureRoute("settings")` works, guide stops when keys are backed up.
- `bun run check-code` passes; full vitest suite has the same 20 pre-existing failures as `main`, none related.
- End-to-end on a Pixel 6 API 36 emulator (debug APK): the full guide walks gear → Master keys → Copy, the toast "Keys copied to clipboard." appears, the guide closes, and the checklist shows "Back up keys" completed (1/5). The dialog Back button navigates from step 3 back to step 2 including the route change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
