### PR TITLE
Fix overlapping layout on Push/SW debug settings page

### DIFF
--- a/apps/web-app/src/pages/PushDebugPage.tsx
+++ b/apps/web-app/src/pages/PushDebugPage.tsx
@@ -296,12 +296,12 @@ export function PushDebugPage({
 
   return (
     <section className="panel">
-      <div className="settings-row">
+      <div className="settings-row settings-row-stack-mobile">
         <div className="settings-left">
           <span className="settings-label">Push / SW debug</span>
         </div>
-        <div className="settings-right">
-          <div className="badge-box">
+        <div className="settings-right settings-right-wrap">
+          <div className="badge-box badge-box-wrap">
             <button
               className="ghost"
               onClick={() => void refreshReport()}
@@ -366,6 +366,7 @@ export function PushDebugPage({
       <pre
         style={{
           overflowX: "auto",
+          overflowWrap: "anywhere",
           whiteSpace: "pre-wrap",
           fontSize: 12,
           lineHeight: 1.4,


### PR DESCRIPTION
## Problem

On `#advanced/push-debug` (Settings → Advanced → Push debug), the action buttons rendered **on top of** the "Push / SW debug" label, and the JSON report text bled through from behind them. The row was unusable on a phone.

## Root cause

`.badge-box` holds 7 action buttons and has `display: flex` with **no `flex-wrap`**. Measured on a 412px viewport:

| | value |
|---|---|
| `.badge-box` intrinsic width | **597px** |
| `.settings-right` container width | 267px |
| resulting `.badge-box` left edge | **−226px** |

Flex items default to `min-width: auto`, so they refuse to shrink below min-content. Since `.settings-row` uses `justify-content: space-between` and `.settings-right` uses `justify-content: flex-end`, the overflow spilled *leftward* — directly over `.settings-left` — instead of running off the right edge.

The label was collateral damage: `.settings-left` has `min-width: 0` and `.settings-label` has `overflow-wrap: anywhere`, so "Push / SW debug" was crushed to 49px wide and wrapped to 3 lines (77px tall). Those fragments are what showed through between the buttons.

Separately, the report `<pre>` had `scrollWidth: 706px` against `clientWidth: 328px` — long unbroken localStorage keys and push endpoint URLs have no break opportunity under `white-space: pre-wrap`.

## Fix

Apply the mobile-stacking pattern **already defined in `App.css`** but never wired up to this page (`settings-row-stack-mobile` / `settings-right-wrap` / `badge-box-wrap`, added in 22fad13 and orphaned by a later refactor). Plus `overflow-wrap: anywhere` on the `<pre>`.

No new CSS was introduced.

## Verification

Reproduced and verified on a **Pixel 6 / API 36 emulator** at 412px, measured over CDP against the running WebView:

| | before | after |
|---|---|---|
| `.badge-box` `flex-wrap` | `nowrap` | `wrap` |
| `.badge-box` width / left | 597px / **−226px** | 328px / 42px |
| `.settings-label` | 49px wide, 77px tall | 125px wide, 26px tall |
| label overlaps buttons | **yes** | no |
| `<pre>` scrollWidth vs clientWidth | 706 / 328 | 328 / 328 |
| report starts below buttons | no | yes |

`bun run check-code` passes (0 errors; the 12 remaining `react-hooks/exhaustive-deps` warnings are pre-existing in `useAppShellComposition.tsx` and untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)