### PR TITLE
Fix regressions found while smoke-testing PR #171

### DIFF
--- a/apps/site/src/cashu/CashuPage.tsx
+++ b/apps/site/src/cashu/CashuPage.tsx
@@ -1774,14 +1774,13 @@ function CashuPage() {
 
         setTokenError(null);
       })
-      .catch((error) => {
+      .catch(() => {
         if (cancelled) return;
         setTokenState(null);
         setMintIconSrc(GENERIC_MINT_ICON_DATA_URL);
-        const detail = getErrorMessage(error, "").trim();
         setTokenError({
           code: "unknown",
-          detail: detail || null,
+          detail: null,
         });
       })
       .finally(() => {

--- a/apps/web-app/src/app/hooks/contacts/useContactEditor.ts
+++ b/apps/web-app/src/app/hooks/contacts/useContactEditor.ts
@@ -281,33 +281,48 @@ export const useContactEditor = ({
     setContactEditInitial(null);
   }, []);
 
+  const clearContactSuggestions = React.useCallback(() => {
+    setContactSuggestions((current) => (current.length === 0 ? current : []));
+  }, []);
+  const contactSuggestionRelayKey = nostrFetchRelays
+    .map((relay) => relay.trim())
+    .filter(Boolean)
+    .join("\n");
+  const contactSuggestionKnownNpubsKey = Array.from(
+    new Set(
+      [
+        ...contacts.map((contact) => normalizeNpubIdentifier(contact.npub)),
+        normalizeNpubIdentifier(currentNpub),
+      ].filter((npub): npub is string => Boolean(npub)),
+    ),
+  )
+    .sort()
+    .join("\n");
+
   React.useEffect(() => {
     if (route.kind !== "contactNew") {
-      setContactSuggestions([]);
+      clearContactSuggestions();
       return;
     }
 
     if (form.npub.trim()) {
-      setContactSuggestions([]);
+      clearContactSuggestions();
       return;
     }
 
-    const relays = nostrFetchRelays
-      .map((relay) => relay.trim())
-      .filter(Boolean);
+    const relays = contactSuggestionRelayKey
+      ? contactSuggestionRelayKey.split("\n")
+      : [];
     if (relays.length === 0) {
-      setContactSuggestions([]);
+      clearContactSuggestions();
       return;
     }
 
-    const knownNpubs = new Set<string>();
-    for (const contact of contacts) {
-      const normalized = normalizeNpubIdentifier(contact.npub);
-      if (normalized) knownNpubs.add(normalized);
-    }
-
-    const ownNpub = normalizeNpubIdentifier(currentNpub);
-    if (ownNpub) knownNpubs.add(ownNpub);
+    const knownNpubs = new Set(
+      contactSuggestionKnownNpubsKey
+        ? contactSuggestionKnownNpubsKey.split("\n")
+        : [],
+    );
 
     let cancelled = false;
 
@@ -333,7 +348,7 @@ export const useContactEditor = ({
           .map((entry) => entry[0]);
 
         if (authors.length === 0) {
-          setContactSuggestions([]);
+          clearContactSuggestions();
           return;
         }
 
@@ -393,7 +408,7 @@ export const useContactEditor = ({
 
         setContactSuggestions(nextSuggestions);
       } catch {
-        if (!cancelled) setContactSuggestions([]);
+        if (!cancelled) clearContactSuggestions();
       }
     };
 
@@ -402,7 +417,13 @@ export const useContactEditor = ({
     return () => {
       cancelled = true;
     };
-  }, [contacts, currentNpub, form.npub, nostrFetchRelays, route.kind]);
+  }, [
+    clearContactSuggestions,
+    contactSuggestionKnownNpubsKey,
+    contactSuggestionRelayKey,
+    form.npub,
+    route.kind,
+  ]);
 
   const buildFullContactOverridePayload = React.useCallback(
     (

--- a/apps/web-app/src/app/hooks/messages/chatNostrProtocol.ts
+++ b/apps/web-app/src/app/hooks/messages/chatNostrProtocol.ts
@@ -74,6 +74,12 @@ export const extractEditedFromTag = (tags: unknown): string | null => {
   return null;
 };
 
+export const resolveStableMessageRumorId = (
+  rumorId: unknown,
+  editedFromId: unknown,
+): string | null =>
+  normalizeText(editedFromId) || normalizeText(rumorId) || null;
+
 export const extractDeleteReferencedIds = (tags: unknown): string[] => {
   const ids: string[] = [];
   const seen = new Set<string>();

--- a/apps/web-app/src/app/hooks/messages/contactIdentity.test.ts
+++ b/apps/web-app/src/app/hooks/messages/contactIdentity.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildUnknownContactId,
+  readUnknownContactIdPubkey,
+} from "./contactIdentity";
+
+describe("unknown contact ids", () => {
+  it("round-trips the peer pubkey", () => {
+    const pubkey = "a".repeat(64);
+    const contactId = buildUnknownContactId(pubkey);
+
+    expect(contactId).not.toBeNull();
+    expect(readUnknownContactIdPubkey(contactId)).toBe(pubkey);
+  });
+
+  it("rejects malformed and known contact ids", () => {
+    expect(readUnknownContactIdPubkey("unknown:not-a-pubkey")).toBeNull();
+    expect(readUnknownContactIdPubkey("contact-id")).toBeNull();
+  });
+});

--- a/apps/web-app/src/app/hooks/messages/contactIdentity.ts
+++ b/apps/web-app/src/app/hooks/messages/contactIdentity.ts
@@ -34,6 +34,16 @@ export const isUnknownContactId = (id: unknown): boolean => {
   return normalizedId.startsWith(UNKNOWN_CONTACT_ID_PREFIX);
 };
 
+export const readUnknownContactIdPubkey = (id: unknown): string | null => {
+  const normalizedId = String(id ?? "")
+    .trim()
+    .toLowerCase();
+  if (!normalizedId.startsWith(UNKNOWN_CONTACT_ID_PREFIX)) return null;
+  return normalizePubkeyHex(
+    normalizedId.slice(UNKNOWN_CONTACT_ID_PREFIX.length),
+  );
+};
+
 export interface ResolvedNostrChatIdentity {
   contactPubHex: string;
   myPubHex: string;

--- a/apps/web-app/src/app/hooks/messages/useChatNostrSyncEffect.ts
+++ b/apps/web-app/src/app/hooks/messages/useChatNostrSyncEffect.ts
@@ -23,6 +23,7 @@ import {
   extractReplyContextFromTags,
   isInvalidInnerRumorPubkey,
   isNestedEncryptedNip44PayloadForAnyPubkey,
+  resolveStableMessageRumorId,
 } from "./chatNostrProtocol";
 import { privateImageMessageFromEvent } from "../../lib/privateImageMessage";
 import { resolveNostrChatIdentity } from "./contactIdentity";
@@ -345,7 +346,10 @@ export const useChatNostrSyncEffect = ({
                 return;
               }
 
-              const stableRumorId = editedFromId || rumorId;
+              const stableRumorId = resolveStableMessageRumorId(
+                rumorId,
+                editedFromId,
+              );
 
               appendLocalNostrMessage({
                 contactId: String(selectedContact.id),

--- a/apps/web-app/src/app/hooks/messages/useInboxNotificationsSync.ts
+++ b/apps/web-app/src/app/hooks/messages/useInboxNotificationsSync.ts
@@ -50,6 +50,7 @@ import {
   extractReplyContextFromTags,
   isInvalidInnerRumorPubkey,
   isNestedEncryptedNip44PayloadForAnyPubkey,
+  resolveStableMessageRumorId,
 } from "./chatNostrProtocol";
 import { buildUnknownContactId, normalizePubkeyHex } from "./contactIdentity";
 import type { KnownNostrMessageIdentityIndex } from "./messageHelpers";
@@ -321,6 +322,9 @@ export const useInboxNotificationsSync = <
           indexedContacts = latestContacts;
           contactByPubHex.clear();
           for (const contact of latestContacts) {
+            const archivedAtSec = Number(contact.archivedAtSec ?? 0);
+            if (Number.isFinite(archivedAtSec) && archivedAtSec > 0) continue;
+
             const npub = normalizeNpubIdentifier(contact.npub);
             if (!npub) continue;
             try {
@@ -839,6 +843,10 @@ export const useInboxNotificationsSync = <
               const { replyToId, rootMessageId } =
                 extractReplyContextFromTags(tags);
               const editedFromId = extractEditedFromTag(tags);
+              const stableRumorId = resolveStableMessageRumorId(
+                rumorId,
+                editedFromId,
+              );
               const effectivePubkey = isOutgoing ? myPubHex : resolvedPeerPub;
               const normalizedIncomingPeerPubkey = isOutgoing
                 ? null
@@ -885,7 +893,7 @@ export const useInboxNotificationsSync = <
                     wrapId,
                     pubkey: effectivePubkey,
                     ...(tagClientId ? { clientId: tagClientId } : {}),
-                    ...(rumorId ? { rumorId } : {}),
+                    ...(stableRumorId ? { rumorId: stableRumorId } : {}),
                     isEdited: true,
                     editedAtSec: createdAtSec,
                     editedFromId,
@@ -935,7 +943,7 @@ export const useInboxNotificationsSync = <
                     wrapId,
                     pubkey: effectivePubkey,
                     ...(tagClientId ? { clientId: tagClientId } : {}),
-                    ...(rumorId ? { rumorId } : {}),
+                    ...(stableRumorId ? { rumorId: stableRumorId } : {}),
                     ...(replyToId ? { replyToId } : {}),
                     ...(rootMessageId ? { rootMessageId } : {}),
                     ...(editedFromId ? { editedFromId } : {}),
@@ -949,7 +957,7 @@ export const useInboxNotificationsSync = <
                 direction: isOutgoing ? "out" : "in",
                 content,
                 wrapId,
-                rumorId: rumorId || null,
+                rumorId: stableRumorId,
                 pubkey: effectivePubkey,
                 createdAtSec,
                 ...(tagClientId ? { clientId: tagClientId } : {}),

--- a/apps/web-app/src/app/hooks/useMessagesDomain.ts
+++ b/apps/web-app/src/app/hooks/useMessagesDomain.ts
@@ -1410,13 +1410,41 @@ export const useMessagesDomain = ({
       if (!normalizedFrom || !normalizedTo) return 0;
 
       const movedMessageIds = new Set<string>();
+      const targetIsUnknown = isUnknownContactId(normalizedTo);
+      const nextOverlayMessages: LocalNostrMessage[] = [];
 
-      const nextOverlayMessages = overlayMessagesRef.current.map((message) => {
-        if (toTrimmedText(message.contactId) !== normalizedFrom) return message;
+      for (const message of overlayMessagesRef.current) {
+        if (toTrimmedText(message.contactId) !== normalizedFrom) {
+          nextOverlayMessages.push(message);
+          continue;
+        }
+
         movedMessageIds.add(toTrimmedText(message.id));
-        return { ...message, contactId: normalizedTo };
-      });
-      persistOverlayMessages(nextOverlayMessages);
+        const movedMessage = { ...message, contactId: normalizedTo };
+
+        if (targetIsUnknown) {
+          nextOverlayMessages.push(movedMessage);
+          continue;
+        }
+
+        const payload = buildMessageInsertPayload(movedMessage);
+        const result = payload ? insertNostrMessage(payload) : null;
+        if (!result?.ok) nextOverlayMessages.push(movedMessage);
+      }
+
+      if (targetIsUnknown) {
+        for (const message of nostrMessagesLatestRef.current) {
+          if (toTrimmedText(message.contactId) !== normalizedFrom) continue;
+          const id = toTrimmedText(message.id);
+          if (!id) continue;
+          movedMessageIds.add(id);
+          nextOverlayMessages.push({
+            ...message,
+            contactId: normalizedTo,
+          });
+          updateNostrMessage({ id, isDeleted: Evolu.sqliteTrue });
+        }
+      }
 
       for (const row of nostrMessageRows) {
         if (!isVisibleMessageOwner(row)) continue;
@@ -1424,12 +1452,32 @@ export const useMessagesDomain = ({
         const id = toTrimmedText(row.id);
         if (!id) continue;
         movedMessageIds.add(id);
+
+        if (targetIsUnknown) {
+          const message = toLocalNostrMessage(row);
+          if (message) {
+            nextOverlayMessages.push({
+              ...message,
+              contactId: normalizedTo,
+            });
+          }
+          updateNostrMessage({ id, isDeleted: Evolu.sqliteTrue });
+          continue;
+        }
+
         updateNostrMessage({ id, contactId: normalizedTo });
       }
+
+      persistOverlayMessages(
+        dedupeNostrMessagesByPriority(nextOverlayMessages).sort(
+          (a, b) => a.createdAtSec - b.createdAtSec,
+        ),
+      );
 
       return movedMessageIds.size;
     },
     [
+      insertNostrMessage,
       isVisibleMessageOwner,
       nostrMessageRows,
       persistOverlayMessages,

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -183,6 +183,7 @@ import {
   buildUnknownContactId,
   isUnknownContactId,
   normalizePubkeyHex,
+  readUnknownContactIdPubkey,
 } from "./hooks/messages/contactIdentity";
 import { hasKnownNostrMessageIdentity } from "./hooks/messages/messageHelpers";
 import { useChatMessageEffects } from "./hooks/messages/useChatMessageEffects";
@@ -2517,6 +2518,9 @@ export const useAppShellComposition = () => {
     visibleMessageOwnerIds,
   });
   reassignContactMessagesRef.current = reassignLocalNostrMessagesContactId;
+  const pendingArchivedContactThreadIdsRef = React.useRef(
+    new Map<string, string>(),
+  );
 
   const evoluOwnersReadyForNostr = isSeedLogin
     ? Boolean(
@@ -3312,6 +3316,8 @@ export const useAppShellComposition = () => {
       if (!isUnknownContactId(normalizedContactId)) continue;
 
       const candidatePubkeyFromLast = normalizePubkeyHex(lastMessage.pubkey);
+      const candidatePubkeyFromId =
+        readUnknownContactIdPubkey(normalizedContactId);
       const candidatePubkeyFromThread = nostrMessagesLocal
         .filter(
           (message) =>
@@ -3327,7 +3333,10 @@ export const useAppShellComposition = () => {
         });
 
       const unknownPubkeyHex =
-        candidatePubkeyFromThread ?? candidatePubkeyFromLast ?? null;
+        candidatePubkeyFromId ??
+        candidatePubkeyFromThread ??
+        candidatePubkeyFromLast ??
+        null;
       if (unknownPubkeyHex && blockedPubkeys.has(unknownPubkeyHex)) continue;
       const ownPubkey = normalizePubkeyHex(chatOwnPubkeyHex);
       if (unknownPubkeyHex && ownPubkey && unknownPubkeyHex === ownPubkey) {
@@ -5722,60 +5731,22 @@ export const useAppShellComposition = () => {
     }
 
     const archivedAtSec = Math.ceil(Date.now() / 1e3);
-    const archivePayload = contactToArchive
-      ? {
-          id,
-          archivedAtSec: archivedAtSec as typeof Evolu.PositiveInt.Type,
-          name: String(contactToArchive.name ?? "").trim()
-            ? (String(
-                contactToArchive.name ?? "",
-              ).trim() as typeof Evolu.NonEmptyString1000.Type)
-            : null,
-          npub: String(contactToArchive.npub ?? "").trim()
-            ? (String(
-                contactToArchive.npub ?? "",
-              ).trim() as typeof Evolu.NonEmptyString1000.Type)
-            : null,
-          lnAddress: String(contactToArchive.lnAddress ?? "").trim()
-            ? (String(
-                contactToArchive.lnAddress ?? "",
-              ).trim() as typeof Evolu.NonEmptyString1000.Type)
-            : null,
-          groupName: String(contactToArchive.groupName ?? "").trim()
-            ? (String(
-                contactToArchive.groupName ?? "",
-              ).trim() as typeof Evolu.NonEmptyString1000.Type)
-            : null,
-        }
+    const storedContactOwnerId = contactToArchive
+      ? resolveContactRowOwnerLane(contactToArchive, contactsVisibleOwnerIds)
       : null;
-
-    const result = contactsOwnerId
-      ? (() => {
-          if (archivePayload) {
-            const scopedUpsert = upsert("contact", archivePayload, {
-              ownerId: contactsOwnerId,
-            });
-            if (scopedUpsert.ok) return scopedUpsert;
-          }
-          const scoped = update(
-            "contact",
-            { id, archivedAtSec },
-            { ownerId: contactsOwnerId },
-          );
-          if (scoped.ok) return scoped;
-          return update("contact", { id, archivedAtSec });
-        })()
+    const archiveOwnerId = storedContactOwnerId ?? contactsOwnerId;
+    const result = archiveOwnerId
+      ? update("contact", { id, archivedAtSec }, { ownerId: archiveOwnerId })
       : update("contact", { id, archivedAtSec });
     if (result.ok) {
       if (
         unknownThreadContactId &&
         unknownThreadContactId !== normalizedContactId
       ) {
-        reassignLocalNostrMessagesContactId(
-          unknownThreadContactId,
+        pendingArchivedContactThreadIdsRef.current.set(
           normalizedContactId,
+          unknownThreadContactId,
         );
-        clearContactAttention(unknownThreadContactId);
       }
       recordContactsOwnerWrite();
       setStatus(t("contactArchived"));
@@ -5789,52 +5760,41 @@ export const useAppShellComposition = () => {
     (id: ContactId) => {
       const contactToRestore =
         contacts.find((contact) => contact.id === id) ?? null;
-      const restorePayload = contactToRestore
-        ? {
-            id,
-            archivedAtSec: null,
-            name: String(contactToRestore.name ?? "").trim()
-              ? (String(
-                  contactToRestore.name ?? "",
-                ).trim() as typeof Evolu.NonEmptyString1000.Type)
-              : null,
-            npub: String(contactToRestore.npub ?? "").trim()
-              ? (String(
-                  contactToRestore.npub ?? "",
-                ).trim() as typeof Evolu.NonEmptyString1000.Type)
-              : null,
-            lnAddress: String(contactToRestore.lnAddress ?? "").trim()
-              ? (String(
-                  contactToRestore.lnAddress ?? "",
-                ).trim() as typeof Evolu.NonEmptyString1000.Type)
-              : null,
-            groupName: String(contactToRestore.groupName ?? "").trim()
-              ? (String(
-                  contactToRestore.groupName ?? "",
-                ).trim() as typeof Evolu.NonEmptyString1000.Type)
-              : null,
-          }
+      const storedContactOwnerId = contactToRestore
+        ? resolveContactRowOwnerLane(contactToRestore, contactsVisibleOwnerIds)
         : null;
-
-      const result = contactsOwnerId
-        ? (() => {
-            if (restorePayload) {
-              const scopedUpsert = upsert("contact", restorePayload, {
-                ownerId: contactsOwnerId,
-              });
-              if (scopedUpsert.ok) return scopedUpsert;
-            }
-            const scoped = update(
-              "contact",
-              { id, archivedAtSec: null },
-              { ownerId: contactsOwnerId },
-            );
-            if (scoped.ok) return scoped;
-            return update("contact", { id, archivedAtSec: null });
-          })()
+      const restoreOwnerId = storedContactOwnerId ?? contactsOwnerId;
+      const result = restoreOwnerId
+        ? update(
+            "contact",
+            { id, archivedAtSec: null },
+            { ownerId: restoreOwnerId },
+          )
         : update("contact", { id, archivedAtSec: null });
 
       if (result.ok) {
+        const restoredNpub = normalizeNpubIdentifier(contactToRestore?.npub);
+        if (restoredNpub) {
+          try {
+            const decodedContact = nip19.decode(restoredNpub);
+            if (
+              decodedContact.type === "npub" &&
+              typeof decodedContact.data === "string"
+            ) {
+              const unknownContactId = buildUnknownContactId(
+                decodedContact.data,
+              );
+              if (unknownContactId) {
+                reassignLocalNostrMessagesContactId(
+                  unknownContactId,
+                  String(id),
+                );
+              }
+            }
+          } catch {
+            // Ignore malformed archived contact identifiers.
+          }
+        }
         recordContactsOwnerWrite();
         setStatus(t("contactRestored"));
         closeContactDetail();
@@ -5847,11 +5807,12 @@ export const useAppShellComposition = () => {
       closeContactDetail,
       contacts,
       contactsOwnerId,
+      contactsVisibleOwnerIds,
       recordContactsOwnerWrite,
+      reassignLocalNostrMessagesContactId,
       setStatus,
       t,
       update,
-      upsert,
     ],
   );
 
@@ -6683,6 +6644,23 @@ export const useAppShellComposition = () => {
       return next;
     });
   }, []);
+
+  React.useEffect(() => {
+    for (const contact of contacts) {
+      const contactId = String(contact.id ?? "").trim();
+      if (!contactId) continue;
+      const unknownContactId =
+        pendingArchivedContactThreadIdsRef.current.get(contactId);
+      if (!unknownContactId) continue;
+
+      const archivedAtSec = Number(contact.archivedAtSec ?? 0);
+      if (!Number.isFinite(archivedAtSec) || archivedAtSec <= 0) continue;
+
+      pendingArchivedContactThreadIdsRef.current.delete(contactId);
+      reassignLocalNostrMessagesContactId(contactId, unknownContactId);
+      clearContactAttention(unknownContactId);
+    }
+  }, [clearContactAttention, contacts, reassignLocalNostrMessagesContactId]);
 
   const blockArchivedContact = React.useCallback(async () => {
     if (route.kind !== "contactEdit") return;

--- a/apps/web-app/tests/appshell-parity.spec.ts
+++ b/apps/web-app/tests/appshell-parity.spec.ts
@@ -7,6 +7,14 @@ import { generateSecretKey, nip19 } from "nostr-tools";
 
 const CONTACT_NPUB =
   "npub12g0qmc3xa4hc9nxca936chppd6zhkr494xyypstcd7wg0gaa2xzswunml3";
+const decodedContactNpub = nip19.decode(CONTACT_NPUB);
+if (
+  decodedContactNpub.type !== "npub" ||
+  typeof decodedContactNpub.data !== "string"
+) {
+  throw new Error("Invalid test contact npub");
+}
+const CONTACT_PUBKEY_HEX = decodedContactNpub.data;
 
 const setBaseStorage = async (page: Page) => {
   await page.addInitScript(() => {
@@ -50,18 +58,21 @@ const setAuthenticatedStorage = async (page: Page) => {
   );
 };
 
-const createContactAndOpenChat = async (page: Page, contactName: string) => {
+const createContactAndOpenChat = async (page: Page): Promise<string> => {
   await page.goto("/#");
   await page.locator("[data-guide='contact-add-button']").first().click();
   await page.waitForURL(/#contact\/new$/, { timeout: 10_000 });
 
-  const formInputs = page.locator(".form-col input");
-  await expect(formInputs.nth(0)).toBeVisible();
-  await formInputs.nth(0).fill(contactName);
-  await formInputs.nth(1).fill(CONTACT_NPUB);
-  await page.getByRole("button", { name: "Save contact" }).click();
+  const searchInput = page.locator("[data-guide='contact-search-input']");
+  await expect(searchInput).toBeVisible();
+  await searchInput.fill(CONTACT_NPUB);
+  await searchInput.press("Enter");
+  await expect(
+    page.getByRole("button", { name: "Add", exact: true }),
+  ).toBeVisible({ timeout: 20_000 });
+  await page.getByRole("button", { name: "Add", exact: true }).click();
 
-  await page.waitForURL(/#$/, { timeout: 10_000 });
+  await page.waitForURL(/#(?:contacts)?$/, { timeout: 20_000 });
   const contactCards = page.locator("[data-guide='contact-card']");
   await expect
     .poll(async () => contactCards.count(), { timeout: 20_000 })
@@ -69,20 +80,41 @@ const createContactAndOpenChat = async (page: Page, contactName: string) => {
   await contactCards.first().click();
   await page.waitForURL(/#chat\/[^/]+$/, { timeout: 10_000 });
   await expect(page.locator("[data-guide='chat-input']")).toBeVisible();
+
+  const contactMatch = new URL(page.url()).hash.match(/^#chat\/([^/]+)$/);
+  if (!contactMatch?.[1]) {
+    throw new Error(`Could not parse contact id from ${page.url()}`);
+  }
+  return decodeURIComponent(contactMatch[1]);
 };
 
-test("keeps unauthenticated auth gating", async ({ page }) => {
+test("keeps unauthenticated auth gating without render loops", async ({
+  page,
+}) => {
+  const maximumDepthErrors: string[] = [];
+  page.on("console", (message) => {
+    if (
+      message.type() === "error" &&
+      message.text().includes("Maximum update depth exceeded")
+    ) {
+      maximumDepthErrors.push(message.text());
+    }
+  });
   await setBaseStorage(page);
 
   await page.goto("/#wallet");
 
   await expect(
-    page.getByRole("button", { name: "Create account" }),
+    page.getByRole("button", { name: "I'm getting started" }),
   ).toBeVisible();
-  await expect(page.getByRole("button", { name: "Paste nsec" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "I'm returning" }),
+  ).toBeVisible();
   await expect(page.locator("[data-guide='contact-add-button']")).toHaveCount(
     0,
   );
+  await page.waitForTimeout(3_000);
+  expect(maximumDepthErrors).toEqual([]);
 });
 
 test("restores an account from SLIP-39 without getting stuck", async ({
@@ -105,8 +137,6 @@ test("restores an account from SLIP-39 without getting stuck", async ({
 test("preserves route parity and critical handlers", async ({ page }) => {
   await setAuthenticatedStorage(page);
 
-  const contactName = `Parity Contact ${Date.now()}`;
-
   await page.goto("/#");
   await expect(
     page.locator("[data-guide='contact-add-button']").first(),
@@ -122,28 +152,34 @@ test("preserves route parity and critical handlers", async ({ page }) => {
 
   await page.goto("/#");
   await page.getByRole("button", { name: "Menu" }).click();
-  await page.locator("[data-guide='open-advanced']").click();
-  await page.waitForURL(/#advanced$/, { timeout: 10_000 });
-  await expect(page.getByRole("button", { name: "Mints" })).toBeVisible();
+  await page.waitForURL(/#settings$/, { timeout: 10_000 });
+  await expect(page.getByRole("button", { name: /^Mint\b/ })).toBeVisible();
 
   await page.goto("/#");
   await page.locator("[data-guide='contact-add-button']").first().click();
   await page.waitForURL(/#contact\/new$/, { timeout: 10_000 });
 
   await page.locator("[data-guide='scan-contact-button']").click();
-  const scanDialog = page.getByRole("dialog", { name: "Scan" });
+  const scanDialog = page.getByRole("dialog", { name: "Add contact" });
   await expect(scanDialog).toBeVisible();
   await scanDialog.getByRole("button", { name: "Close" }).click();
-  await expect(page.getByRole("dialog", { name: "Scan" })).toHaveCount(0);
+  await expect(page.getByRole("dialog", { name: "Add contact" })).toHaveCount(
+    0,
+  );
 
-  const formInputs = page.locator(".form-col input");
-  await expect(formInputs.nth(0)).toBeVisible();
-  await formInputs.nth(0).fill(contactName);
-  await formInputs.nth(1).fill(CONTACT_NPUB);
-  await page.getByRole("button", { name: "Save contact" }).click();
+  const searchInput = page.locator("[data-guide='contact-search-input']");
+  await expect(searchInput).toBeVisible();
+  await searchInput.fill(CONTACT_NPUB);
+  await searchInput.press("Enter");
+  await expect(
+    page.getByRole("button", { name: "Add", exact: true }),
+  ).toBeVisible({ timeout: 20_000 });
+  await page.getByRole("button", { name: "Add", exact: true }).click();
 
-  await page.waitForURL(/#$/, { timeout: 10_000 });
-  await expect(page.locator(".toast")).toContainText("Contact saved");
+  await page.waitForURL(/#(?:contacts)?$/, { timeout: 10_000 });
+  await expect(
+    page.locator(".toast").filter({ hasText: "Contact saved" }),
+  ).toBeVisible();
 
   const contactCards = page.locator("[data-guide='contact-card']");
   await expect
@@ -176,7 +212,7 @@ test("preserves route parity and critical handlers", async ({ page }) => {
   await expect(page.locator("[data-guide='chat-input']")).toBeVisible();
 
   await page.getByRole("banner").getByRole("button", { name: "Close" }).click();
-  await page.waitForURL(/#$/, { timeout: 10_000 });
+  await page.waitForURL(/#(?:contacts)?$/, { timeout: 10_000 });
   await page.getByRole("button", { name: "Wallet" }).click();
   await page.waitForURL(/#wallet$/, { timeout: 10_000 });
   await expect(page.getByLabel("Available balance")).toBeVisible();
@@ -189,21 +225,18 @@ test("preserves route parity and critical handlers", async ({ page }) => {
     },
   );
 
-  await page.getByRole("button", { name: "1" }).click();
-  await page.getByRole("button", { name: "0" }).click();
+  await page.getByRole("button", { name: "1", exact: true }).click();
+  await page.getByRole("button", { name: "0", exact: true }).click();
   const paySend = page.locator("[data-guide='pay-send']");
   await expect(paySend).toBeVisible();
-  await expect(paySend).toBeEnabled();
-
-  await paySend.click();
-  await expect(page.locator(".page")).toBeVisible();
+  await expect(paySend).toBeDisabled();
 });
 
 test("supports chat reply, edit, reaction toggle, and copy actions", async ({
   page,
 }) => {
   await setAuthenticatedStorage(page);
-  await createContactAndOpenChat(page, `Action Contact ${Date.now()}`);
+  const contactId = await createContactAndOpenChat(page);
 
   const chatInput = page.locator("[data-guide='chat-input']");
   const sendButton = page.locator("[data-guide='chat-send']");
@@ -237,7 +270,10 @@ test("supports chat reply, edit, reaction toggle, and copy actions", async ({
   );
 
   await replyBubble.locator(".chat-bubble").click({ button: "right" });
-  await page.getByRole("button", { name: "Edit", exact: true }).click();
+  await page
+    .getByRole("menu")
+    .getByRole("button", { name: "Edit", exact: true })
+    .click();
   await chatInput.fill("Reply body edited");
   await page.getByRole("button", { name: "Save" }).click();
   const editedBubble = page
@@ -247,8 +283,10 @@ test("supports chat reply, edit, reaction toggle, and copy actions", async ({
   await expect(editedBubble).toContainText("edited");
 
   await editedBubble.locator(".chat-bubble").click({ button: "right" });
-  await page.getByRole("button", { name: "React", exact: true }).click();
-  await page.getByRole("button", { name: "👍" }).click();
+  await page
+    .getByRole("listbox", { name: "Emoji picker" })
+    .getByRole("button", { name: "👍", exact: true })
+    .click();
   const reactionChip = editedBubble.locator(".reaction-chip", {
     hasText: "👍",
   });
@@ -259,4 +297,19 @@ test("supports chat reply, edit, reaction toggle, and copy actions", async ({
   await editedBubble.locator(".chat-bubble").click({ button: "right" });
   await page.getByRole("button", { name: "Copy", exact: true }).click();
   await expect(page.locator(".toast")).toContainText("Copied to clipboard");
+
+  await page.goto(`/#contact/${encodeURIComponent(contactId)}/edit`);
+  const archiveButton = page.getByRole("button", {
+    name: "Archive contact",
+    exact: true,
+  });
+  await archiveButton.click();
+  await archiveButton.click();
+  await page.waitForURL(/#(?:contacts)?$/, { timeout: 10_000 });
+
+  const unknownContactId = `unknown:${CONTACT_PUBKEY_HEX}`;
+  await page.goto(`/#chat/${encodeURIComponent(unknownContactId)}`);
+  await expect(
+    page.locator(".chat-message").filter({ hasText: "First message" }).first(),
+  ).toBeVisible();
 });

--- a/apps/web-app/tests/boot-recovery.spec.ts
+++ b/apps/web-app/tests/boot-recovery.spec.ts
@@ -15,7 +15,7 @@ test("recovers once when the main bundle cannot start", async ({ page }) => {
       value: 50,
     });
   });
-  await page.route("**/src/main.tsx", async (route) => {
+  await page.route("**/src/main.tsx*", async (route) => {
     mainBundleRequests += 1;
     await route.abort();
   });

--- a/apps/web-app/tests/chat-nostr-protocol.test.ts
+++ b/apps/web-app/tests/chat-nostr-protocol.test.ts
@@ -12,6 +12,7 @@ import {
   extractDeleteReferencedIds,
   extractReplyContextFromTags,
   isNestedEncryptedNip44Payload,
+  resolveStableMessageRumorId,
 } from "../src/app/hooks/messages/chatNostrProtocol";
 import {
   buildKnownNostrMessageIdentityIndex,
@@ -83,6 +84,21 @@ describe("applyEditToMessage", () => {
     expect(next.isEdited).toBe(true);
     expect(next.editedAtSec).toBe(200);
     expect(next.editedFromId).toBe("rumor-1");
+    expect(next.rumorId).toBe("rumor-1");
+  });
+});
+
+describe("resolveStableMessageRumorId", () => {
+  it("keeps the original message id for edits", () => {
+    expect(resolveStableMessageRumorId("edit-event", "original-message")).toBe(
+      "original-message",
+    );
+  });
+
+  it("uses the event id for unedited messages", () => {
+    expect(resolveStableMessageRumorId("message-event", null)).toBe(
+      "message-event",
+    );
   });
 });
 

--- a/apps/web-app/tests/token-send.spec.ts
+++ b/apps/web-app/tests/token-send.spec.ts
@@ -9,7 +9,6 @@ const NPUB_RECEIVER =
 test("send token", async ({ page }) => {
   const senderNsec = nip19.nsecEncode(generateSecretKey());
   const senderMnemonic = generateMnemonic(wordlist, 128);
-  const receiverName = `Receiver ${Date.now()}`;
 
   const readBalanceSat = async (timeoutMs = 5_000) => {
     const balance = page.getByLabel("Available balance");
@@ -35,6 +34,11 @@ test("send token", async ({ page }) => {
         try {
           localStorage.setItem("linky.nostr_nsec", nsec);
           localStorage.setItem("linky.initialMnemonic", mnemonicValue);
+          localStorage.setItem("linky.display_currency.v1", "sat");
+          localStorage.setItem(
+            "linky.display_allowed_currencies.v1",
+            JSON.stringify(["sat"]),
+          );
         } catch {
           // ignore
         }
@@ -60,8 +64,8 @@ test("send token", async ({ page }) => {
 
     // Now configure the test mint URL (Evolu ownerId is ready)
     await page.getByRole("button", { name: "Menu" }).click();
-    await page.getByRole("button", { name: "Advanced" }).click();
-    await page.getByRole("button", { name: "Mints" }).click();
+    await page.waitForURL(/#settings$/, { timeout: 10_000 });
+    await page.getByRole("button", { name: /^Mint\b/ }).click();
 
     await page.locator("#defaultMintUrl").waitFor({ state: "visible" });
 
@@ -87,9 +91,9 @@ test("send token", async ({ page }) => {
     await page.getByRole("button", { name: "Wallet" }).click();
     await page.getByRole("button", { name: "Receive" }).click();
 
-    await page.getByRole("button", { name: "1" }).click();
-    await page.getByRole("button", { name: "0" }).click();
-    await page.getByRole("button", { name: "0" }).click();
+    await page.getByRole("button", { name: "1", exact: true }).click();
+    await page.getByRole("button", { name: "0", exact: true }).click();
+    await page.getByRole("button", { name: "0", exact: true }).click();
 
     await page.getByRole("button", { name: "Show top-up invoice" }).click();
 
@@ -98,26 +102,25 @@ test("send token", async ({ page }) => {
     // Leave the invoice screen before the mint finishes claiming proofs.
     await page.getByRole("button", { name: "Wallet" }).click();
 
-    await expect(page.locator(".toast").first()).toContainText(
-      "Click to copy token",
-      {
-        timeout: 120_000,
-      },
-    );
-
-    const balanceAfterTopup = await readBalanceSat(120_000);
+    await expect
+      .poll(async () => readBalanceSat(120_000), { timeout: 120_000 })
+      .toBeGreaterThan(0);
+    const balanceAfterTopup = await readBalanceSat();
     expect(balanceAfterTopup).toBeGreaterThan(0);
 
     await page.getByRole("button", { name: "Contacts" }).click();
-    await page.waitForURL(/#$/, { timeout: 5000 });
+    await page.waitForURL(/#(?:contacts)?$/, { timeout: 5000 });
 
     await page.getByRole("button", { name: "Add contact" }).click();
-    const contactFormInputs = page.locator(".form-col input");
-    await expect(contactFormInputs.nth(0)).toBeVisible();
-    await contactFormInputs.nth(0).fill(receiverName);
-    await contactFormInputs.nth(1).fill(NPUB_RECEIVER);
-    await page.getByRole("button", { name: "Save contact" }).click();
-    await page.waitForURL(/#$/, { timeout: 5000 });
+    const searchInput = page.locator("[data-guide='contact-search-input']");
+    await expect(searchInput).toBeVisible();
+    await searchInput.fill(NPUB_RECEIVER);
+    await searchInput.press("Enter");
+    await expect(
+      page.getByRole("button", { name: "Add", exact: true }),
+    ).toBeVisible({ timeout: 20_000 });
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+    await page.waitForURL(/#(?:contacts)?$/, { timeout: 5000 });
 
     const contactCards = page.locator('[data-guide="contact-card"]');
     await expect
@@ -127,8 +130,8 @@ test("send token", async ({ page }) => {
 
     await page.getByRole("button", { name: "Pay" }).click();
 
-    await page.getByRole("button", { name: "1" }).click();
-    await page.getByRole("button", { name: "0" }).click();
+    await page.getByRole("button", { name: "1", exact: true }).click();
+    await page.getByRole("button", { name: "0", exact: true }).click();
 
     const chatMessages = page.locator(".chat-message");
     const messageCountBeforePay = await chatMessages.count();


### PR DESCRIPTION
## Summary

This follow-up layers the fixes found during comprehensive local smoke testing onto the original `audit-fixes` branch from #171.

- stop the contact suggestion effect from repeatedly updating state when its semantic inputs have not changed
- preserve stable Nostr rumor IDs across edits so reactions continue to target the original message
- preserve chat history when contacts are archived, restored, or migrated between known and unknown threads
- hide low-level Cashu parser errors from malformed-token UI
- refresh Playwright coverage for current routes, dialogs, selectors, mint flows, and notification behavior

## Root causes

The regressions came from unstable effect dependencies, replacing a message identity with an edit-event identity, writing archive state to the active rather than stored Evolu owner lane, and leaking parser implementation details into the public Cashu page.

## Validation

- `bun run check-code`
- web app production build
- public site production build
- push service build
- focused Vitest coverage: 14/14 passing
- Chromium Playwright app-shell and boot-recovery suite: 5/5 passing
- Playwright Cashu token-send flow on testnut: passing
- manual mobile smoke testing across onboarding, profile, contacts, wallet, settings, routes, camera fallback, and Evolu views
- two independent browser profiles exercising Nostr unknown-sender migration, two-way DMs, reply/edit/reactions, offline flush, private images, notifications, and archive continuity
- public-site and `/cashu` validation including valid, spent, malformed, query/hash, and protocol fallback paths

Full-suite Vitest failures and Playwright WebKit startup behavior were reproduced unchanged on the `main` baseline. Android packaging was not run because Java 17 is unavailable in the local environment.