### PR TITLE
Preserve chat position when the mobile keyboard opens

### DIFF
--- a/apps/web-app/src/app/lib/chatViewport.test.ts
+++ b/apps/web-app/src/app/lib/chatViewport.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  captureChatViewportAnchor,
+  restoreChatViewportAnchor,
+} from "./chatViewport";
+
+const setClientHeight = (element: HTMLElement, height: number): void => {
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    value: height,
+  });
+};
+
+describe("chat viewport anchor", () => {
+  it("keeps the same content at the bottom when the viewport shrinks", () => {
+    const messages = document.createElement("div");
+    messages.scrollTop = 640;
+    setClientHeight(messages, 400);
+
+    const anchor = captureChatViewportAnchor(messages);
+
+    setClientHeight(messages, 160);
+    restoreChatViewportAnchor(messages, anchor);
+
+    expect(messages.scrollTop).toBe(880);
+    expect(messages.scrollTop + messages.clientHeight).toBe(1_040);
+  });
+
+  it("keeps a chat at the end when the viewport shrinks", () => {
+    const messages = document.createElement("div");
+    messages.scrollTop = 1_200;
+    setClientHeight(messages, 400);
+
+    const anchor = captureChatViewportAnchor(messages);
+
+    setClientHeight(messages, 160);
+    restoreChatViewportAnchor(messages, anchor);
+
+    expect(messages.scrollTop).toBe(1_440);
+  });
+});

--- a/apps/web-app/src/app/lib/chatViewport.ts
+++ b/apps/web-app/src/app/lib/chatViewport.ts
@@ -1,0 +1,25 @@
+export interface ChatViewportAnchor {
+  visibleBottom: number;
+}
+
+export const captureChatViewportAnchor = (
+  messages: HTMLElement | null,
+): ChatViewportAnchor | null => {
+  if (!messages || messages.clientHeight <= 0) return null;
+
+  return {
+    visibleBottom: messages.scrollTop + messages.clientHeight,
+  };
+};
+
+export const restoreChatViewportAnchor = (
+  messages: HTMLElement | null,
+  anchor: ChatViewportAnchor | null,
+): void => {
+  if (!messages || !anchor) return;
+
+  messages.scrollTop = Math.max(
+    0,
+    anchor.visibleBottom - messages.clientHeight,
+  );
+};

--- a/apps/web-app/src/pages/ChatPage.tsx
+++ b/apps/web-app/src/pages/ChatPage.tsx
@@ -893,6 +893,12 @@ const useChatViewport = (
     body.style.overflow = "hidden";
 
     const updateViewportHeight = () => {
+      // iOS can pan the document after focusin has already fired, especially
+      // when reopening the keyboard. The chat owns its scrolling, so keep the
+      // document itself pinned before applying visual viewport measurements.
+      if (getWindowScrollTop() > 1) {
+        window.scrollTo(0, 0);
+      }
       pendingViewportAnchor ??= captureChatViewportAnchor(
         chatMessagesRef.current,
       );
@@ -957,9 +963,6 @@ const useChatViewport = (
     const handleComposeFocusChange = (event: FocusEvent) => {
       const input = composeInputRef.current;
       if (!input || event.target !== input) return;
-      if (event.type === "focusin" && getWindowScrollTop() > 1) {
-        window.scrollTo(0, 0);
-      }
       scheduleViewportRefresh();
     };
 

--- a/apps/web-app/src/pages/ChatPage.tsx
+++ b/apps/web-app/src/pages/ChatPage.tsx
@@ -25,6 +25,11 @@ import {
   setMessageEditorCaret,
 } from "../app/lib/messageEditorDom";
 import {
+  captureChatViewportAnchor,
+  restoreChatViewportAnchor,
+  type ChatViewportAnchor,
+} from "../app/lib/chatViewport";
+import {
   applyMessageMentionSuggestion,
   getMessageMentionQuery,
   getMessageMentionSuggestions,
@@ -873,7 +878,8 @@ const useChatViewport = (
     const root = document.documentElement;
     const body = document.body;
     const pendingRefreshTimeouts = new Set<number>();
-    let pendingBottomScrollFrame: number | null = null;
+    let pendingViewportAnchor: ChatViewportAnchor | null = null;
+    let pendingViewportAnchorFrame: number | null = null;
     const getWindowScrollTop = () =>
       Math.max(
         window.scrollY,
@@ -887,6 +893,9 @@ const useChatViewport = (
     body.style.overflow = "hidden";
 
     const updateViewportHeight = () => {
+      pendingViewportAnchor ??= captureChatViewportAnchor(
+        chatMessagesRef.current,
+      );
       const viewport = window.visualViewport;
       const nextHeight = viewport?.height ?? window.innerHeight;
       const nextOffsetTop = viewport?.offsetTop ?? 0;
@@ -919,16 +928,16 @@ const useChatViewport = (
         delete root.dataset.chatKeyboardOpen;
       }
 
-      if (pendingBottomScrollFrame !== null) {
-        window.cancelAnimationFrame(pendingBottomScrollFrame);
+      if (pendingViewportAnchorFrame !== null) {
+        window.cancelAnimationFrame(pendingViewportAnchorFrame);
       }
-      pendingBottomScrollFrame = window.requestAnimationFrame(() => {
-        pendingBottomScrollFrame = null;
-        const messages = chatMessagesRef.current;
-        const scrollHeight = messages?.scrollHeight;
-        if (messages && scrollHeight !== undefined) {
-          messages.scrollTop = scrollHeight;
-        }
+      pendingViewportAnchorFrame = window.requestAnimationFrame(() => {
+        pendingViewportAnchorFrame = null;
+        restoreChatViewportAnchor(
+          chatMessagesRef.current,
+          pendingViewportAnchor,
+        );
+        pendingViewportAnchor = null;
       });
     };
 
@@ -977,8 +986,8 @@ const useChatViewport = (
       for (const timeoutId of pendingRefreshTimeouts) {
         window.clearTimeout(timeoutId);
       }
-      if (pendingBottomScrollFrame !== null) {
-        window.cancelAnimationFrame(pendingBottomScrollFrame);
+      if (pendingViewportAnchorFrame !== null) {
+        window.cancelAnimationFrame(pendingViewportAnchorFrame);
       }
       root.style.overflow = previousHtmlOverflow;
       body.style.overflow = previousBodyOverflow;


### PR DESCRIPTION
## What changed

- capture the visible bottom edge of the chat before a viewport resize
- restore that same content edge after the mobile keyboard changes the available height
- keep the iOS document scroll pinned during every visual viewport update
- add regression coverage for mid-conversation and bottom-pinned positions

## Why

Two separate scroll behaviors were involved:

1. The chat viewport handler forced `scrollTop` to the absolute end on every visual viewport update, discarding the user's visible message position.
2. On a later keyboard reopening, iOS Safari pans the document after `focusin` has already fired. That moved the fixed chat panel above the visual viewport while leaving the composer by the keyboard, creating a large empty gap.

The chat now preserves its own visible bottom edge and resets any late iOS document pan from the viewport resize/scroll callbacks.

## Validation

- `bun run check-code`
- `bunx vitest run src/app/lib/chatViewport.test.ts`
- reproduced in iOS Simulator with Hynek's chat
- verified focus → dismiss → focus twice; second opening remained at `scrollY = 0` with the bottom message directly above the input
