### PR TITLE
Sync onboarding tutorial dismissal across devices

### DIFF
--- a/apps/web-app/src/app/hooks/guide/useContactsOnboardingProgress.test.tsx
+++ b/apps/web-app/src/app/hooks/guide/useContactsOnboardingProgress.test.tsx
@@ -1,0 +1,109 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CONTACTS_ONBOARDING_DISMISSED_STORAGE_KEY } from "../../../utils/constants";
+import { useContactsOnboardingProgress } from "./useContactsOnboardingProgress";
+
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+  configurable: true,
+  value: true,
+});
+
+type OnboardingProgress = ReturnType<typeof useContactsOnboardingProgress>;
+
+interface HarnessProps {
+  dismissedSynced: boolean;
+  onProgress: (progress: OnboardingProgress) => void;
+  persistDismissed: () => void;
+  stopGuide: () => void;
+}
+
+const Harness = ({
+  dismissedSynced,
+  onProgress,
+  persistDismissed,
+  stopGuide,
+}: HarnessProps): null => {
+  const progress = useContactsOnboardingProgress({
+    cashuBalance: 0,
+    contactsCount: 0,
+    contactsOnboardingDismissedSynced: dismissedSynced,
+    contactsOnboardingHasBackedUpKeys: false,
+    contactsOnboardingHasPaid: false,
+    contactsOnboardingHasSentMessage: false,
+    persistContactsOnboardingDismissed: persistDismissed,
+    routeKind: "contacts",
+    stopContactsGuide: stopGuide,
+    t: (key) => key,
+  });
+  onProgress(progress);
+  return null;
+};
+
+afterEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe("useContactsOnboardingProgress", () => {
+  it("migrates an existing local dismissal into Evolu", async () => {
+    localStorage.setItem(CONTACTS_ONBOARDING_DISMISSED_STORAGE_KEY, "1");
+    const persistDismissed = vi.fn();
+    const progressSnapshots: OnboardingProgress[] = [];
+    const root = createRoot(document.createElement("div"));
+
+    await act(async () => {
+      root.render(
+        <Harness
+          dismissedSynced={false}
+          onProgress={(value) => progressSnapshots.push(value)}
+          persistDismissed={persistDismissed}
+          stopGuide={vi.fn()}
+        />,
+      );
+    });
+
+    expect(progressSnapshots.at(-1)?.showContactsOnboarding).toBe(false);
+    expect(persistDismissed).toHaveBeenCalled();
+    await act(async () => root.unmount());
+  });
+
+  it("adopts a dismissal synced from another device", async () => {
+    const persistDismissed = vi.fn();
+    const stopGuide = vi.fn();
+    const progressSnapshots: OnboardingProgress[] = [];
+    const onProgress = (value: OnboardingProgress) =>
+      progressSnapshots.push(value);
+    const root = createRoot(document.createElement("div"));
+
+    await act(async () => {
+      root.render(
+        <Harness
+          dismissedSynced={false}
+          onProgress={onProgress}
+          persistDismissed={persistDismissed}
+          stopGuide={stopGuide}
+        />,
+      );
+    });
+    expect(progressSnapshots.at(-1)?.showContactsOnboarding).toBe(true);
+
+    await act(async () => {
+      root.render(
+        <Harness
+          dismissedSynced
+          onProgress={onProgress}
+          persistDismissed={persistDismissed}
+          stopGuide={stopGuide}
+        />,
+      );
+    });
+
+    expect(progressSnapshots.at(-1)?.showContactsOnboarding).toBe(false);
+    expect(
+      localStorage.getItem(CONTACTS_ONBOARDING_DISMISSED_STORAGE_KEY),
+    ).toBe("1");
+    expect(stopGuide).toHaveBeenCalled();
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web-app/src/app/hooks/guide/useContactsOnboardingProgress.ts
+++ b/apps/web-app/src/app/hooks/guide/useContactsOnboardingProgress.ts
@@ -9,9 +9,11 @@ import {
 interface UseContactsOnboardingProgressParams {
   cashuBalance: number;
   contactsCount: number;
+  contactsOnboardingDismissedSynced: boolean;
   contactsOnboardingHasBackedUpKeys: boolean;
   contactsOnboardingHasPaid: boolean;
   contactsOnboardingHasSentMessage: boolean;
+  persistContactsOnboardingDismissed: () => void;
   routeKind: Route["kind"];
   stopContactsGuide: () => void;
   t: (key: string) => string;
@@ -33,9 +35,11 @@ interface ContactsOnboardingTasksSummary {
 export const useContactsOnboardingProgress = ({
   cashuBalance,
   contactsCount,
+  contactsOnboardingDismissedSynced,
   contactsOnboardingHasBackedUpKeys,
   contactsOnboardingHasPaid,
   contactsOnboardingHasSentMessage,
+  persistContactsOnboardingDismissed,
   routeKind,
   stopContactsGuide,
   t,
@@ -94,11 +98,24 @@ export const useContactsOnboardingProgress = ({
   const showContactsOnboarding =
     !contactsOnboardingDismissed && routeKind === "contacts";
 
-  const dismissContactsOnboarding = React.useCallback(() => {
+  React.useEffect(() => {
+    if (!contactsOnboardingDismissedSynced) return;
     safeLocalStorageSet(CONTACTS_ONBOARDING_DISMISSED_STORAGE_KEY, "1");
     setContactsOnboardingDismissed(true);
     stopContactsGuide();
-  }, [stopContactsGuide]);
+  }, [contactsOnboardingDismissedSynced, stopContactsGuide]);
+
+  React.useEffect(() => {
+    if (!contactsOnboardingDismissed) return;
+    persistContactsOnboardingDismissed();
+  }, [contactsOnboardingDismissed, persistContactsOnboardingDismissed]);
+
+  const dismissContactsOnboarding = React.useCallback(() => {
+    safeLocalStorageSet(CONTACTS_ONBOARDING_DISMISSED_STORAGE_KEY, "1");
+    setContactsOnboardingDismissed(true);
+    persistContactsOnboardingDismissed();
+    stopContactsGuide();
+  }, [persistContactsOnboardingDismissed, stopContactsGuide]);
 
   React.useEffect(() => {
     if (contactsOnboardingDismissed) return;

--- a/apps/web-app/src/app/lib/onboardingTutorialSync.test.ts
+++ b/apps/web-app/src/app/lib/onboardingTutorialSync.test.ts
@@ -1,0 +1,45 @@
+import * as Evolu from "@evolu/common";
+import { describe, expect, it } from "vitest";
+import {
+  buildDismissedOnboardingTutorialOwnerMetaPayload,
+  hasDismissedOnboardingTutorialOwnerMetaRow,
+  ONBOARDING_TUTORIAL_OWNER_META_SCOPE,
+} from "./onboardingTutorialSync";
+
+const ownerId = Evolu.OwnerId.orThrow("AAAAAAAAAAAAAAAAAAAAAA");
+
+describe("onboardingTutorialSync", () => {
+  it("builds the stable dismissed metadata row", () => {
+    expect(buildDismissedOnboardingTutorialOwnerMetaPayload()).toEqual({
+      id: Evolu.createIdFromString<"OwnerMeta">("onboarding-tutorial-status"),
+      scope: ONBOARDING_TUTORIAL_OWNER_META_SCOPE,
+      value: "dismissed",
+    });
+  });
+
+  it("only accepts a dismissed row from the active metadata owner", () => {
+    expect(
+      hasDismissedOnboardingTutorialOwnerMetaRow(
+        [{ ownerId, value: "dismissed" }],
+        ownerId,
+      ),
+    ).toBe(true);
+    expect(
+      hasDismissedOnboardingTutorialOwnerMetaRow(
+        [
+          {
+            ownerId: Evolu.OwnerId.orThrow("AQEBAQEBAQEBAQEBAQEBAQ"),
+            value: "dismissed",
+          },
+        ],
+        ownerId,
+      ),
+    ).toBe(false);
+    expect(
+      hasDismissedOnboardingTutorialOwnerMetaRow(
+        [{ ownerId, value: "active" }],
+        ownerId,
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/web-app/src/app/lib/onboardingTutorialSync.ts
+++ b/apps/web-app/src/app/lib/onboardingTutorialSync.ts
@@ -1,0 +1,47 @@
+import * as Evolu from "@evolu/common";
+
+const parseNonEmptyString100 = (
+  value: string,
+): typeof Evolu.NonEmptyString100.Type => {
+  const parsed = Evolu.NonEmptyString100.fromUnknown(value);
+  if (!parsed.ok) throw new Error("Invalid onboarding tutorial metadata");
+  return parsed.value;
+};
+
+const parseNonEmptyString1000 = (
+  value: string,
+): typeof Evolu.NonEmptyString1000.Type => {
+  const parsed = Evolu.NonEmptyString1000.fromUnknown(value);
+  if (!parsed.ok) throw new Error("Invalid onboarding tutorial metadata");
+  return parsed.value;
+};
+
+export const ONBOARDING_TUTORIAL_OWNER_META_SCOPE =
+  parseNonEmptyString100("onboardingTutorial");
+
+const ONBOARDING_TUTORIAL_DISMISSED_VALUE =
+  parseNonEmptyString1000("dismissed");
+
+const ONBOARDING_TUTORIAL_OWNER_META_ROW_ID =
+  Evolu.createIdFromString<"OwnerMeta">("onboarding-tutorial-status");
+
+export const buildDismissedOnboardingTutorialOwnerMetaPayload = () => ({
+  id: ONBOARDING_TUTORIAL_OWNER_META_ROW_ID,
+  scope: ONBOARDING_TUTORIAL_OWNER_META_SCOPE,
+  value: ONBOARDING_TUTORIAL_DISMISSED_VALUE,
+});
+
+export const hasDismissedOnboardingTutorialOwnerMetaRow = (
+  rows: ReadonlyArray<object>,
+  ownerId: Evolu.OwnerId | null,
+): boolean => {
+  if (!ownerId) return false;
+  const expectedOwnerId = String(ownerId);
+
+  return rows.some((row) => {
+    if (!("ownerId" in row) || String(row.ownerId) !== expectedOwnerId) {
+      return false;
+    }
+    return "value" in row && row.value === ONBOARDING_TUTORIAL_DISMISSED_VALUE;
+  });
+};

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -292,6 +292,11 @@ import {
 import type { AppNostrPool } from "./lib/nostrPool";
 import { getSharedAppNostrPool } from "./lib/nostrPool";
 import {
+  buildDismissedOnboardingTutorialOwnerMetaPayload,
+  hasDismissedOnboardingTutorialOwnerMetaRow,
+  ONBOARDING_TUTORIAL_OWNER_META_SCOPE,
+} from "./lib/onboardingTutorialSync";
+import {
   publishSingleWrappedWithRetry as publishSingleWrappedWithRetryBase,
   publishWrappedWithRetry as publishWrappedWithRetryBase,
 } from "./lib/nostrPublishRetry";
@@ -1538,6 +1543,37 @@ export const useAppShellComposition = () => {
     },
     [metaOwnerId, ownerMetaDefaultMintRowId, ownerMetaDefaultMintValue, upsert],
   );
+
+  const onboardingTutorialOwnerId = isSeedLogin ? metaOwnerId : appOwnerId;
+  const onboardingTutorialOwnerMetaQuery = useMemo(
+    () =>
+      evolu.createQuery((db) =>
+        db
+          .selectFrom("ownerMeta")
+          .selectAll()
+          .where("isDeleted", "is not", Evolu.sqliteTrue)
+          .where("scope", "=", ONBOARDING_TUTORIAL_OWNER_META_SCOPE),
+      ),
+    [],
+  );
+  const onboardingTutorialOwnerMetaRows = useQuery(
+    onboardingTutorialOwnerMetaQuery,
+  );
+  const contactsOnboardingDismissedSynced = React.useMemo(
+    () =>
+      hasDismissedOnboardingTutorialOwnerMetaRow(
+        onboardingTutorialOwnerMetaRows,
+        onboardingTutorialOwnerId,
+      ),
+    [onboardingTutorialOwnerId, onboardingTutorialOwnerMetaRows],
+  );
+  const persistContactsOnboardingDismissed = React.useCallback(() => {
+    if (!onboardingTutorialOwnerId) return;
+    if (contactsOnboardingDismissedSynced) return;
+    upsert("ownerMeta", buildDismissedOnboardingTutorialOwnerMetaPayload(), {
+      ownerId: onboardingTutorialOwnerId,
+    });
+  }, [contactsOnboardingDismissedSynced, onboardingTutorialOwnerId, upsert]);
 
   const upsertDefaultMintToOwnerMetaRef = React.useRef(
     upsertDefaultMintToOwnerMeta,
@@ -5658,9 +5694,11 @@ export const useAppShellComposition = () => {
   } = useContactsOnboardingProgress({
     cashuBalance,
     contactsCount: contacts.length,
+    contactsOnboardingDismissedSynced,
     contactsOnboardingHasBackedUpKeys,
     contactsOnboardingHasPaid,
     contactsOnboardingHasSentMessage,
+    persistContactsOnboardingDismissed,
     routeKind: route.kind,
     stopContactsGuide,
     t,


### PR DESCRIPTION
## Summary

- persist the contacts onboarding tutorial dismissal in the user synced Evolu `ownerMeta` lane
- adopt a remote dismissal locally and stop any active tutorial guide
- migrate the existing local-only dismissal flag into Evolu
- cover metadata scoping, legacy migration, and cross-device adoption with tests

## Why

The tutorial dismissal previously lived only in localStorage. Restoring the same account on another device therefore showed the onboarding tutorial again. The new dismissal record is monotonic: a synced `dismissed` value hides the tutorial, while an absent record leaves it available for new users without allowing a fresh device to overwrite an existing dismissal.

## Validation

- `bun run check-code`
- `cd apps/web-app && bunx vitest run src/app/lib/onboardingTutorialSync.test.ts src/app/hooks/guide/useContactsOnboardingProgress.test.tsx`

`check-code` passes with the four existing React hook lint warnings in `useAppShellComposition.tsx`.