### PR TITLE
Decompose useAppShellComposition into per-domain composition hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,11 +112,11 @@ Native Android builds require Java 17. `apps/native-shell/scripts/with-java17.sh
 - `apps/web-app/src/App.tsx` is a thin wrapper that default-exports `app/AppShell`
 - App shell structure lives under `apps/web-app/src/app/`:
   - `AppShell.tsx` is a thin renderer/auth gate that wires `AppShellContextsProvider` and route content
-  - `useAppShellComposition.tsx` owns AppShell orchestration, hook composition, and route-prop bundle assembly
+  - `useAppShellComposition.tsx` is a thin composition layer that wires the per-domain composition hooks together and assembles route-prop bundles; domain state/effects/callbacks live in `hooks/composition/` per-domain hooks
   - `context/AppShellContexts.tsx` is the single authenticated shell context transport; it provides shell/route contexts and typed consumer hooks (`useAppShellCore`, `useAppShellActions`, `useAppShellRouteContext`)
   - `hooks/` contains app domain hooks (`useRelayDomain`, `useMintDomain`, `useContactsDomain`, `useMessagesDomain`, `usePaymentsDomain`, `useCashuDomain`, `useProfileAuthDomain`, `useGuideScannerDomain`) plus app-shell extraction hooks (`useAppDataTransfer`, `useContactsNostrPrefetchEffects`, `useMainSwipePageEffects`, `useProfileNpubCashEffects`, `useScannedTextHandler`, `useFeedbackContact`, `useOwnerScopedStorage`, `usePaidOverlayState`, `useRouteDerivedShellState`)
   - `hooks/useEvoluContactsOwnerRotation.ts` owns deterministic contacts/cashu/messages/transactions owner derivation, pointer-only contacts/cashu/messages/transactions rotations, legacy cashu mirror upkeep for older clients, and per-scope owner pointer persistence in `ownerMeta`
-  - `hooks/composition/` contains sub-composition slices for shell orchestration concerns (`useProfileAuthComposition`, `useProfilePeopleComposition`, `usePaymentMoneyComposition`, `useRoutingViewComposition`, `useSystemSettingsComposition`)
+  - `hooks/composition/` contains per-domain composition hooks (`useIdentityOwnersComposition`, `useProfileComposition`, `useContactsMessagingComposition`, `useCashuWalletComposition`, `useScanNativeComposition`) plus sub-composition slices for shell orchestration concerns (`useProfileAuthComposition`, `useProfilePeopleComposition`, `usePaymentMoneyComposition`, `useRoutingViewComposition`, `useSystemSettingsComposition`)
   - `hooks/contacts/` contains contact-editor and contact-list view helpers (`useContactEditor`, `useVisibleContacts`)
   - `hooks/layout/` contains extracted shell layout/menu/swipe state helpers (`useMainMenuState`, `useMainSwipeNavigation`)
   - `hooks/profile/` contains extracted profile editor and profile metadata sync flows (`useProfileEditor`, `useProfileMetadataSyncEffect`)

--- a/apps/web-app/src/app/hooks/composition/useCashuWalletComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useCashuWalletComposition.ts
@@ -1,0 +1,4496 @@
+import type { Proof } from "@cashu/cashu-ts";
+import * as Evolu from "@evolu/common";
+import { useQuery } from "@evolu/react";
+import { nip19, type UnsignedEvent } from "nostr-tools";
+import React, { useMemo, useState } from "react";
+import { createSendTokenWithTokensAtMint } from "../../../cashuSend";
+import { deriveDefaultProfile } from "../../../derivedProfile";
+import {
+  evolu,
+  useEvolu,
+  type CashuTokenId,
+  type ContactId,
+} from "../../../evolu";
+import { navigateTo, useRouting } from "../../../hooks/useRouting";
+import type { Lang } from "../../../i18n";
+import {
+  inferLightningAddressFromLnurlTarget,
+  redeemLnurlWithdraw,
+  type LnurlWithdrawPreview,
+} from "../../../lnurlPay";
+import { NOSTR_RELAYS } from "../../../nostrProfile";
+import { getCashuDeterministicSeedFromStorage } from "../../../utils/cashuDeterministic";
+import {
+  isCashuOutputsAlreadySignedError,
+  isCashuOutputsArePendingError,
+} from "../../../utils/cashuErrors";
+import { getCashuLib } from "../../../utils/cashuLib";
+import { cashuAmountToNumber } from "../../../utils/cashuProofs";
+import { createLoadedCashuWallet } from "../../../utils/cashuWallet";
+import {
+  CASHU_AUTOSWAP_MIN_SOURCE_SUM,
+  CASHU_ONBOARDING_SET_MAIN_MINT_STORAGE_KEY,
+  CONTACTS_ONBOARDING_HAS_PAID_STORAGE_KEY,
+  LOCAL_PENDING_TOPUP_QUOTE_STORAGE_KEY_PREFIX,
+  MAX_CONTACTS_PER_OWNER,
+  WALLET_WARNING_BALANCE_THRESHOLD_SAT,
+  WALLET_WARNING_DISMISSED_STORAGE_KEY,
+} from "../../../utils/constants";
+import { formatDisplayAmountParts } from "../../../utils/displayAmounts";
+import {
+  getLightningInvoicePreview,
+  type LightningInvoicePreview,
+} from "../../../utils/lightningInvoice";
+import {
+  CASHU_DEFAULT_MINT_OVERRIDE_STORAGE_KEY,
+  isTestMintUrl,
+  MAIN_MINT_URL,
+  normalizeMintUrl,
+} from "../../../utils/mint";
+import { normalizeNpubIdentifier } from "../../../utils/nostrNpub";
+import { parseNpubCashProfileInfo } from "../../../utils/npubCashInfo";
+import {
+  getInitialCashuAutoswapEnabled,
+  getInitialLightningInvoiceAutoPayLimit,
+  getInitialPayWithCashuEnabled,
+  safeLocalStorageGet,
+  safeLocalStorageRemove,
+  safeLocalStorageSet,
+  safeLocalStorageSetJson,
+  withLocalStorageLeaseLock,
+} from "../../../utils/storage";
+import { getUnknownErrorMessage } from "../../../utils/unknown";
+import { makeLocalId } from "../../../utils/validation";
+import { useCashuTokenChecks } from "../cashu/useCashuTokenChecks";
+import { useNpubCashClaim } from "../cashu/useNpubCashClaim";
+import { useRestoreMissingTokens } from "../cashu/useRestoreMissingTokens";
+import { useSaveCashuFromText } from "../cashu/useSaveCashuFromText";
+import { normalizePubkeyHex } from "../messages/contactIdentity";
+import { useNpubCashMintSelection } from "../mint/useNpubCashMintSelection";
+import { useContactPayMethod } from "../payments/useContactPayMethod";
+import { usePayContactWithCashuMessage } from "../payments/usePayContactWithCashuMessage";
+import { useRouteAmountResetEffects } from "../payments/useRouteAmountResetEffects";
+import { shouldKeepTopupQuoteAfterClaimError } from "../topup/topupMintClaim";
+import {
+  isClaimableMintQuoteState,
+  readMintQuoteState,
+} from "../topup/topupMintQuoteState";
+import {
+  requestMintQuoteBolt11,
+  useTopupInvoiceQuoteEffects,
+  type TopupMintQuoteDraft,
+} from "../topup/useTopupInvoiceQuoteEffects";
+import { useAnonymousPaymentTelemetry } from "../useAnonymousPaymentTelemetry";
+import { useCashuDomain } from "../useCashuDomain";
+import { useLightningPaymentsDomain } from "../useLightningPaymentsDomain";
+import { useMintDomain } from "../useMintDomain";
+import { useOwnerScopedStorage } from "../useOwnerScopedStorage";
+import { usePaidOverlayState } from "../usePaidOverlayState";
+import { usePaymentsDomain } from "../usePaymentsDomain";
+import { useProfileNpubCashEffects } from "../useProfileNpubCashEffects";
+import {
+  appendPendingAutoswapClaim,
+  claimAutoswapPendingEntry,
+  makePendingAutoswapClaimsKey,
+  readPendingAutoswapClaims,
+  type AutoswapPendingClaim,
+} from "../../lib/autoswapClaim";
+import { getLinkyBankPaymentOfferInfo } from "../../lib/bankPaymentOffer";
+import { resolveCashuRowStoredOwnerLane } from "../../lib/cashuOwnerLane";
+import { isCashuRowCandidateBetter } from "../../lib/cashuRowPreference";
+import { createCashuTokenId } from "../../lib/cashuTokenIdentity";
+import {
+  CASHU_TOKEN_STATE_RESERVED,
+  isCashuTokenAcceptedState,
+  isCashuTokenDefinitivelySpent,
+  isCashuTokenEmittedState,
+  isCashuTokenIssuedState,
+  isCashuTokenReservedState,
+} from "../../lib/cashuTokenState";
+import { getSharedAppNostrPool } from "../../lib/nostrPool";
+import {
+  buildPaymentAmountAttempts,
+  buildPaymentFailureAmountAttempts,
+  getPaymentAmountReserveCap,
+  isRetryablePaymentAmountFailure,
+} from "../../lib/paymentAmountFallback";
+import {
+  canOfferPaymentMintMelt,
+  getPaymentMintMeltPlan,
+} from "../../lib/paymentMintMelt";
+import {
+  buildCashuMintCandidates as buildCashuMintCandidatesBase,
+  selectSingleMintCandidateForAmount,
+} from "../../lib/paymentMintSelection";
+import {
+  buildCashuPaymentRequestMessage,
+  parseCashuPaymentRequestMessage,
+  type CashuPaymentRequestMessageInfo,
+} from "../../lib/paymentRequestMessage";
+import {
+  LINKY_PAYMENT_NOTICE_CONTEXT_BANK_PAYMENT_OFFER,
+  wrapEventWithoutPushMarker,
+  wrapEventWithPushMarker,
+} from "../../lib/pushWrappedEvent";
+import { getCashuTokenMessageInfo as getCashuTokenMessageInfoBase } from "../../lib/tokenMessageInfo";
+import { extractCashuTokenMeta } from "../../lib/tokenText";
+import {
+  isExpiredPendingTopupQuote,
+  isLikelyCorsOrNetworkError,
+  isSameTopupMintQuote,
+  makeClaimedTopupQuoteLockKey,
+  makeClaimedTopupQuoteStorageKey,
+  readClaimedTopupQuoteFromStorage,
+  readPendingTopupQuoteFromStorage,
+  toPendingTopupQuoteStorage,
+  toTopupMintQuoteDraft,
+  type ClaimedTopupQuoteStorage,
+} from "../../lib/topupQuoteStorage";
+import { mintTopupProofs } from "../../lib/topupProofRecovery";
+import type {
+  ContactRowLike,
+  LocalNostrMessage,
+  PaymentLogData,
+} from "../../types/appTypes";
+import {
+  useContactsMessagingComposition,
+  type DisplayContact,
+} from "./useContactsMessagingComposition";
+import { useIdentityOwnersComposition } from "./useIdentityOwnersComposition";
+import { useProfileComposition } from "./useProfileComposition";
+
+type LoadedCashuWallet = Awaited<ReturnType<typeof createLoadedCashuWallet>>;
+
+type CashuProofPayload = Record<string, unknown> & {
+  C: string;
+  amount: number;
+  secret: string;
+};
+
+const isCashuProofPayload = (value: unknown): value is CashuProofPayload => {
+  if (typeof value !== "object" || value === null) return false;
+  return (
+    Reflect.get(value, "amount") !== undefined &&
+    typeof Reflect.get(value, "secret") === "string" &&
+    typeof Reflect.get(value, "C") === "string"
+  );
+};
+
+const normalizeCashuProofPayload = (
+  proof: unknown,
+): CashuProofPayload | null => {
+  if (!isCashuProofPayload(proof)) return null;
+  return {
+    ...proof,
+    amount: cashuAmountToNumber(Reflect.get(proof, "amount")),
+  };
+};
+
+export const logPayStep = (step: string, data?: PaymentLogData): void => {
+  try {
+    console.log("[linky][pay]", step, data ?? {});
+  } catch {
+    // ignore logging errors
+  }
+};
+
+type IdentityOwnersCompositionResult = ReturnType<
+  typeof useIdentityOwnersComposition
+>;
+type ContactsMessagingCompositionResult = ReturnType<
+  typeof useContactsMessagingComposition
+>;
+type ProfileCompositionResult = ReturnType<typeof useProfileComposition>;
+type OwnerScopedStorageResult = ReturnType<typeof useOwnerScopedStorage>;
+type EvoluMutations = ReturnType<typeof useEvolu>;
+
+export const createCashuTokensAllQuery = () =>
+  evolu.createQuery((db) =>
+    db.selectFrom("cashuToken").selectAll().orderBy("createdAt", "desc"),
+  );
+
+type CashuTokenQueryRow = Evolu.InferRow<
+  ReturnType<typeof createCashuTokensAllQuery>
+>;
+
+interface UseCashuWalletCompositionParams {
+  cashuTokensAll: readonly CashuTokenQueryRow[];
+  contactPayBackToChatRef: React.MutableRefObject<ContactId | null>;
+  contactsHeaderVisible: boolean;
+  contactsMessaging: Pick<
+    ContactsMessagingCompositionResult,
+    | "activeContactsOwnerContactCount"
+    | "activeNostrMessagePublishClientIdsRef"
+    | "appendLocalNostrMessage"
+    | "buildSavedContactName"
+    | "chatMessages"
+    | "chatSeenWrapIdsRef"
+    | "contacts"
+    | "enqueuePendingPayment"
+    | "isBankPaymentOfferCanceled"
+    | "nostrBootstrapReady"
+    | "nostrMessagesLocal"
+    | "nostrMessagesRecent"
+    | "nostrPictureByNpub"
+    | "openScannedContactPendingNpubRef"
+    | "pendingPayments"
+    | "publishSingleWrappedWithRetry"
+    | "publishWrappedWithRetry"
+    | "removePendingPayment"
+    | "respondToBankPaymentOfferWithGroupState"
+    | "selectedChatContact"
+    | "selectedContact"
+    | "sendChatMessage"
+    | "setContactsOnboardingHasPaid"
+    | "unknownNameByNpub"
+    | "updateLocalNostrMessage"
+  >;
+  formatDisplayedAmountParts: (
+    amountSat: number,
+  ) => ReturnType<typeof formatDisplayAmountParts>;
+  formatDisplayedAmountText: (amountSat: number) => string;
+  identity: Pick<
+    IdentityOwnersCompositionResult,
+    | "appOwnerId"
+    | "appOwnerIdRef"
+    | "cashuOwnerId"
+    | "cashuOwnerIdRef"
+    | "cashuVisibleOwnerIds"
+    | "contactsOwnerId"
+    | "currentNpub"
+    | "currentNsec"
+    | "isSeedLogin"
+    | "metaOwnerId"
+    | "recordContactsOwnerWrite"
+    | "transactionsOwnerId"
+  >;
+  insert: EvoluMutations["insert"];
+  lang: Lang;
+  maybeShowPwaNotification: (
+    title: string,
+    body: string,
+    tag?: string,
+  ) => Promise<void>;
+  ownerScopedStorage: Pick<
+    OwnerScopedStorageResult,
+    | "logPaymentEvent"
+    | "makeLocalStorageKey"
+    | "migrateLegacyPaymentEventsToEvolu"
+    | "readSeenMintsFromStorage"
+    | "rememberSeenMint"
+  >;
+  payAmount: string;
+  profile: Pick<
+    ProfileCompositionResult,
+    | "effectiveMyLightningAddress"
+    | "myProfileName"
+    | "npubCashInfoInFlightRef"
+    | "npubCashInfoLoadedAtMsRef"
+    | "npubCashInfoLoadedForNpubRef"
+    | "npubCashServerBaseUrl"
+    | "ownedProfileLightningAddresses"
+    | "profileClaimLightningAddressServerBaseUrl"
+    | "setIsProfileEditing"
+    | "setMyProfileQr"
+    | "setOwnedProfileLightningAddresses"
+    | "setOwnedProfileLightningAddressesLoading"
+  >;
+  pushToast: (message: string) => void;
+  route: ReturnType<typeof useRouting>;
+  setContactPaymentIntent: React.Dispatch<
+    React.SetStateAction<"pay" | "request">
+  >;
+  setPayAmount: React.Dispatch<React.SetStateAction<string>>;
+  setStatus: React.Dispatch<React.SetStateAction<string | null>>;
+  t: (key: string) => string;
+  update: EvoluMutations["update"];
+  upsert: EvoluMutations["upsert"];
+}
+
+export const useCashuWalletComposition = ({
+  cashuTokensAll,
+  contactPayBackToChatRef,
+  contactsHeaderVisible,
+  contactsMessaging,
+  formatDisplayedAmountParts,
+  formatDisplayedAmountText,
+  identity,
+  insert,
+  lang,
+  maybeShowPwaNotification,
+  ownerScopedStorage,
+  payAmount,
+  profile,
+  pushToast,
+  route,
+  setContactPaymentIntent,
+  setPayAmount,
+  setStatus,
+  t,
+  update,
+  upsert,
+}: UseCashuWalletCompositionParams) => {
+  const {
+    appOwnerId,
+    appOwnerIdRef,
+    cashuOwnerId,
+    cashuOwnerIdRef,
+    cashuVisibleOwnerIds,
+    contactsOwnerId,
+    currentNpub,
+    currentNsec,
+    isSeedLogin,
+    metaOwnerId,
+    recordContactsOwnerWrite,
+    transactionsOwnerId,
+  } = identity;
+  const {
+    activeContactsOwnerContactCount,
+    activeNostrMessagePublishClientIdsRef,
+    appendLocalNostrMessage,
+    buildSavedContactName,
+    chatMessages,
+    chatSeenWrapIdsRef,
+    contacts,
+    enqueuePendingPayment,
+    isBankPaymentOfferCanceled,
+    nostrBootstrapReady,
+    nostrMessagesLocal,
+    nostrMessagesRecent,
+    nostrPictureByNpub,
+    openScannedContactPendingNpubRef,
+    pendingPayments,
+    publishSingleWrappedWithRetry,
+    publishWrappedWithRetry,
+    removePendingPayment,
+    respondToBankPaymentOfferWithGroupState,
+    selectedChatContact,
+    selectedContact,
+    sendChatMessage,
+    setContactsOnboardingHasPaid,
+    unknownNameByNpub,
+    updateLocalNostrMessage,
+  } = contactsMessaging;
+  const {
+    effectiveMyLightningAddress,
+    myProfileName,
+    npubCashInfoInFlightRef,
+    npubCashInfoLoadedAtMsRef,
+    npubCashInfoLoadedForNpubRef,
+    npubCashServerBaseUrl,
+    ownedProfileLightningAddresses,
+    profileClaimLightningAddressServerBaseUrl,
+    setIsProfileEditing,
+    setMyProfileQr,
+    setOwnedProfileLightningAddresses,
+    setOwnedProfileLightningAddressesLoading,
+  } = profile;
+  const {
+    logPaymentEvent,
+    makeLocalStorageKey,
+    migrateLegacyPaymentEventsToEvolu,
+    readSeenMintsFromStorage,
+    rememberSeenMint,
+  } = ownerScopedStorage;
+
+  const hasMintOverrideRef = React.useRef(false);
+
+  const topupInvoiceStartBalanceRef = React.useRef<number | null>(null);
+  const topupInvoicePaidHandledRef = React.useRef(false);
+  const [pendingCashuDeleteId, setPendingCashuDeleteId] =
+    useState<CashuTokenId | null>(null);
+  const [pendingMintDeleteUrl, setPendingMintDeleteUrl] = useState<
+    string | null
+  >(null);
+
+  const [payWithCashuEnabled, setPayWithCashuEnabled] = useState<boolean>(() =>
+    getInitialPayWithCashuEnabled(),
+  );
+  const [cashuAutoswapEnabled, setCashuAutoswapEnabled] = useState<boolean>(
+    () => getInitialCashuAutoswapEnabled(),
+  );
+  const [lightningInvoiceAutoPayLimit, setLightningInvoiceAutoPayLimit] =
+    useState<number>(() => getInitialLightningInvoiceAutoPayLimit());
+
+  const pendingTopupStorageKey = `${LOCAL_PENDING_TOPUP_QUOTE_STORAGE_KEY_PREFIX}.${String(appOwnerId ?? "anon")}`;
+
+  useAnonymousPaymentTelemetry({
+    appOwnerId,
+    makeLocalStorageKey,
+  });
+
+  React.useEffect(() => {
+    appOwnerIdRef.current = appOwnerId;
+    if (!appOwnerId) return;
+    const overrideKey = makeLocalStorageKey(
+      CASHU_DEFAULT_MINT_OVERRIDE_STORAGE_KEY,
+    );
+    const overrideRaw = safeLocalStorageGet(overrideKey);
+    const override = normalizeMintUrl(overrideRaw);
+    const shouldSeedMainMint =
+      safeLocalStorageGet(CASHU_ONBOARDING_SET_MAIN_MINT_STORAGE_KEY) === "1";
+
+    if (!override && shouldSeedMainMint) {
+      const seededMint = normalizeMintUrl(MAIN_MINT_URL);
+      if (seededMint) {
+        safeLocalStorageSet(overrideKey, seededMint);
+        safeLocalStorageRemove(CASHU_ONBOARDING_SET_MAIN_MINT_STORAGE_KEY);
+        hasMintOverrideRef.current = true;
+        setDefaultMintUrl(seededMint);
+        setDefaultMintUrlDraft(seededMint);
+        // Mirror the onboarding-seeded value into Evolu so a brand-new
+        // account converges to cashu.cz across devices even before the user
+        // touches the mint UI.
+        upsertDefaultMintToOwnerMetaRef.current(seededMint);
+        return;
+      }
+    }
+
+    if (override) {
+      hasMintOverrideRef.current = true;
+      setDefaultMintUrl(override);
+      setDefaultMintUrlDraft(override);
+    } else {
+      if (shouldSeedMainMint) {
+        safeLocalStorageRemove(CASHU_ONBOARDING_SET_MAIN_MINT_STORAGE_KEY);
+      }
+      hasMintOverrideRef.current = false;
+    }
+  }, [appOwnerId, appOwnerIdRef, makeLocalStorageKey]);
+
+  const [cashuDraft, setCashuDraft] = useState("");
+  const cashuDraftRef = React.useRef<HTMLTextAreaElement | null>(null);
+  const [cashuEmitAmount, setCashuEmitAmount] = useState("");
+  const [cashuIsBusy, setCashuIsBusy] = useState(false);
+  const [cashuBulkCheckIsBusy, setCashuBulkCheckIsBusy] = useState(false);
+  const [tokensRestoreIsBusy, setTokensRestoreIsBusy] = useState(false);
+
+  const cashuOpQueueRef = React.useRef<Promise<void>>(Promise.resolve());
+  const enqueueCashuOp = React.useCallback((op: () => Promise<void>) => {
+    const next = cashuOpQueueRef.current.then(op, op);
+    cashuOpQueueRef.current = next.catch(() => {});
+    return next;
+  }, []);
+
+  const [defaultMintUrl, setDefaultMintUrl] = useState<string | null>(null);
+  const [defaultMintUrlDraft, setDefaultMintUrlDraft] = useState<string>("");
+
+  const [lnAddressPayAmount, setLnAddressPayAmount] = useState<string>("");
+
+  const [topupAmount, setTopupAmount] = useState<string>("");
+  const [topupInvoice, setTopupInvoice] = useState<string | null>(null);
+  const [topupInvoiceCashuRequest, setTopupInvoiceCashuRequest] = useState<
+    string | null
+  >(null);
+  const [topupInvoiceQr, setTopupInvoiceQr] = useState<string | null>(null);
+  const [topupInvoiceQrPayload, setTopupInvoiceQrPayload] = useState<
+    string | null
+  >(null);
+  const [topupInvoiceError, setTopupInvoiceError] = useState<string | null>(
+    null,
+  );
+  const [topupInvoiceIsBusy, setTopupInvoiceIsBusy] = useState(false);
+  const [topupMintQuote, setTopupMintQuote] =
+    useState<TopupMintQuoteDraft | null>(null);
+
+  React.useEffect(() => {
+    if (!appOwnerId) {
+      setTopupMintQuote(null);
+      return;
+    }
+
+    const stored = readPendingTopupQuoteFromStorage(pendingTopupStorageKey);
+    if (!stored) {
+      safeLocalStorageRemove(pendingTopupStorageKey);
+      setTopupMintQuote(null);
+      return;
+    }
+
+    if (isExpiredPendingTopupQuote(stored.createdAtMs)) {
+      safeLocalStorageRemove(pendingTopupStorageKey);
+      setTopupMintQuote(null);
+      return;
+    }
+
+    const nextQuote = toTopupMintQuoteDraft(stored);
+    setTopupMintQuote((current) => {
+      if (isSameTopupMintQuote(current, nextQuote)) return current;
+      return nextQuote;
+    });
+  }, [appOwnerId, pendingTopupStorageKey]);
+
+  React.useEffect(() => {
+    if (!appOwnerId) return;
+
+    if (!topupMintQuote) {
+      safeLocalStorageRemove(pendingTopupStorageKey);
+      return;
+    }
+
+    safeLocalStorageSet(
+      pendingTopupStorageKey,
+      JSON.stringify(toPendingTopupQuoteStorage(topupMintQuote)),
+    );
+  }, [appOwnerId, pendingTopupStorageKey, topupMintQuote]);
+  const [pendingCashuTokenContactPickId, setPendingCashuTokenContactPickId] =
+    useState<CashuTokenId | null>(null);
+
+  const [
+    pendingLightningInvoiceConfirmation,
+    setPendingLightningInvoiceConfirmation,
+  ] = useState<LightningInvoicePreview | null>(null);
+  const [
+    pendingLnurlWithdrawConfirmation,
+    setPendingLnurlWithdrawConfirmation,
+  ] = useState<LnurlWithdrawPreview | null>(null);
+  const [
+    pendingMintAutoswapChangeConfirmation,
+    setPendingMintAutoswapChangeConfirmation,
+  ] = useState<{
+    fromMint: string;
+    toMint: string;
+  } | null>(null);
+  const pendingMintAutoswapChangeResolverRef = React.useRef<
+    ((confirmed: boolean) => void) | null
+  >(null);
+  const [
+    pendingPaymentMintMeltConfirmation,
+    setPendingPaymentMintMeltConfirmation,
+  ] = useState<{
+    fromMint: string;
+    toMint: string;
+  } | null>(null);
+  const meltLargestForeignMintToMainMintRef = React.useRef<() => Promise<void>>(
+    async () => {},
+  );
+  const [lnurlWithdrawIsBusy, setLnurlWithdrawIsBusy] = useState(false);
+
+  const npubCashClaimInFlightRef = React.useRef(false);
+  const npubCashMintSyncRef = React.useRef<string | null>(null);
+
+  const {
+    paidOverlayIsOpen,
+    paidOverlayTitle,
+    showPaidOverlay,
+    topupPaidNavTimerRef,
+  } = usePaidOverlayState({
+    t,
+  });
+
+  const finalizeTopupInvoicePaid = React.useCallback(
+    (args: { amountSat: number; gainedToken?: string | null }) => {
+      if (topupInvoicePaidHandledRef.current) return;
+
+      const amountSat = args.amountSat;
+      const topupInvoice = topupMintQuote?.invoice ?? null;
+      const topupInvoicePreview = topupInvoice
+        ? getLightningInvoicePreview(topupInvoice)
+        : null;
+
+      logPaymentEvent({
+        amount: amountSat,
+        details:
+          topupInvoice || args.gainedToken
+            ? {
+                ...(args.gainedToken ? { gainedToken: args.gainedToken } : {}),
+                ...(topupInvoice ? { lightningInvoice: topupInvoice } : {}),
+                ...(topupInvoicePreview?.description
+                  ? { lightningMemo: topupInvoicePreview.description }
+                  : {}),
+              }
+            : null,
+        direction: "in",
+        method: "lightning_invoice",
+        mint: topupMintQuote?.mintUrl ?? defaultMintUrl ?? null,
+        status: "ok",
+        unit: topupMintQuote?.unit ?? "sat",
+      });
+
+      topupInvoicePaidHandledRef.current = true;
+      topupInvoiceStartBalanceRef.current = null;
+      setTopupAmount("");
+      setTopupInvoice(null);
+      setTopupInvoiceQr(null);
+      setTopupInvoiceError(null);
+      setTopupInvoiceIsBusy(false);
+
+      const displayAmount = formatDisplayedAmountParts(amountSat);
+      showPaidOverlay(
+        t("topupOverlay")
+          .replace(
+            "{amount}",
+            `${displayAmount.approxPrefix}${displayAmount.amountText}`,
+          )
+          .replace("{unit}", displayAmount.unitLabel),
+      );
+
+      if (topupPaidNavTimerRef.current !== null) {
+        try {
+          window.clearTimeout(topupPaidNavTimerRef.current);
+        } catch {
+          // ignore
+        }
+      }
+
+      topupPaidNavTimerRef.current = window.setTimeout(() => {
+        topupPaidNavTimerRef.current = null;
+        navigateTo({ route: "wallet" });
+      }, 1400);
+    },
+    [
+      defaultMintUrl,
+      formatDisplayedAmountParts,
+      logPaymentEvent,
+      setTopupAmount,
+      setTopupInvoice,
+      setTopupInvoiceError,
+      setTopupInvoiceIsBusy,
+      setTopupInvoiceQr,
+      showPaidOverlay,
+      t,
+      topupMintQuote,
+      topupPaidNavTimerRef,
+    ],
+  );
+
+  // Default mint cross-tab + cross-device sync via Evolu `ownerMeta`.
+  //
+  // Background: the per-owner localStorage override
+  // (`linky.cashu.defaultMintOverride.v1.<owner>`) is tab-local, so other
+  // tabs (and other devices) don't see the change until reload. ownerMeta is
+  // an Evolu lane that already propagates via BroadcastChannel (same-origin
+  // tabs, instant) and via the Evolu sync server (other devices), so we
+  // mirror the default-mint value into it.
+  const ownerMetaDefaultMintRowId = React.useMemo(
+    () => Evolu.createIdFromString<"OwnerMeta">("owner-pointer-defaultMint"),
+    [],
+  );
+
+  const ownerMetaDefaultMintQuery = useMemo(
+    () =>
+      evolu.createQuery((db) =>
+        db
+          .selectFrom("ownerMeta")
+          .selectAll()
+          .where("isDeleted", "is not", Evolu.sqliteTrue)
+          .where(
+            "scope",
+            "=",
+            "defaultMint" as typeof Evolu.NonEmptyString100.Type,
+          ),
+      ),
+    [],
+  );
+  const ownerMetaDefaultMintRows = useQuery(ownerMetaDefaultMintQuery);
+
+  const ownerMetaDefaultMintValue = React.useMemo(() => {
+    for (const row of ownerMetaDefaultMintRows) {
+      if (typeof row !== "object" || row === null) continue;
+      if (!("value" in row)) continue;
+      const raw = String(row.value ?? "").trim();
+      if (!raw) continue;
+      const cleaned = normalizeMintUrl(raw);
+      if (cleaned) return cleaned;
+    }
+    return null;
+  }, [ownerMetaDefaultMintRows]);
+
+  // ownerMeta -> local state: when another tab/device wrote a different
+  // default mint, pick it up here. This is the ONLY direction watched as an
+  // effect. A symmetric `defaultMintUrl -> ownerMeta` watcher would
+  // ping-pong with the remote: in the same render where this effect queues
+  // setDefaultMintUrl(remoteValue), the symmetric effect would read the
+  // STALE local `defaultMintUrl` and upsert it back, racing with the remote
+  // value. Two devices in this state oscillate every few ms (visible in
+  // ownerMeta CRDT history). Explicit pushes happen instead from
+  // `upsertDefaultMintToOwnerMeta` called by user actions and the seed
+  // effect.
+  React.useEffect(() => {
+    if (!ownerMetaDefaultMintValue) return;
+    if (!appOwnerId) return;
+    const current = normalizeMintUrl(defaultMintUrl ?? "");
+    if (current === ownerMetaDefaultMintValue) return;
+    setDefaultMintUrl(ownerMetaDefaultMintValue);
+    setDefaultMintUrlDraft(ownerMetaDefaultMintValue);
+    hasMintOverrideRef.current = true;
+    try {
+      const overrideKey = makeLocalStorageKey(
+        CASHU_DEFAULT_MINT_OVERRIDE_STORAGE_KEY,
+      );
+      safeLocalStorageSet(overrideKey, ownerMetaDefaultMintValue);
+    } catch {
+      // ignore
+    }
+  }, [
+    appOwnerId,
+    defaultMintUrl,
+    makeLocalStorageKey,
+    ownerMetaDefaultMintValue,
+  ]);
+
+  const upsertDefaultMintToOwnerMeta = React.useCallback(
+    (mintUrl: string | null | undefined) => {
+      if (!metaOwnerId) return;
+      const cleaned = normalizeMintUrl(mintUrl ?? "");
+      if (!cleaned) return;
+      if (cleaned === ownerMetaDefaultMintValue) return;
+      upsert(
+        "ownerMeta",
+        {
+          id: ownerMetaDefaultMintRowId,
+          scope: "defaultMint" as typeof Evolu.NonEmptyString100.Type,
+          value: cleaned as typeof Evolu.NonEmptyString1000.Type,
+        },
+        { ownerId: metaOwnerId },
+      );
+    },
+    [metaOwnerId, ownerMetaDefaultMintRowId, ownerMetaDefaultMintValue, upsert],
+  );
+
+  const upsertDefaultMintToOwnerMetaRef = React.useRef(
+    upsertDefaultMintToOwnerMeta,
+  );
+  React.useEffect(() => {
+    upsertDefaultMintToOwnerMetaRef.current = upsertDefaultMintToOwnerMeta;
+  }, [upsertDefaultMintToOwnerMeta]);
+
+  const resolveOwnerIdForWrite = React.useCallback(async () => {
+    if (cashuOwnerIdRef.current) return cashuOwnerIdRef.current;
+    if (isSeedLogin) return null;
+    try {
+      const owner = await evolu.appOwner;
+      return owner?.id ?? null;
+    } catch {
+      return null;
+    }
+  }, [cashuOwnerIdRef, isSeedLogin]);
+
+  React.useEffect(() => {
+    if (!appOwnerId) return;
+    migrateLegacyPaymentEventsToEvolu(appOwnerId, transactionsOwnerId);
+  }, [appOwnerId, migrateLegacyPaymentEventsToEvolu, transactionsOwnerId]);
+
+  useRouteAmountResetEffects({
+    contactPayBackToChatRef,
+    contactsHeaderVisible,
+    routeKind: route.kind,
+    setContactPaymentIntent,
+    setLnAddressPayAmount,
+    setPayAmount,
+  });
+
+  const topupRecipientNprofile = React.useMemo(() => {
+    try {
+      const decoded = nip19.decode(currentNpub ?? "");
+      if (decoded.type !== "npub" || typeof decoded.data !== "string") {
+        return null;
+      }
+      return nip19.nprofileEncode({
+        pubkey: decoded.data,
+        relays: NOSTR_RELAYS,
+      });
+    } catch {
+      return null;
+    }
+  }, [currentNpub]);
+
+  const activeCashuOwnerId = String(cashuOwnerId ?? "").trim();
+  const visibleCashuOwnerIds = React.useMemo(
+    () =>
+      new Set(
+        cashuVisibleOwnerIds
+          .map((ownerId) => String(ownerId ?? "").trim())
+          .filter(Boolean),
+      ),
+    [cashuVisibleOwnerIds],
+  );
+  const readCashuRowOwnerId = React.useCallback((row: unknown): string => {
+    if (typeof row !== "object" || row === null) return "";
+    if (!("ownerId" in row)) return "";
+    const ownerId = row.ownerId;
+    if (typeof ownerId !== "string") return "";
+    return ownerId.trim();
+  }, []);
+
+  const readCashuRowAliases = React.useCallback(
+    (row: { rawToken?: string | null; token?: string | null } | null) => {
+      return [
+        String(row?.rawToken ?? "").trim(),
+        String(row?.token ?? "").trim(),
+      ].filter(Boolean);
+    },
+    [],
+  );
+
+  const dedupeVisibleCashuRows = React.useCallback(
+    function dedupeVisibleCashuRows<
+      TRow extends {
+        id?: string | null;
+        isDeleted?: unknown;
+        ownerId?: unknown;
+        rawToken?: string | null;
+        state?: unknown;
+        token?: string | null;
+      },
+    >(rows: readonly TRow[]): TRow[] {
+      if (visibleCashuOwnerIds.size === 0) return [];
+
+      const ownerRank = new Map<string, number>();
+      let rank = 0;
+      for (const normalizedOwnerId of visibleCashuOwnerIds) {
+        if (!normalizedOwnerId || ownerRank.has(normalizedOwnerId)) continue;
+        ownerRank.set(normalizedOwnerId, rank);
+        rank += 1;
+      }
+
+      const canonicalByAlias = new Map<string, string>();
+      const bestByCanonical = new Map<string, TRow>();
+      const readRowCandidates = (row: TRow): string[] => {
+        const id = String(row.id ?? "").trim();
+        return id
+          ? [id, ...readCashuRowAliases(row)]
+          : readCashuRowAliases(row);
+      };
+
+      const isCandidateBetter = (candidate: TRow, existing: TRow): boolean => {
+        return isCashuRowCandidateBetter({
+          activeOwnerId: activeCashuOwnerId,
+          candidate,
+          existing,
+          ownerRank,
+        });
+      };
+
+      for (const row of rows) {
+        const ownerId = readCashuRowOwnerId(row);
+        if (!visibleCashuOwnerIds.has(ownerId)) continue;
+
+        const rowCandidates = readRowCandidates(row);
+        if (rowCandidates.length === 0) continue;
+
+        const canonicalKey =
+          rowCandidates.find((candidate) => canonicalByAlias.has(candidate)) ??
+          rowCandidates[0];
+        const existing = bestByCanonical.get(canonicalKey);
+
+        if (!existing || isCandidateBetter(row, existing)) {
+          bestByCanonical.set(canonicalKey, row);
+        }
+
+        for (const candidate of rowCandidates) {
+          canonicalByAlias.set(candidate, canonicalKey);
+        }
+      }
+
+      return rows.filter((row) => {
+        const rowCandidates = readRowCandidates(row);
+        if (rowCandidates.length === 0) return false;
+
+        const canonicalKey =
+          rowCandidates.find((candidate) => canonicalByAlias.has(candidate)) ??
+          rowCandidates[0];
+        return bestByCanonical.get(canonicalKey) === row;
+      });
+    },
+    [
+      activeCashuOwnerId,
+      readCashuRowAliases,
+      readCashuRowOwnerId,
+      visibleCashuOwnerIds,
+    ],
+  );
+
+  const cashuTokensAllFiltered = React.useMemo(() => {
+    return dedupeVisibleCashuRows(cashuTokensAll);
+  }, [cashuTokensAll, dedupeVisibleCashuRows]);
+
+  const cashuTokensFiltered = React.useMemo(
+    () => cashuTokensAllFiltered.filter((row) => !row.isDeleted),
+    [cashuTokensAllFiltered],
+  );
+
+  const cashuTokensWithMeta = useMemo(
+    () =>
+      cashuTokensFiltered.flatMap((row) => {
+        const meta = extractCashuTokenMeta({
+          amount: row.amount,
+          mint: row.mint,
+          rawToken: row.rawToken,
+          token: row.token,
+          unit: row.unit,
+        });
+        const amount = meta.amount ?? 0;
+        if (amount <= 0) return [];
+
+        return [
+          {
+            ...row,
+            mint: meta.mint ?? null,
+            unit: meta.unit ?? null,
+            amount,
+            tokenText: meta.tokenText,
+          },
+        ];
+      }),
+    [cashuTokensFiltered],
+  );
+
+  const {
+    cashuTokensHydratedRef,
+    ensureCashuTokenPersisted,
+    isCashuTokenKnownAny,
+    isCashuTokenStored,
+    rememberCashuTokenKnown,
+  } = useCashuDomain({
+    appOwnerId: cashuOwnerId,
+    appOwnerIdRef: cashuOwnerIdRef,
+    cashuTokensAll,
+    upsert,
+    logPaymentEvent,
+  });
+
+  const migratedMisplacedCashuTokenIdsRef = React.useRef<Set<string>>(
+    new Set(),
+  );
+
+  React.useEffect(() => {
+    if (!appOwnerId) return;
+
+    const sourceOwnerId = String(appOwnerId ?? "").trim();
+    if (!sourceOwnerId) return;
+    if (!activeCashuOwnerId) return;
+    if (sourceOwnerId === activeCashuOwnerId) return;
+    if (!cashuOwnerId) return;
+
+    const activeRows = cashuTokensAll.filter((row) => {
+      if (row.isDeleted) return false;
+      return readCashuRowOwnerId(row) === activeCashuOwnerId;
+    });
+
+    const hasActiveDuplicate = (row: (typeof cashuTokensAll)[number]) => {
+      const identityToken = String(row.rawToken ?? row.token ?? "").trim();
+      const rowCandidates = [
+        String(row.id ?? "").trim(),
+        identityToken ? String(createCashuTokenId(identityToken)) : "",
+        String(row.rawToken ?? "").trim(),
+        String(row.token ?? "").trim(),
+      ].filter(Boolean);
+      if (rowCandidates.length === 0) return false;
+
+      return activeRows.some((activeRow) => {
+        const activeIdentityToken = String(
+          activeRow.rawToken ?? activeRow.token ?? "",
+        ).trim();
+        const activeCandidates = [
+          String(activeRow.id ?? "").trim(),
+          activeIdentityToken
+            ? String(createCashuTokenId(activeIdentityToken))
+            : "",
+          String(activeRow.rawToken ?? "").trim(),
+          String(activeRow.token ?? "").trim(),
+        ].filter(Boolean);
+
+        return rowCandidates.some((candidate) =>
+          activeCandidates.includes(candidate),
+        );
+      });
+    };
+
+    const misplacedRows = cashuTokensAll.filter((row) => {
+      if (row.isDeleted) return false;
+      return readCashuRowOwnerId(row) === sourceOwnerId;
+    });
+
+    for (const row of misplacedRows) {
+      const rowId = String(row.id ?? "").trim();
+      if (!rowId) continue;
+      if (migratedMisplacedCashuTokenIdsRef.current.has(rowId)) continue;
+
+      if (!hasActiveDuplicate(row)) {
+        const token = String(row.token ?? row.rawToken ?? "").trim();
+        const rawToken = String(row.rawToken ?? "").trim();
+        const state = String(row.state ?? "").trim() || "accepted";
+        const error = String(row.error ?? "").trim();
+
+        if (token) {
+          const payload: {
+            id: CashuTokenId;
+            token: typeof Evolu.NonEmptyString.Type;
+            state: typeof Evolu.NonEmptyString100.Type;
+            error?: typeof Evolu.NonEmptyString1000.Type;
+          } = {
+            id: createCashuTokenId(rawToken || token),
+            token: token as typeof Evolu.NonEmptyString.Type,
+            state: state as typeof Evolu.NonEmptyString100.Type,
+          };
+
+          if (error) {
+            payload.error = error as typeof Evolu.NonEmptyString1000.Type;
+          }
+
+          const insertResult = upsert("cashuToken", payload, {
+            ownerId: cashuOwnerId,
+          });
+          if (!insertResult.ok) continue;
+        }
+      }
+
+      migratedMisplacedCashuTokenIdsRef.current.add(rowId);
+
+      update(
+        "cashuToken",
+        {
+          id: row.id as CashuTokenId,
+          isDeleted: Evolu.sqliteTrue,
+        },
+        { ownerId: appOwnerId },
+      );
+    }
+  }, [
+    activeCashuOwnerId,
+    appOwnerId,
+    cashuOwnerId,
+    cashuTokensAll,
+    upsert,
+    readCashuRowOwnerId,
+    update,
+  ]);
+
+  React.useEffect(() => {
+    if (!topupMintQuote) return;
+
+    let cancelled = false;
+    let claimInFlight = false;
+    let lastLoggedClaimError = "";
+    // Cache the loaded wallet across the 5s polling ticks within this
+    // effect mount. Each tick only does a `checkMintQuote` + the eventual
+    // mintProofs, neither of which needs a fresh `loadMint()`. The effect
+    // tears down when topupMintQuote changes, so the cache is naturally
+    // scoped to one quote / one mintUrl+unit pair.
+    let cachedWallet: LoadedCashuWallet | null = null;
+    const run = async () => {
+      if (claimInFlight) return;
+      claimInFlight = true;
+      try {
+        const quoteId = String(topupMintQuote.quote ?? "").trim();
+        if (!quoteId) return;
+
+        const topupOwnerKey = String(appOwnerId ?? "anon");
+        const claimStorageKey = makeClaimedTopupQuoteStorageKey({
+          ownerId: topupOwnerKey,
+          mintUrl: topupMintQuote.mintUrl,
+          quote: quoteId,
+        });
+        const claimLockKey = makeClaimedTopupQuoteLockKey({
+          ownerId: topupOwnerKey,
+          mintUrl: topupMintQuote.mintUrl,
+          quote: quoteId,
+        });
+
+        const insertClaimedTopupToken = async (
+          claimed: ClaimedTopupQuoteStorage,
+        ) => {
+          if (isCashuTokenKnownAny(claimed.token)) return true;
+
+          const ownerId = await resolveOwnerIdForWrite();
+          const payload = {
+            id: createCashuTokenId(claimed.token),
+            token: claimed.token as typeof Evolu.NonEmptyString.Type,
+            state: "accepted" as typeof Evolu.NonEmptyString100.Type,
+          };
+
+          const result = ownerId
+            ? upsert("cashuToken", payload, { ownerId })
+            : upsert("cashuToken", payload);
+          if (!result.ok) {
+            setStatus(
+              `${t("errorPrefix")}: ${getUnknownErrorMessage(result.error, "unknown")}`,
+            );
+            return false;
+          }
+
+          return true;
+        };
+
+        const claimedBeforeRun =
+          readClaimedTopupQuoteFromStorage(claimStorageKey);
+        if (claimedBeforeRun) {
+          const restored = await insertClaimedTopupToken(claimedBeforeRun);
+          if (restored && !cancelled) {
+            if (route.kind === "topupInvoice" && claimedBeforeRun.amount > 0) {
+              finalizeTopupInvoicePaid({
+                amountSat: claimedBeforeRun.amount,
+                gainedToken: claimedBeforeRun.token,
+              });
+            }
+            setTopupMintQuote(null);
+          }
+          return;
+        }
+
+        const { Mint, Wallet, MintQuoteState, getEncodedToken } =
+          await getCashuLib();
+        await withLocalStorageLeaseLock({
+          key: claimLockKey,
+          ttlMs: 15_000,
+          timeoutMs: 2_000,
+          waitMs: 50,
+          fn: async () => {
+            const alreadyClaimed =
+              readClaimedTopupQuoteFromStorage(claimStorageKey);
+            if (alreadyClaimed) {
+              const restored = await insertClaimedTopupToken(alreadyClaimed);
+              if (restored && !cancelled) {
+                if (
+                  route.kind === "topupInvoice" &&
+                  alreadyClaimed.amount > 0
+                ) {
+                  finalizeTopupInvoicePaid({
+                    amountSat: alreadyClaimed.amount,
+                    gainedToken: alreadyClaimed.token,
+                  });
+                }
+                setTopupMintQuote(null);
+              }
+              return;
+            }
+
+            let wallet = cachedWallet;
+            if (!wallet) {
+              const det = getCashuDeterministicSeedFromStorage();
+              wallet = await createLoadedCashuWallet({
+                Mint,
+                Wallet,
+                mintUrl: topupMintQuote.mintUrl,
+                ...(topupMintQuote.unit ? { unit: topupMintQuote.unit } : {}),
+                ...(det ? { bip39seed: det.bip39seed } : {}),
+              });
+              cachedWallet = wallet;
+            }
+
+            const status = await wallet.checkMintQuoteBolt11(quoteId);
+            const quoteState = readMintQuoteState(status);
+            if (!isClaimableMintQuoteState(quoteState, MintQuoteState)) {
+              return;
+            }
+
+            const unit = wallet.unit ?? topupMintQuote.unit ?? null;
+            const proofs = await mintTopupProofs({
+              amount: topupMintQuote.amount,
+              mintUrl: topupMintQuote.mintUrl,
+              quoteId,
+              unit,
+              wallet,
+            });
+            const token = String(
+              getEncodedToken({
+                mint: topupMintQuote.mintUrl,
+                proofs,
+                ...(unit ? { unit } : {}),
+              }) ?? "",
+            ).trim();
+            if (!token) throw new Error("Mint produced empty token");
+
+            safeLocalStorageSetJson(claimStorageKey, {
+              amount: topupMintQuote.amount,
+              claimedAtMs: Date.now(),
+              mintUrl: topupMintQuote.mintUrl,
+              quote: quoteId,
+              token,
+              unit,
+            });
+
+            if (!isCashuTokenKnownAny(token)) {
+              const ownerId = await resolveOwnerIdForWrite();
+              const payload = {
+                id: createCashuTokenId(token),
+                token: token as typeof Evolu.NonEmptyString.Type,
+                state: "accepted" as typeof Evolu.NonEmptyString100.Type,
+              };
+
+              const result = ownerId
+                ? upsert("cashuToken", payload, { ownerId })
+                : upsert("cashuToken", payload);
+              if (!result.ok) {
+                setStatus(
+                  `${t("errorPrefix")}: ${getUnknownErrorMessage(result.error, "unknown")}`,
+                );
+                return;
+              }
+            }
+
+            if (route.kind === "topupInvoice") {
+              finalizeTopupInvoicePaid({
+                amountSat: topupMintQuote.amount,
+                gainedToken: token,
+              });
+            } else {
+              const displayAmount = formatDisplayedAmountParts(
+                topupMintQuote.amount,
+              );
+              showPaidOverlay(
+                t("topupOverlay")
+                  .replace(
+                    "{amount}",
+                    `${displayAmount.approxPrefix}${displayAmount.amountText}`,
+                  )
+                  .replace("{unit}", displayAmount.unitLabel),
+              );
+            }
+
+            if (!cancelled) setTopupMintQuote(null);
+          },
+        });
+      } catch (error) {
+        const message = getUnknownErrorMessage(error, "unknown");
+        const errorKey = `${topupMintQuote.mintUrl}:${message}`;
+        if (errorKey !== lastLoggedClaimError) {
+          lastLoggedClaimError = errorKey;
+          console.warn("[linky][topup] mint claim failed", {
+            error: message,
+            likelyCors: isLikelyCorsOrNetworkError(message),
+            mintUrl: topupMintQuote.mintUrl,
+            route: route.kind,
+          });
+        }
+        if (
+          shouldKeepTopupQuoteAfterClaimError(
+            error,
+            (e: unknown) =>
+              isCashuOutputsAlreadySignedError(e) ||
+              isCashuOutputsArePendingError(e),
+          )
+        ) {
+          setStatus(`${t("restoreFailed")}: ${message}`);
+        } else if (isCashuOutputsAlreadySignedError(error) && !cancelled) {
+          // Recovery already ran inside mintTopupProofs. Drop the pending
+          // quote so the 5s tick stops re-issuing the same failing mint
+          // call against the same deterministic counter.
+          setTopupMintQuote(null);
+        }
+      } finally {
+        claimInFlight = false;
+      }
+    };
+
+    void run();
+    const intervalId = window.setInterval(() => {
+      void run();
+    }, 5000);
+    const runWhenVisible = () => {
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState === "hidden"
+      ) {
+        return;
+      }
+      void run();
+    };
+
+    window.addEventListener("focus", runWhenVisible);
+    window.addEventListener("pageshow", runWhenVisible);
+    window.addEventListener("online", runWhenVisible);
+    document.addEventListener("visibilitychange", runWhenVisible);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", runWhenVisible);
+      window.removeEventListener("pageshow", runWhenVisible);
+      window.removeEventListener("online", runWhenVisible);
+      document.removeEventListener("visibilitychange", runWhenVisible);
+    };
+  }, [
+    appOwnerId,
+    formatDisplayedAmountParts,
+    finalizeTopupInvoicePaid,
+    upsert,
+    isCashuTokenKnownAny,
+    resolveOwnerIdForWrite,
+    topupMintQuote,
+    t,
+    route.kind,
+    showPaidOverlay,
+    setStatus,
+  ]);
+
+  const {
+    getMintIconUrl,
+    getMintRuntime,
+    isMintDeleted,
+    mintInfoByUrl,
+    mintInfoDeduped,
+    refreshMintInfo,
+    setMintIconUrlByMint,
+    setMintInfoAll,
+    touchMintInfo,
+  } = useMintDomain({
+    appOwnerId,
+    appOwnerIdRef,
+    cashuTokensAll: cashuTokensAllFiltered,
+    defaultMintUrl,
+    rememberSeenMint,
+  });
+
+  // Tutorial progress remains local-only.
+
+  React.useEffect(() => {
+    if (!import.meta.env.DEV) return;
+
+    try {
+      if (localStorage.getItem("linky_debug_evolu_snapshot") !== "1") return;
+    } catch {
+      return;
+    }
+
+    // Debug: log Evolu state without secrets.
+    // NOTE: Relays and derived npub are Nostr/runtime state, not stored in Evolu.
+    console.log("[linky][evolu] snapshot", {
+      nostrIdentity: {
+        hasNsec: Boolean(currentNsec),
+        hasNpub: Boolean(currentNpub),
+      },
+      cashuTokens: cashuTokensFiltered.map((t) => ({
+        id: String(t.id ?? ""),
+        mint: String(t.mint ?? ""),
+        amount: Number(t.amount ?? 0) || 0,
+        state: String(t.state ?? ""),
+      })),
+      cashuTokensAll: {
+        count: cashuTokensAllFiltered.length,
+        newest10: cashuTokensAllFiltered.slice(0, 10).map((t) => ({
+          id: String(t.id ?? ""),
+          mint: String(t.mint ?? ""),
+          amount: Number(t.amount ?? 0) || 0,
+          state: String(t.state ?? ""),
+          isDeleted: Boolean(t.isDeleted),
+        })),
+      },
+    });
+  }, [cashuTokensAllFiltered, cashuTokensFiltered, currentNpub, currentNsec]);
+
+  React.useEffect(() => {
+    const pendingTokens = cashuTokensAllFiltered.filter((row) => {
+      const state = String(row.state ?? "");
+      if (state !== "pending") return false;
+      const isDeleted = Boolean(row.isDeleted);
+      return !isDeleted;
+    });
+    if (pendingTokens.length === 0) return;
+
+    for (const row of pendingTokens) {
+      const tokenText = String(row.token ?? row.rawToken ?? "").trim();
+      if (!tokenText) continue;
+      const hasMessage = nostrMessagesLocal.some((m) => {
+        const isOut = String(m.direction ?? "") === "out";
+        const matches = String(m.content ?? "").trim() === tokenText;
+        const status = String(m.status ?? "sent");
+        return isOut && matches && status !== "pending";
+      });
+      if (!hasMessage) continue;
+      const payload = {
+        id: row.id as CashuTokenId,
+        isDeleted: Evolu.sqliteTrue,
+      };
+      // Target the lane that holds the row (Evolu keys rows by (ownerId, id));
+      // deleting under the active lane no-ops on rows in older cashu-n lanes.
+      const rowOwnerId = resolveCashuRowStoredOwnerLane(row) ?? cashuOwnerId;
+      if (rowOwnerId) {
+        update("cashuToken", payload, { ownerId: rowOwnerId });
+      } else {
+        update("cashuToken", payload);
+      }
+    }
+  }, [cashuOwnerId, cashuTokensAllFiltered, nostrMessagesLocal, update]);
+
+  // lastMessageByContactId provided by the derived Nostr index above.
+
+  const cashuTotalBalance = useMemo(() => {
+    return cashuTokensWithMeta.reduce((sum, token) => {
+      if (!isCashuTokenAcceptedState(token.state)) return sum;
+      const amount = Number(token.amount ?? 0);
+      return sum + (Number.isFinite(amount) ? amount : 0);
+    }, 0);
+  }, [cashuTokensWithMeta]);
+
+  const cashuAcceptedMintBalances = useMemo(() => {
+    const balances = new Map<string, number>();
+    for (const token of cashuTokensWithMeta) {
+      if (!isCashuTokenAcceptedState(token.state)) continue;
+
+      const mint = normalizeMintUrl(String(token.mint ?? "").trim());
+      if (!mint) continue;
+
+      const amount = Number(token.amount ?? 0);
+      const nextAmount = Number.isFinite(amount) && amount > 0 ? amount : 0;
+      balances.set(mint, (balances.get(mint) ?? 0) + nextAmount);
+    }
+
+    return balances;
+  }, [cashuTokensWithMeta]);
+
+  const cashuBalance = useMemo(() => {
+    let largestBalance = 0;
+    for (const balance of cashuAcceptedMintBalances.values()) {
+      if (balance > largestBalance) largestBalance = balance;
+    }
+
+    return largestBalance;
+  }, [cashuAcceptedMintBalances]);
+
+  const paymentMintMeltPlan = React.useMemo(() => {
+    return getPaymentMintMeltPlan({
+      mainMint: normalizeMintUrl(defaultMintUrl ?? MAIN_MINT_URL),
+      balances: Array.from(cashuAcceptedMintBalances, ([mint, sum]) => ({
+        mint,
+        sum,
+      })),
+    });
+  }, [cashuAcceptedMintBalances, defaultMintUrl]);
+
+  const cashuBalanceAfterMelt = Math.max(
+    cashuBalance,
+    paymentMintMeltPlan?.maxBalanceAfterMelt ?? 0,
+  );
+
+  const requestPaymentMintMelt = React.useCallback(
+    (amountSat: number): boolean => {
+      if (
+        !canOfferPaymentMintMelt({
+          amountSat,
+          currentBalance: cashuBalance,
+          plan: paymentMintMeltPlan,
+        }) ||
+        !paymentMintMeltPlan
+      ) {
+        return false;
+      }
+
+      setPendingPaymentMintMeltConfirmation({
+        fromMint: paymentMintMeltPlan.fromMint,
+        toMint: paymentMintMeltPlan.toMint,
+      });
+      return true;
+    },
+    [cashuBalance, paymentMintMeltPlan],
+  );
+
+  const cashuHasMultipleAcceptedMints = cashuAcceptedMintBalances.size > 1;
+
+  const cashuOwnTokens = React.useMemo(
+    () =>
+      cashuTokensWithMeta.filter(
+        (token) =>
+          !isCashuTokenEmittedState(token.state) &&
+          !isCashuTokenReservedState(token.state),
+      ),
+    [cashuTokensWithMeta],
+  );
+
+  const cashuIssuedTokens = React.useMemo(
+    () =>
+      cashuTokensWithMeta.filter(
+        (token) =>
+          isCashuTokenEmittedState(token.state) ||
+          isCashuTokenReservedState(token.state),
+      ),
+    [cashuTokensWithMeta],
+  );
+
+  const cashuOwnSpentTokens = React.useMemo(
+    () =>
+      cashuOwnTokens.filter((token) =>
+        isCashuTokenDefinitivelySpent({
+          state: token.state,
+          error: token.error,
+        }),
+      ),
+    [cashuOwnTokens],
+  );
+
+  const [deleteSpentCashuTokensIsBusy, setDeleteSpentCashuTokensIsBusy] =
+    useState(false);
+  const deleteSpentCashuTokens = React.useCallback(async () => {
+    if (deleteSpentCashuTokensIsBusy) return;
+    const targets = cashuOwnSpentTokens.filter((token) => Boolean(token.id));
+    if (targets.length === 0) return;
+
+    setDeleteSpentCashuTokensIsBusy(true);
+    try {
+      const fallbackOwnerId = await resolveOwnerIdForWrite();
+      let deleted = 0;
+      for (const token of targets) {
+        const payload = {
+          id: token.id as CashuTokenId,
+          isDeleted: Evolu.sqliteTrue,
+        };
+        // Delete in the row's own lane; Evolu keys rows by (ownerId, id) so a
+        // delete under the active lane silently misses rows in older lanes.
+        const ownerId =
+          resolveCashuRowStoredOwnerLane(token) ?? fallbackOwnerId;
+        const result = ownerId
+          ? update("cashuToken", payload, { ownerId })
+          : update("cashuToken", payload);
+        if (result.ok) deleted += 1;
+      }
+      if (deleted > 0) {
+        setStatus(
+          t("cashuDeleteSpentDone").replace("{count}", String(deleted)),
+        );
+      }
+    } finally {
+      setDeleteSpentCashuTokensIsBusy(false);
+    }
+  }, [
+    cashuOwnSpentTokens,
+    deleteSpentCashuTokensIsBusy,
+    resolveOwnerIdForWrite,
+    setStatus,
+    t,
+    update,
+  ]);
+
+  const canPayWithCashu = cashuBalance > 0;
+
+  React.useEffect(() => {
+    if (route.kind !== "topupInvoice") return;
+    if (topupInvoiceIsBusy) return;
+    if (!topupInvoice || !topupInvoiceQr) return;
+
+    const amountSat = Number.parseInt(topupAmount.trim(), 10);
+    if (!Number.isFinite(amountSat) || amountSat <= 0) return;
+
+    if (topupInvoiceStartBalanceRef.current === null) {
+      topupInvoiceStartBalanceRef.current = cashuTotalBalance;
+      return;
+    }
+
+    if (topupInvoicePaidHandledRef.current) return;
+
+    const start = topupInvoiceStartBalanceRef.current ?? 0;
+    const expected = start + amountSat;
+    if (cashuTotalBalance < expected) return;
+
+    finalizeTopupInvoicePaid({ amountSat });
+  }, [
+    cashuTotalBalance,
+    finalizeTopupInvoicePaid,
+    formatDisplayedAmountParts,
+    route.kind,
+    showPaidOverlay,
+    t,
+    topupAmount,
+    topupInvoice,
+    topupInvoiceIsBusy,
+    topupPaidNavTimerRef,
+    topupInvoiceQr,
+  ]);
+
+  const [postPaySaveContact, setPostPaySaveContact] = React.useState<null | {
+    lnAddress: string;
+    amountSat: number;
+  }>(null);
+
+  useTopupInvoiceQuoteEffects({
+    defaultMintUrl,
+    effectiveMyLightningAddress,
+    routeKind: route.kind,
+    t,
+    topupAmount,
+    topupInvoice,
+    topupInvoiceError,
+    topupInvoiceIsBusy,
+    topupInvoicePaidHandledRef,
+    topupInvoiceQr,
+    topupInvoiceStartBalanceRef,
+    topupMintQuote,
+    topupPaidNavTimerRef,
+    topupRefreshKey: myProfileName,
+    topupRecipientNprofile,
+    setTopupAmount,
+    setTopupInvoice,
+    setTopupInvoiceCashuRequest,
+    setTopupInvoiceError,
+    setTopupInvoiceIsBusy,
+    setTopupInvoiceQr,
+    setTopupInvoiceQrPayload,
+    setTopupMintQuote,
+  });
+
+  const defaultMintDisplay = useMemo(() => {
+    if (!defaultMintUrl) return null;
+    try {
+      const u = new URL(defaultMintUrl);
+      return u.host;
+    } catch {
+      return defaultMintUrl;
+    }
+  }, [defaultMintUrl]);
+
+  const currentMainMintAcceptedBalance = React.useMemo(() => {
+    const currentMainMint = normalizeMintUrl(defaultMintUrl ?? MAIN_MINT_URL);
+    if (!currentMainMint) return 0;
+
+    let sum = 0;
+    for (const row of cashuTokensWithMeta) {
+      if (!isCashuTokenAcceptedState(row.state)) continue;
+
+      const mint = normalizeMintUrl(String(row.mint ?? "").trim());
+      if (mint !== currentMainMint) continue;
+
+      const amount = Number(row.amount ?? 0);
+      if (Number.isFinite(amount) && amount > 0) {
+        sum += amount;
+      }
+    }
+
+    return sum;
+  }, [cashuTokensWithMeta, defaultMintUrl]);
+
+  const {
+    applyDefaultMintSelection: applyDefaultMintSelectionInner,
+    makeNip98AuthHeader,
+  } = useNpubCashMintSelection({
+    cashuAutoswapEnabled,
+    currentMainMintAcceptedBalance,
+    currentNpub,
+    currentNsec,
+    defaultMintUrl,
+    defaultMintUrlDraft,
+    hasMintOverrideRef,
+    makeLocalStorageKey,
+    npubCashServerBaseUrl,
+    ownedLightningAddresses: ownedProfileLightningAddresses,
+    profileClaimLightningAddressServerBaseUrl,
+    npubCashMintSyncRef,
+    pushToast,
+    requestMintAutoswapChangeConfirmation: React.useCallback(
+      (args: { fromMint: string; toMint: string }) => {
+        pendingMintAutoswapChangeResolverRef.current?.(false);
+        return new Promise<boolean>((resolve) => {
+          pendingMintAutoswapChangeResolverRef.current = resolve;
+          setPendingMintAutoswapChangeConfirmation(args);
+        });
+      },
+      [],
+    ),
+    setCashuAutoswapEnabled,
+    setDefaultMintUrl,
+    setDefaultMintUrlDraft,
+    setStatus,
+    t,
+  });
+
+  const applyDefaultMintSelection = React.useCallback(
+    async (mintUrl: string): Promise<void> => {
+      await applyDefaultMintSelectionInner(mintUrl);
+      // Mirror the user's explicit choice into Evolu's ownerMeta so other
+      // tabs/devices converge. Done here (not in a defaultMintUrl-watch
+      // effect) to avoid stale-closure ping-pong with the remote.
+      upsertDefaultMintToOwnerMetaRef.current(mintUrl);
+    },
+    [applyDefaultMintSelectionInner],
+  );
+
+  React.useEffect(() => {
+    if (!currentNpub || !currentNsec) {
+      setOwnedProfileLightningAddresses([]);
+      setOwnedProfileLightningAddressesLoading(false);
+      return;
+    }
+
+    setOwnedProfileLightningAddresses([]);
+    setOwnedProfileLightningAddressesLoading(true);
+
+    const controller = new AbortController();
+    let cancelled = false;
+
+    const loadOwnedLightningAddresses = async () => {
+      try {
+        const url = `${profileClaimLightningAddressServerBaseUrl}/api/v1/info`;
+        const auth = await makeNip98AuthHeader(url, "GET");
+        const response = await fetch(url, {
+          method: "GET",
+          headers: { Authorization: auth },
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          if (!cancelled) {
+            setOwnedProfileLightningAddresses([]);
+            setOwnedProfileLightningAddressesLoading(false);
+          }
+          return;
+        }
+
+        const json = await response.json();
+        if (cancelled) return;
+
+        const info = parseNpubCashProfileInfo(json);
+        setOwnedProfileLightningAddresses(info.ownedLightningAddresses);
+        setOwnedProfileLightningAddressesLoading(false);
+      } catch {
+        if (cancelled) return;
+        setOwnedProfileLightningAddresses([]);
+        setOwnedProfileLightningAddressesLoading(false);
+      }
+    };
+
+    void loadOwnedLightningAddresses();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [
+    currentNpub,
+    currentNsec,
+    makeNip98AuthHeader,
+    profileClaimLightningAddressServerBaseUrl,
+    setOwnedProfileLightningAddresses,
+    setOwnedProfileLightningAddressesLoading,
+  ]);
+
+  React.useEffect(() => {
+    const selectedMint = normalizeMintUrl(defaultMintUrl ?? MAIN_MINT_URL);
+    if (!cashuAutoswapEnabled) return;
+    if (!isTestMintUrl(selectedMint)) return;
+    setCashuAutoswapEnabled(false);
+  }, [cashuAutoswapEnabled, defaultMintUrl, setCashuAutoswapEnabled]);
+
+  const resolvePendingMintAutoswapChangeConfirmation = React.useCallback(
+    (confirmed: boolean) => {
+      const resolve = pendingMintAutoswapChangeResolverRef.current;
+      pendingMintAutoswapChangeResolverRef.current = null;
+      setPendingMintAutoswapChangeConfirmation(null);
+      resolve?.(confirmed);
+    },
+    [],
+  );
+
+  const closeMintAutoswapChangeConfirmation = React.useCallback(() => {
+    resolvePendingMintAutoswapChangeConfirmation(false);
+  }, [resolvePendingMintAutoswapChangeConfirmation]);
+
+  const confirmMintAutoswapChangeConfirmation = React.useCallback(() => {
+    resolvePendingMintAutoswapChangeConfirmation(true);
+  }, [resolvePendingMintAutoswapChangeConfirmation]);
+
+  React.useEffect(() => {
+    return () => {
+      pendingMintAutoswapChangeResolverRef.current?.(false);
+      pendingMintAutoswapChangeResolverRef.current = null;
+    };
+  }, []);
+
+  const { claimNpubCashOnce, claimNpubCashOnceLatestRef } = useNpubCashClaim({
+    cashuIsBusy,
+    cashuTokensAll,
+    currentNpub: nostrBootstrapReady ? currentNpub : null,
+    currentNsec: nostrBootstrapReady ? currentNsec : null,
+    enqueueCashuOp,
+    ensureCashuTokenPersisted,
+    formatDisplayedAmountParts,
+    upsert,
+    isMintDeleted,
+    logPaymentEvent,
+    makeLocalStorageKey,
+    makeNip98AuthHeader,
+    maybeShowPwaNotification,
+    mintInfoByUrl,
+    npubCashServerBaseUrl,
+    npubCashClaimInFlightRef,
+    refreshMintInfo,
+    resolveOwnerIdForWrite,
+    rememberCashuTokenKnown,
+    routeKind: route.kind,
+    setCashuIsBusy,
+    setStatus,
+    showPaidOverlay,
+    t,
+    touchMintInfo,
+  });
+
+  useProfileNpubCashEffects({
+    claimNpubCashOnce,
+    claimNpubCashOnceLatestRef,
+    currentNpub,
+    currentNsec,
+    hasMintOverrideRef,
+    makeNip98AuthHeader,
+    networkEnabled: nostrBootstrapReady,
+    npubCashServerBaseUrl,
+    npubCashInfoInFlightRef,
+    npubCashInfoLoadedAtMsRef,
+    npubCashInfoLoadedForNpubRef,
+    routeKind: route.kind,
+    setDefaultMintUrl,
+    setDefaultMintUrlDraft,
+    setIsProfileEditing,
+    setMyProfileQr,
+  });
+
+  const [contactPayMethod, setContactPayMethod] = useState<
+    null | "cashu" | "lightning"
+  >(null);
+  useContactPayMethod({
+    payWithCashuEnabled,
+    routeKind: route.kind,
+    selectedContactLnAddress: String(selectedContact?.lnAddress ?? ""),
+    selectedContactNpub: String(selectedContact?.npub ?? ""),
+    setContactPayMethod,
+  });
+
+  const buildCashuMintCandidates = React.useCallback(
+    (
+      mintGroups: Map<string, { tokens: string[]; sum: number }>,
+      preferredMint: string | null,
+    ) => {
+      return buildCashuMintCandidatesBase(
+        mintGroups,
+        normalizeMintUrl(preferredMint ?? ""),
+      );
+    },
+    [],
+  );
+
+  const payContactWithCashuMessage =
+    usePayContactWithCashuMessage<ContactRowLike>({
+      activePublishClientIdsRef: activeNostrMessagePublishClientIdsRef,
+      appendLocalNostrMessage,
+      buildCashuMintCandidates,
+      cashuBalance,
+      cashuTokensAll,
+      cashuTokensWithMeta,
+      chatSeenWrapIdsRef,
+      currentNpub,
+      currentNsec,
+      defaultMintUrl,
+      enqueuePendingPayment,
+      formatDisplayedAmountParts,
+      upsert,
+      logPayStep,
+      logPaymentEvent,
+      nostrMessagesLocal,
+      payWithCashuEnabled,
+      publishSingleWrappedWithRetry,
+      publishWrappedWithRetry,
+      pushToast,
+      resolveOwnerIdForWrite,
+      setContactsOnboardingHasPaid,
+      setStatus,
+      showPaidOverlay,
+      t,
+      update,
+      updateLocalNostrMessage,
+    });
+
+  const settleBankPaymentOffer = React.useCallback(
+    async (message: LocalNostrMessage) => {
+      if (cashuIsBusy) return;
+
+      const offerInfo = getLinkyBankPaymentOfferInfo(
+        String(message.content ?? ""),
+      );
+      if (!offerInfo || offerInfo.status !== "bank_paid") {
+        setStatus(t("spdPaymentOfferFailed"));
+        return;
+      }
+      if (isBankPaymentOfferCanceled(offerInfo.offerId)) {
+        setStatus(t("bankPaymentOfferStatusCanceled"));
+        return;
+      }
+      if (!offerInfo.amountSat) {
+        setStatus(t("payInvalidAmount"));
+        return;
+      }
+
+      const contactId = String(message.contactId ?? "").trim();
+      const contact =
+        contacts.find(
+          (candidate) => String(candidate.id ?? "").trim() === contactId,
+        ) ?? null;
+      if (!contact) {
+        setStatus(t("contactNotFound"));
+        return;
+      }
+
+      setCashuIsBusy(true);
+      try {
+        const result = await payContactWithCashuMessage({
+          contact,
+          amountSat: offerInfo.amountSat,
+          logCompletedOnly: true,
+          paymentNoticeContext: LINKY_PAYMENT_NOTICE_CONTEXT_BANK_PAYMENT_OFFER,
+          paymentNoticeOfferId: offerInfo.offerId,
+        });
+        if (!result.ok) return;
+
+        await respondToBankPaymentOfferWithGroupState(message, "settled");
+      } finally {
+        setCashuIsBusy(false);
+      }
+    },
+    [
+      cashuIsBusy,
+      contacts,
+      isBankPaymentOfferCanceled,
+      payContactWithCashuMessage,
+      respondToBankPaymentOfferWithGroupState,
+      setCashuIsBusy,
+      setStatus,
+      t,
+    ],
+  );
+
+  usePaymentsDomain({
+    cashuIsBusy,
+    contacts,
+    currentNpub,
+    currentNsec,
+    payContactWithCashuMessage,
+    pendingPayments,
+    pushToast,
+    removePendingPayment,
+    setCashuIsBusy,
+    t,
+  });
+
+  const paySelectedContact = React.useCallback(async () => {
+    if (cashuIsBusy) return;
+    if (route.kind !== "contactPay") return;
+    if (!selectedContact) return;
+
+    const amountSat = Number.parseInt(String(payAmount ?? "").trim(), 10);
+    if (!Number.isFinite(amountSat) || amountSat <= 0) {
+      setStatus(t("payInvalidAmount"));
+      return;
+    }
+
+    if (amountSat > cashuBalance) {
+      if (!requestPaymentMintMelt(amountSat)) {
+        setStatus(t("payInsufficient"));
+      }
+      return;
+    }
+
+    const normalizedMethod =
+      contactPayMethod === "lightning" || contactPayMethod === "cashu"
+        ? contactPayMethod
+        : "cashu";
+
+    if (normalizedMethod === "lightning") {
+      const lnAddress = String(selectedContact.lnAddress ?? "").trim();
+      if (!lnAddress) {
+        setStatus(t("payMissingLn"));
+        return;
+      }
+      setLnAddressPayAmount(String(amountSat));
+      navigateTo({ route: "lnAddressPay", lnAddress });
+      return;
+    }
+
+    setCashuIsBusy(true);
+    try {
+      await payContactWithCashuMessage({
+        contact: selectedContact,
+        amountSat,
+      });
+    } finally {
+      setCashuIsBusy(false);
+    }
+  }, [
+    cashuIsBusy,
+    cashuBalance,
+    contactPayMethod,
+    payAmount,
+    payContactWithCashuMessage,
+    requestPaymentMintMelt,
+    route.kind,
+    selectedContact,
+    setCashuIsBusy,
+    setLnAddressPayAmount,
+    setStatus,
+    t,
+  ]);
+
+  const findContactForCashuPaymentRequest = React.useCallback(
+    (requestInfo: CashuPaymentRequestMessageInfo) => {
+      const requestPubkeyHex = normalizePubkeyHex(
+        requestInfo.transportPubkeyHex,
+      );
+      if (!requestPubkeyHex) return null;
+
+      for (const contact of contacts) {
+        const normalizedNpub = normalizeNpubIdentifier(contact.npub);
+        if (!normalizedNpub) continue;
+
+        try {
+          const decoded = nip19.decode(normalizedNpub);
+          if (decoded.type !== "npub") continue;
+          if (typeof decoded.data !== "string") continue;
+          if (decoded.data === requestPubkeyHex) return contact;
+        } catch {
+          // ignore malformed contact npubs
+        }
+      }
+
+      return null;
+    },
+    [contacts],
+  );
+
+  const ensureContactForCashuPaymentRequest = React.useCallback(
+    (requestInfo: CashuPaymentRequestMessageInfo): ContactRowLike | null => {
+      const existing = findContactForCashuPaymentRequest(requestInfo);
+      if (existing?.id) return existing;
+
+      const requestPubkeyHex = normalizePubkeyHex(
+        requestInfo.transportPubkeyHex,
+      );
+      if (!requestPubkeyHex) return null;
+
+      let npub: string | null = null;
+      try {
+        npub = nip19.npubEncode(requestPubkeyHex);
+      } catch {
+        return null;
+      }
+
+      const normalizedNpub = normalizeNpubIdentifier(npub);
+      if (!normalizedNpub) return null;
+
+      const duplicate = contacts.find(
+        (contact) => normalizeNpubIdentifier(contact.npub) === normalizedNpub,
+      );
+      if (duplicate?.id) return duplicate;
+
+      if (activeContactsOwnerContactCount >= MAX_CONTACTS_PER_OWNER) {
+        setStatus(
+          t("contactsLimitReached").replace(
+            "{max}",
+            String(MAX_CONTACTS_PER_OWNER),
+          ),
+        );
+        return null;
+      }
+
+      const defaultProfile = deriveDefaultProfile(normalizedNpub, lang);
+      const contactName = buildSavedContactName(
+        unknownNameByNpub[normalizedNpub] ?? defaultProfile.name,
+        normalizedNpub,
+      );
+      const payload = {
+        name: contactName as typeof Evolu.NonEmptyString1000.Type,
+        npub: normalizedNpub as typeof Evolu.NonEmptyString1000.Type,
+        lnAddress: null,
+        groupName: null,
+      };
+
+      const result = contactsOwnerId
+        ? (() => {
+            const scoped = insert("contact", payload, {
+              ownerId: contactsOwnerId,
+            });
+            if (scoped.ok) return scoped;
+            return insert("contact", payload);
+          })()
+        : insert("contact", payload);
+
+      if (!result.ok) {
+        setStatus(`${t("errorPrefix")}: ${String(result.error ?? "")}`);
+        return null;
+      }
+
+      recordContactsOwnerWrite();
+      openScannedContactPendingNpubRef.current = normalizedNpub;
+
+      return {
+        id: result.value.id,
+        name: contactName,
+        npub: normalizedNpub,
+        lnAddress: null,
+        groupName: null,
+        ownerId: contactsOwnerId,
+      };
+    },
+    [
+      activeContactsOwnerContactCount,
+      buildSavedContactName,
+      contacts,
+      contactsOwnerId,
+      findContactForCashuPaymentRequest,
+      insert,
+      lang,
+      openScannedContactPendingNpubRef,
+      recordContactsOwnerWrite,
+      setStatus,
+      t,
+      unknownNameByNpub,
+    ],
+  );
+
+  const findPreviousCashuPaymentRequestMessage = React.useCallback(
+    (
+      requestInfo: CashuPaymentRequestMessageInfo,
+      contactId: string,
+    ): LocalNostrMessage | null => {
+      const normalizedContactId = String(contactId ?? "").trim();
+      if (!normalizedContactId) return null;
+
+      const requestId = String(requestInfo.requestId ?? "").trim();
+      const encodedRequest = String(requestInfo.encodedRequest ?? "").trim();
+      if (!requestId && !encodedRequest) return null;
+
+      const candidates = [
+        ...chatMessages,
+        ...nostrMessagesRecent,
+        ...nostrMessagesLocal,
+      ];
+
+      for (let index = candidates.length - 1; index >= 0; index -= 1) {
+        const message = candidates[index];
+        if (String(message.contactId ?? "").trim() !== normalizedContactId) {
+          continue;
+        }
+        if (String(message.direction ?? "").trim() !== "in") continue;
+
+        const rumorId = String(message.rumorId ?? "").trim();
+        if (!rumorId) continue;
+
+        const previousInfo = parseCashuPaymentRequestMessage(
+          String(message.content ?? ""),
+        );
+        if (!previousInfo) continue;
+
+        const previousRequestId = String(previousInfo.requestId ?? "").trim();
+        if (requestId && previousRequestId === requestId) return message;
+
+        if (
+          !requestId &&
+          String(previousInfo.encodedRequest ?? "").trim() === encodedRequest
+        ) {
+          return message;
+        }
+      }
+
+      return null;
+    },
+    [chatMessages, nostrMessagesLocal, nostrMessagesRecent],
+  );
+
+  const payCashuPaymentRequestViaPost = React.useCallback(
+    async (requestInfo: CashuPaymentRequestMessageInfo): Promise<boolean> => {
+      const postUrlRaw = String(requestInfo.transportPostUrl ?? "").trim();
+      if (!postUrlRaw) return false;
+
+      let postUrl: URL;
+      try {
+        postUrl = new URL(postUrlRaw);
+      } catch {
+        setStatus(t("paymentRequestUnknownContact"));
+        return false;
+      }
+
+      if (postUrl.protocol !== "https:" && postUrl.protocol !== "http:") {
+        setStatus(t("paymentRequestUnknownContact"));
+        return false;
+      }
+
+      if (cashuBalance < requestInfo.amount) {
+        setStatus(t("payInsufficient"));
+        return true;
+      }
+
+      setCashuIsBusy(true);
+
+      const cashuWriteOwnerId = await resolveOwnerIdForWrite();
+      const insertCashuToken = (args: {
+        amount: number | null;
+        mint: string | null;
+        state: "accepted" | "pending";
+        token: string;
+        unit: string | null;
+      }) => {
+        const payload: {
+          id: CashuTokenId;
+          token: typeof Evolu.NonEmptyString.Type;
+          state: typeof Evolu.NonEmptyString100.Type;
+        } = {
+          id: createCashuTokenId(args.token),
+          token: args.token as typeof Evolu.NonEmptyString.Type,
+          state: args.state as typeof Evolu.NonEmptyString100.Type,
+        };
+
+        return cashuWriteOwnerId
+          ? upsert("cashuToken", payload, { ownerId: cashuWriteOwnerId })
+          : upsert("cashuToken", payload);
+      };
+
+      const updateCashuToken = (
+        payload: {
+          id: CashuTokenId;
+          isDeleted: typeof Evolu.sqliteTrue;
+        },
+        targetOwnerId?: Evolu.OwnerId | null,
+      ) => {
+        const ownerId = targetOwnerId ?? cashuWriteOwnerId;
+        return ownerId
+          ? update("cashuToken", payload, { ownerId })
+          : update("cashuToken", payload);
+      };
+
+      let sentAmountSat = 0;
+      let usedMint: string | null = null;
+      let usedInputTokens: string[] = [];
+      let sendToken: string | null = null;
+      let sendTokenAmount = 0;
+      let sendProofs: Proof[] = [];
+      let sendTokenUnit: string | null = null;
+      let gainedToken: string | null = null;
+      let lastError: unknown = null;
+
+      try {
+        const requestedMints = new Set<string>();
+        for (const mintUrl of requestInfo.mintUrls) {
+          const normalizedMint = normalizeMintUrl(mintUrl);
+          if (normalizedMint) requestedMints.add(normalizedMint);
+        }
+
+        const mintGroups = new Map<string, { tokens: string[]; sum: number }>();
+        for (const row of cashuTokensWithMeta) {
+          if (!isCashuTokenAcceptedState(row.state)) continue;
+          const mint = normalizeMintUrl(String(row.mint ?? "").trim());
+          if (!mint) continue;
+          if (requestedMints.size > 0 && !requestedMints.has(mint)) continue;
+
+          const tokenText = String(row.token ?? row.rawToken ?? "").trim();
+          if (!tokenText) continue;
+
+          const amount = Number(row.amount ?? 0) || 0;
+          const entry = mintGroups.get(mint) ?? { tokens: [], sum: 0 };
+          entry.tokens.push(tokenText);
+          entry.sum += amount;
+          mintGroups.set(mint, entry);
+        }
+
+        const preferredMint =
+          requestInfo.mintUrls
+            .map((mintUrl) => normalizeMintUrl(mintUrl))
+            .find((mintUrl) => Boolean(mintUrl)) ??
+          normalizeMintUrl(defaultMintUrl ?? "");
+        const candidates = buildCashuMintCandidates(mintGroups, preferredMint);
+        const candidate = selectSingleMintCandidateForAmount(
+          candidates,
+          requestInfo.amount,
+        );
+        if (!candidate) {
+          setStatus(t("payInsufficient"));
+          return true;
+        }
+
+        usedInputTokens = [...candidate.tokens];
+        const maxReservedFeeSat = getPaymentAmountReserveCap(
+          requestInfo.amount,
+          candidate.sum,
+        );
+        const attempts = buildPaymentAmountAttempts(
+          requestInfo.amount,
+          candidate.sum,
+        ).filter((attemptAmountSat) => {
+          return requestInfo.amount - attemptAmountSat <= maxReservedFeeSat;
+        });
+
+        for (let index = 0; index < attempts.length; index += 1) {
+          const attemptAmountSat = attempts[index];
+          const hasLowerAmountFallback = index < attempts.length - 1;
+
+          try {
+            const split = await createSendTokenWithTokensAtMint({
+              amount: attemptAmountSat,
+              mint: candidate.mint,
+              tokens: candidate.tokens,
+              unit: "sat",
+            });
+
+            if (!split.ok) {
+              lastError = split.error;
+              if (
+                hasLowerAmountFallback &&
+                isRetryablePaymentAmountFailure(String(split.error ?? ""))
+              ) {
+                continue;
+              }
+              break;
+            }
+
+            const spentRows = cashuTokensWithMeta.filter((row) => {
+              if (!isCashuTokenAcceptedState(row.state)) return false;
+              const tokenText = String(row.token ?? row.rawToken ?? "").trim();
+              return candidate.tokens.includes(tokenText);
+            });
+            for (const row of spentRows) {
+              const rowId = row.id;
+              if (!rowId) continue;
+              const deleted = updateCashuToken(
+                { id: rowId as CashuTokenId, isDeleted: Evolu.sqliteTrue },
+                resolveCashuRowStoredOwnerLane(row),
+              );
+              if (!deleted.ok) throw deleted.error;
+            }
+
+            if (split.remainingToken && split.remainingAmount > 0) {
+              gainedToken = split.remainingToken;
+              const inserted = insertCashuToken({
+                token: split.remainingToken,
+                mint: split.mint,
+                unit: split.unit ?? null,
+                amount: split.remainingAmount,
+                state: "accepted",
+              });
+              if (!inserted.ok) throw inserted.error;
+            }
+
+            sendToken = split.sendToken;
+            sendTokenAmount = split.sendAmount;
+            sendProofs = split.sendProofs;
+            sendTokenUnit = split.unit ?? null;
+            sentAmountSat = split.sendAmount;
+            usedMint = split.mint;
+            break;
+          } catch (error) {
+            lastError = error;
+            if (
+              hasLowerAmountFallback &&
+              isRetryablePaymentAmountFailure(
+                getUnknownErrorMessage(error, "unknown"),
+              )
+            ) {
+              continue;
+            }
+            break;
+          }
+        }
+
+        if (!sendToken) {
+          const errorMessage = getUnknownErrorMessage(
+            lastError,
+            "insufficient funds",
+          );
+          logPaymentEvent({
+            direction: "out",
+            status: "error",
+            amount: requestInfo.amount,
+            fee: null,
+            mint: usedMint,
+            unit: "sat",
+            error: errorMessage,
+            contactId: null,
+            method: "cashu_chat",
+            phase: "swap",
+          });
+          setStatus(`${t("payFailed")}: ${errorMessage}`);
+          return true;
+        }
+
+        const proofs = sendProofs.flatMap((proof) => {
+          const normalized = normalizeCashuProofPayload(proof);
+          return normalized ? [normalized] : [];
+        });
+        if (proofs.length === 0) throw new Error("empty payment proofs");
+
+        const body: Record<string, unknown> = {
+          mint: usedMint,
+          unit: sendTokenUnit ?? "sat",
+          proofs,
+        };
+        if (requestInfo.requestId) body.id = requestInfo.requestId;
+        if (requestInfo.description) body.memo = requestInfo.description;
+
+        const response = await fetch(postUrl.toString(), {
+          method: "POST",
+          cache: "no-store",
+          credentials: "omit",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          mode: "cors",
+          body: JSON.stringify(body),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Payment request POST ${response.status}`);
+        }
+
+        logPaymentEvent({
+          direction: "out",
+          status: "ok",
+          amount: sentAmountSat,
+          details: {
+            ...(gainedToken ? { gainedToken } : {}),
+            ...(requestInfo.requestId
+              ? { requestId: requestInfo.requestId }
+              : {}),
+            postUrl: postUrl.toString(),
+            usedInputTokens,
+          },
+          fee: null,
+          mint: usedMint,
+          unit: sendTokenUnit ?? "sat",
+          error: null,
+          contactId: null,
+          method: "cashu_chat",
+          phase: "complete",
+        });
+
+        const displayAmount = formatDisplayedAmountParts(sentAmountSat);
+        showPaidOverlay(
+          t("paidSentTo")
+            .replace(
+              "{amount}",
+              `${displayAmount.approxPrefix}${displayAmount.amountText}`,
+            )
+            .replace("{unit}", displayAmount.unitLabel)
+            .replace(
+              "{name}",
+              requestInfo.description || postUrl.hostname || t("appTitle"),
+            ),
+        );
+        safeLocalStorageSet(CONTACTS_ONBOARDING_HAS_PAID_STORAGE_KEY, "1");
+        setContactsOnboardingHasPaid(true);
+        return true;
+      } catch (error) {
+        if (sendToken) {
+          const inserted = insertCashuToken({
+            token: sendToken,
+            mint: usedMint,
+            unit: sendTokenUnit,
+            amount: sendTokenAmount,
+            state: "accepted",
+          });
+          if (!inserted.ok) {
+            console.warn("[linky][payment-request] recovery insert failed", {
+              error: String(inserted.error ?? ""),
+            });
+          }
+        }
+
+        const errorMessage = getUnknownErrorMessage(error, "unknown");
+        logPaymentEvent({
+          direction: "out",
+          status: "error",
+          amount: requestInfo.amount,
+          fee: null,
+          mint: usedMint,
+          unit: sendTokenUnit ?? "sat",
+          error: errorMessage,
+          contactId: null,
+          method: "cashu_chat",
+          phase: "publish",
+        });
+        setStatus(`${t("payFailed")}: ${errorMessage}`);
+        return true;
+      } finally {
+        setCashuIsBusy(false);
+      }
+    },
+    [
+      buildCashuMintCandidates,
+      cashuBalance,
+      cashuTokensWithMeta,
+      defaultMintUrl,
+      formatDisplayedAmountParts,
+      logPaymentEvent,
+      resolveOwnerIdForWrite,
+      setCashuIsBusy,
+      setContactsOnboardingHasPaid,
+      setStatus,
+      showPaidOverlay,
+      t,
+      update,
+      upsert,
+    ],
+  );
+
+  const payCashuPaymentRequest = React.useCallback(
+    async (requestInfo: CashuPaymentRequestMessageInfo) => {
+      if (cashuIsBusy) return;
+      if (requestInfo.amount > cashuBalance) {
+        const requestedMints = requestInfo.mintUrls.flatMap((mintUrl) => {
+          const normalizedMint = normalizeMintUrl(mintUrl);
+          return normalizedMint ? [normalizedMint] : [];
+        });
+        const targetMainMint = paymentMintMeltPlan?.toMint ?? "";
+        const mainMintIsAccepted =
+          requestedMints.length === 0 ||
+          (Boolean(targetMainMint) && requestedMints.includes(targetMainMint));
+        if (
+          !mainMintIsAccepted ||
+          !requestPaymentMintMelt(requestInfo.amount)
+        ) {
+          setStatus(t("payInsufficient"));
+        }
+        return;
+      }
+
+      const contact = ensureContactForCashuPaymentRequest(requestInfo);
+      if (!contact?.id) {
+        if (await payCashuPaymentRequestViaPost(requestInfo)) return;
+        setStatus(t("paymentRequestUnknownContact"));
+        return;
+      }
+
+      setCashuIsBusy(true);
+      try {
+        const previousRequestMessage = findPreviousCashuPaymentRequestMessage(
+          requestInfo,
+          String(contact.id ?? ""),
+        );
+        const previousRequestRumorId = String(
+          previousRequestMessage?.rumorId ?? "",
+        ).trim();
+
+        await payContactWithCashuMessage({
+          contact,
+          amountSat: requestInfo.amount,
+          paymentRequestId: requestInfo.requestId,
+          ...(previousRequestRumorId
+            ? {
+                replyContext: {
+                  replyToId: previousRequestRumorId,
+                  rootMessageId:
+                    String(
+                      previousRequestMessage?.rootMessageId ?? "",
+                    ).trim() || previousRequestRumorId,
+                  replyToContent:
+                    String(previousRequestMessage?.content ?? "").trim() ||
+                    null,
+                },
+              }
+            : {}),
+        });
+      } finally {
+        setCashuIsBusy(false);
+      }
+    },
+    [
+      cashuIsBusy,
+      cashuBalance,
+      ensureContactForCashuPaymentRequest,
+      findPreviousCashuPaymentRequestMessage,
+      payCashuPaymentRequestViaPost,
+      payContactWithCashuMessage,
+      paymentMintMeltPlan?.toMint,
+      requestPaymentMintMelt,
+      setCashuIsBusy,
+      setStatus,
+      t,
+    ],
+  );
+
+  const {
+    payLightningAddressWithCashu: payLightningAddressWithCashuBase,
+    payLightningInvoiceWithCashu: payLightningInvoiceWithCashuBase,
+  } = useLightningPaymentsDomain({
+    buildCashuMintCandidates,
+    canPayWithCashu,
+    cashuBalance,
+    cashuIsBusy,
+    cashuOwnerId,
+    cashuTokensAll,
+    cashuTokensWithMeta,
+    cashuVisibleOwnerIds,
+    contacts,
+    defaultMintUrl,
+    formatDisplayedAmountParts,
+    upsert,
+    logPaymentEvent,
+    normalizeMintUrl,
+    setCashuIsBusy,
+    setContactsOnboardingHasPaid,
+    setPostPaySaveContact,
+    setStatus,
+    showPaidOverlay,
+    t,
+    update,
+  });
+
+  const payLightningAddressWithCashu = React.useCallback(
+    async (lnAddress: string, amountSat: number): Promise<void> => {
+      if (amountSat > cashuBalance) {
+        if (!requestPaymentMintMelt(amountSat)) {
+          setStatus(t("payInsufficient"));
+        }
+        return;
+      }
+      const paid = await payLightningAddressWithCashuBase(lnAddress, amountSat);
+      if (paid) navigateTo({ route: "wallet" });
+    },
+    [
+      cashuBalance,
+      payLightningAddressWithCashuBase,
+      requestPaymentMintMelt,
+      setStatus,
+      t,
+    ],
+  );
+
+  const payLightningInvoiceWithCashu = React.useCallback(
+    async (invoice: string): Promise<boolean> => {
+      const amountSat = getLightningInvoicePreview(invoice)?.amountSat ?? null;
+      if (amountSat !== null && amountSat > cashuBalance) {
+        if (!requestPaymentMintMelt(amountSat)) {
+          setStatus(t("payInsufficient"));
+        }
+        return false;
+      }
+      const paid = await payLightningInvoiceWithCashuBase(invoice);
+      if (paid && route.kind === "manualPay") {
+        navigateTo({ route: "wallet" });
+      }
+      return paid;
+    },
+    [
+      cashuBalance,
+      payLightningInvoiceWithCashuBase,
+      requestPaymentMintMelt,
+      route.kind,
+      setStatus,
+      t,
+    ],
+  );
+
+  const closeLightningInvoiceConfirmation = React.useCallback(() => {
+    setPendingLightningInvoiceConfirmation(null);
+  }, []);
+
+  const confirmLightningInvoicePayment = React.useCallback(async () => {
+    const pending = pendingLightningInvoiceConfirmation;
+    if (!pending) return;
+
+    const ok = await payLightningInvoiceWithCashu(pending.invoice);
+    if (ok) setPendingLightningInvoiceConfirmation(null);
+  }, [payLightningInvoiceWithCashu, pendingLightningInvoiceConfirmation]);
+
+  const closeLnurlWithdrawConfirmation = React.useCallback(() => {
+    if (lnurlWithdrawIsBusy) return;
+    setPendingLnurlWithdrawConfirmation(null);
+  }, [lnurlWithdrawIsBusy]);
+
+  const confirmLnurlWithdraw = React.useCallback(async () => {
+    const pending = pendingLnurlWithdrawConfirmation;
+    if (!pending || lnurlWithdrawIsBusy) return;
+
+    const mintUrl = normalizeMintUrl(defaultMintUrl ?? MAIN_MINT_URL);
+    if (!mintUrl) {
+      setStatus(t("topupInvoiceFailed"));
+      return;
+    }
+
+    setLnurlWithdrawIsBusy(true);
+    try {
+      setStatus(t("lnurlWithdrawPreparing"));
+      const { invoice, quoteId } = await requestMintQuoteBolt11({
+        amountSat: pending.amountSat,
+        mintUrl,
+      });
+      await redeemLnurlWithdraw({
+        callback: pending.callback,
+        invoice,
+        k1: pending.k1,
+      });
+      setTopupMintQuote({
+        amount: pending.amountSat,
+        invoice,
+        mintUrl,
+        quote: quoteId,
+        unit: "sat",
+      });
+      setPendingLnurlWithdrawConfirmation(null);
+      setStatus(t("lnurlWithdrawPending"));
+    } catch (error) {
+      const message = getUnknownErrorMessage(error, t("lnurlWithdrawFailed"));
+      setStatus(`${t("errorPrefix")}: ${message}`);
+    } finally {
+      setLnurlWithdrawIsBusy(false);
+    }
+  }, [
+    defaultMintUrl,
+    lnurlWithdrawIsBusy,
+    pendingLnurlWithdrawConfirmation,
+    setStatus,
+    t,
+  ]);
+
+  const [walletWarningDismissed, setWalletWarningDismissed] = React.useState(
+    () => safeLocalStorageGet(WALLET_WARNING_DISMISSED_STORAGE_KEY) === "1",
+  );
+
+  const walletWarningApplies =
+    cashuBalance > WALLET_WARNING_BALANCE_THRESHOLD_SAT;
+
+  const dismissWalletWarning = React.useCallback(() => {
+    safeLocalStorageSet(WALLET_WARNING_DISMISSED_STORAGE_KEY, "1");
+    setWalletWarningDismissed(true);
+  }, []);
+
+  const saveCashuFromText = useSaveCashuFromText({
+    enqueueCashuOp,
+    ensureCashuTokenPersisted,
+    formatDisplayedAmountParts,
+    upsert,
+    isCashuTokenStored,
+    isMintDeleted,
+    logPaymentEvent,
+    mintInfoByUrl,
+    refreshMintInfo,
+    resolveOwnerIdForWrite,
+    rememberCashuTokenKnown,
+    setCashuDraft,
+    setCashuIsBusy,
+    setStatus,
+    showPaidOverlay,
+    t,
+    touchMintInfo,
+  });
+
+  const {
+    checkAllCashuTokensAndDeleteInvalid,
+    checkAndRefreshCashuToken,
+    checkIssuedCashuTokensAndDeleteClaimed,
+    checkSingleIssuedCashuTokenIsClaimed,
+    requestDeleteCashuToken,
+  } = useCashuTokenChecks({
+    appOwnerId: cashuOwnerId,
+    cashuBulkCheckIsBusy,
+    cashuIsBusy,
+    cashuTokensAll: cashuTokensAllFiltered,
+    pendingCashuDeleteId,
+    pushToast,
+    setCashuBulkCheckIsBusy,
+    setCashuIsBusy,
+    setPendingCashuDeleteId,
+    setStatus,
+    t,
+    update,
+  });
+
+  // Background check for issued-token claims (issue #86). Runs once on
+  // mount and every 60s thereafter while we have any issued tokens —
+  // wallet.checkProofsStates is the passive NUT-07 query that doesn't
+  // consume proofs. The helper itself skips when cashuIsBusy /
+  // bulkCheckIsBusy is true, so concurrent send/melt operations aren't
+  // disturbed. Detection deletes the row, so the issued list cleans up
+  // even when the user isn't sitting on #wallet/tokens.
+  //
+  // The helper's callback identity changes every time cashuTokensAll
+  // updates (Evolu emits frequently). Stashing it in a ref keeps the
+  // 60s interval from being torn down + restarted on every churn — the
+  // earlier inline-deps version was firing the check roughly every
+  // second under load.
+  const hasAnyIssuedTokensForBackgroundCheck = cashuIssuedTokens.length > 0;
+  const checkIssuedCashuTokensRef = React.useRef(
+    checkIssuedCashuTokensAndDeleteClaimed,
+  );
+  React.useEffect(() => {
+    checkIssuedCashuTokensRef.current = checkIssuedCashuTokensAndDeleteClaimed;
+  }, [checkIssuedCashuTokensAndDeleteClaimed]);
+  const formatDisplayedAmountTextRef = React.useRef(formatDisplayedAmountText);
+  React.useEffect(() => {
+    formatDisplayedAmountTextRef.current = formatDisplayedAmountText;
+  }, [formatDisplayedAmountText]);
+  const pushToastRef = React.useRef(pushToast);
+  React.useEffect(() => {
+    pushToastRef.current = pushToast;
+  }, [pushToast]);
+  const claimToastTRef = React.useRef(t);
+  React.useEffect(() => {
+    claimToastTRef.current = t;
+  }, [t]);
+  React.useEffect(() => {
+    if (!hasAnyIssuedTokensForBackgroundCheck) return;
+    let cancelled = false;
+    const tick = async () => {
+      if (cancelled) return;
+      try {
+        const outcome = await checkIssuedCashuTokensRef.current();
+        if (cancelled) return;
+        if (outcome.claimed.length === 0) return;
+        // Background detection — surface a toast so the user knows the
+        // issued token was redeemed even when they aren't on the QR
+        // screen (the CashuTokenPage poll handles the in-page UX with a
+        // checkmark overlay).
+        const formatter = formatDisplayedAmountTextRef.current;
+        const tt = claimToastTRef.current;
+        for (const entry of outcome.claimed) {
+          const message =
+            entry.amount > 0
+              ? tt("cashuTokenClaimedWithAmount").replace(
+                  "{amount}",
+                  formatter(entry.amount),
+                )
+              : tt("cashuTokenClaimed");
+          pushToastRef.current(message);
+        }
+      } catch {
+        // ignore — the helper already swallows mint-side errors.
+      }
+    };
+    void tick();
+    const intervalId = window.setInterval(() => {
+      void tick();
+    }, 60_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [hasAnyIssuedTokensForBackgroundCheck]);
+
+  const returnCashuTokenToWallet = React.useCallback(
+    async (id: CashuTokenId) => {
+      const ownerId = await resolveOwnerIdForWrite();
+      const payload = {
+        id,
+        state: "accepted" as typeof Evolu.NonEmptyString100.Type,
+        error: null,
+      };
+      const result = ownerId
+        ? update("cashuToken", payload, { ownerId })
+        : update("cashuToken", payload);
+
+      if (!result.ok) {
+        setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
+        return;
+      }
+
+      setStatus(t("cashuReturnedToWallet"));
+    },
+    [resolveOwnerIdForWrite, setStatus, t, update],
+  );
+
+  const pendingCashuContactSend = React.useMemo(() => {
+    if (!pendingCashuTokenContactPickId) return null;
+
+    const row = cashuTokensAllFiltered.find(
+      (candidate) =>
+        candidate.id === pendingCashuTokenContactPickId &&
+        !candidate.isDeleted &&
+        isCashuTokenIssuedState(candidate.state),
+    );
+    if (!row) return null;
+
+    const meta = extractCashuTokenMeta(row);
+    const amountSat = Number(meta.amount ?? row.amount ?? 0);
+    if (!Number.isFinite(amountSat) || amountSat <= 0) return null;
+
+    return {
+      amountSat: Math.floor(amountSat),
+      tokenId: pendingCashuTokenContactPickId,
+    };
+  }, [cashuTokensAllFiltered, pendingCashuTokenContactPickId]);
+
+  const cancelPendingCashuContactSend = React.useCallback(async () => {
+    const tokenId = pendingCashuContactSend?.tokenId ?? null;
+    setPendingCashuTokenContactPickId(null);
+    if (!tokenId) return;
+
+    await returnCashuTokenToWallet(tokenId);
+  }, [pendingCashuContactSend, returnCashuTokenToWallet]);
+
+  const reserveCashuToken = React.useCallback(
+    async (id: CashuTokenId) => {
+      const ownerId = await resolveOwnerIdForWrite();
+      const payload = {
+        id,
+        state:
+          CASHU_TOKEN_STATE_RESERVED as typeof Evolu.NonEmptyString100.Type,
+        error: null,
+      };
+      const result = ownerId
+        ? update("cashuToken", payload, { ownerId })
+        : update("cashuToken", payload);
+
+      if (!result.ok) {
+        setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
+        return;
+      }
+
+      setStatus(t("cashuReserved"));
+    },
+    [resolveOwnerIdForWrite, setStatus, t, update],
+  );
+
+  const markCashuTokenIssued = React.useCallback(
+    async (id: CashuTokenId): Promise<boolean> => {
+      const ownerId = await resolveOwnerIdForWrite();
+      const payload = {
+        id,
+        state: "issued" as typeof Evolu.NonEmptyString100.Type,
+        error: null,
+      };
+      const result = ownerId
+        ? update("cashuToken", payload, { ownerId })
+        : update("cashuToken", payload);
+
+      if (!result.ok) {
+        setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
+        return false;
+      }
+
+      return true;
+    },
+    [resolveOwnerIdForWrite, setStatus, t, update],
+  );
+
+  const deleteCashuToken = React.useCallback(
+    async (id: CashuTokenId): Promise<boolean> => {
+      const matchingAliases = new Set<string>();
+
+      for (const row of cashuTokensAll) {
+        if (row.isDeleted || row.id !== id) continue;
+        for (const alias of readCashuRowAliases(row)) {
+          matchingAliases.add(alias);
+        }
+      }
+
+      let aliasesExpanded = true;
+      while (aliasesExpanded) {
+        aliasesExpanded = false;
+
+        for (const row of cashuTokensAll) {
+          if (row.isDeleted) continue;
+          const rowAliases = readCashuRowAliases(row);
+          if (
+            rowAliases.length === 0 ||
+            !rowAliases.some((alias) => matchingAliases.has(alias))
+          ) {
+            continue;
+          }
+
+          for (const alias of rowAliases) {
+            if (matchingAliases.has(alias)) continue;
+            matchingAliases.add(alias);
+            aliasesExpanded = true;
+          }
+        }
+      }
+
+      const rowsToDelete =
+        matchingAliases.size > 0
+          ? cashuTokensAll.filter((row) => {
+              if (row.isDeleted) return false;
+              return readCashuRowAliases(row).some((alias) =>
+                matchingAliases.has(alias),
+              );
+            })
+          : [];
+
+      if (rowsToDelete.length > 0) {
+        for (const row of rowsToDelete) {
+          const rowOwnerId = readCashuRowOwnerId(row);
+          const payload = {
+            id: row.id,
+            isDeleted: Evolu.sqliteTrue,
+          };
+          const result = rowOwnerId
+            ? update("cashuToken", payload, { ownerId: row.ownerId })
+            : update("cashuToken", payload);
+
+          if (!result.ok) {
+            setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
+            return false;
+          }
+        }
+
+        return true;
+      }
+
+      const ownerId = await resolveOwnerIdForWrite();
+      const payload = {
+        id,
+        isDeleted: Evolu.sqliteTrue,
+      };
+      const result = ownerId
+        ? update("cashuToken", payload, { ownerId })
+        : update("cashuToken", payload);
+
+      if (!result.ok) {
+        setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
+        return false;
+      }
+
+      return true;
+    },
+    [
+      cashuTokensAll,
+      readCashuRowAliases,
+      readCashuRowOwnerId,
+      resolveOwnerIdForWrite,
+      setStatus,
+      t,
+      update,
+    ],
+  );
+
+  const startSendCashuTokenToContact = React.useCallback(
+    async (id: CashuTokenId) => {
+      setPendingCashuTokenContactPickId(id);
+      setStatus(t("cashuSelectContactToSend"));
+      navigateTo({ route: "contacts" });
+    },
+    [setStatus, t],
+  );
+
+  const sendCashuTokenToContact = React.useCallback(
+    async (contact: DisplayContact, tokenId: CashuTokenId) => {
+      setPendingCashuTokenContactPickId(null);
+
+      const row = cashuTokensAllFiltered.find(
+        (candidate) => candidate.id === tokenId && !candidate.isDeleted,
+      );
+      const tokenMeta = row ? extractCashuTokenMeta(row) : null;
+      const tokenText = String(tokenMeta?.tokenText ?? "").trim();
+
+      if (!row || !tokenText || !isCashuTokenIssuedState(row.state)) {
+        setStatus(t("cashuInvalid"));
+        return;
+      }
+
+      const contactId = String(contact.id ?? "").trim();
+      if (!contactId) {
+        setStatus(t("contactNotFound"));
+        return;
+      }
+
+      if (!currentNsec) {
+        setStatus(t("profileMissingNpub"));
+        return;
+      }
+
+      let contactPubHex = normalizePubkeyHex(contact.unknownPubkeyHex);
+      const contactNpub = normalizeNpubIdentifier(contact.npub);
+
+      if (!contactPubHex && contactNpub) {
+        let decodedContact: ReturnType<typeof nip19.decode> | null = null;
+        try {
+          decodedContact = nip19.decode(contactNpub);
+        } catch {
+          decodedContact = null;
+        }
+        if (
+          decodedContact &&
+          decodedContact.type === "npub" &&
+          typeof decodedContact.data === "string"
+        ) {
+          contactPubHex = decodedContact.data;
+        }
+      }
+
+      if (!contactPubHex) {
+        setStatus(t("chatMissingContactNpub"));
+        return;
+      }
+
+      const transactionNote =
+        String(contact.name ?? "").trim() ||
+        String(contact.lnAddress ?? "").trim() ||
+        null;
+      const logIssuedTokenSendTransaction = (phase: "complete" | "publish") => {
+        logPaymentEvent({
+          amount: tokenMeta?.amount ?? null,
+          contactId: contact.id as ContactId,
+          details: {
+            usedInputTokens: [tokenText],
+          },
+          direction: "out",
+          error: null,
+          fee: null,
+          method: "cashu_chat",
+          mint: tokenMeta?.mint ?? null,
+          note: transactionNote,
+          phase,
+          status: "ok",
+          unit: tokenMeta?.unit ?? null,
+        });
+      };
+
+      let activeClientId: string | null = null;
+
+      try {
+        const { getEventHash, getPublicKey } = await import("nostr-tools");
+
+        const decodedMe = nip19.decode(currentNsec);
+        if (
+          decodedMe.type !== "nsec" ||
+          !(decodedMe.data instanceof Uint8Array)
+        ) {
+          throw new Error("invalid nsec");
+        }
+
+        const privBytes = decodedMe.data;
+        const myPubHex = getPublicKey(privBytes);
+        const clientId = makeLocalId();
+        activeClientId = clientId;
+        activeNostrMessagePublishClientIdsRef.current.add(clientId);
+
+        const baseEvent = {
+          created_at: Math.ceil(Date.now() / 1e3),
+          kind: 14,
+          pubkey: myPubHex,
+          tags: [
+            ["p", contactPubHex],
+            ["p", myPubHex],
+            ["client", clientId],
+          ],
+          content: tokenText,
+        } satisfies UnsignedEvent;
+
+        const rumorId = getEventHash(baseEvent);
+        const pendingId = appendLocalNostrMessage({
+          contactId,
+          direction: "out",
+          content: tokenText,
+          wrapId: `pending:${clientId}`,
+          rumorId,
+          pubkey: myPubHex,
+          createdAtSec: baseEvent.created_at,
+          status: "pending",
+          clientId,
+        });
+
+        const deleted = await deleteCashuToken(tokenId);
+        if (!deleted) {
+          return;
+        }
+
+        navigateTo({ route: "chat", id: contactId });
+
+        const isOffline =
+          typeof navigator !== "undefined" && navigator.onLine === false;
+        if (isOffline) {
+          logIssuedTokenSendTransaction("publish");
+          setStatus(t("chatQueued"));
+          return;
+        }
+
+        const wrapForMe = wrapEventWithoutPushMarker(
+          baseEvent,
+          privBytes,
+          myPubHex,
+        );
+        const wrapForContact = wrapEventWithPushMarker(
+          baseEvent,
+          privBytes,
+          contactPubHex,
+        );
+
+        const pool = await getSharedAppNostrPool();
+        const publishOutcome = await publishWrappedWithRetry(
+          pool,
+          NOSTR_RELAYS,
+          wrapForMe,
+          wrapForContact,
+        );
+
+        if (!publishOutcome.anySuccess) {
+          logIssuedTokenSendTransaction("publish");
+          setStatus(t("chatQueued"));
+          return;
+        }
+
+        chatSeenWrapIdsRef.current.add(String(wrapForMe.id ?? ""));
+        if (pendingId) {
+          updateLocalNostrMessage(pendingId, {
+            status: "sent",
+            wrapId: String(wrapForMe.id ?? ""),
+            pubkey: myPubHex,
+            rumorId,
+          });
+        }
+
+        logIssuedTokenSendTransaction("complete");
+      } catch (error) {
+        setStatus(`${t("errorPrefix")}: ${String(error ?? "unknown")}`);
+      } finally {
+        if (activeClientId) {
+          activeNostrMessagePublishClientIdsRef.current.delete(activeClientId);
+        }
+      }
+    },
+    [
+      appendLocalNostrMessage,
+      cashuTokensAllFiltered,
+      currentNsec,
+      logPaymentEvent,
+      deleteCashuToken,
+      publishWrappedWithRetry,
+      setStatus,
+      t,
+      updateLocalNostrMessage,
+    ],
+  );
+
+  const handleMintIconLoad = React.useCallback(
+    (origin: string, url: string | null) => {
+      setMintIconUrlByMint((prev) => ({
+        ...prev,
+        [origin]: url,
+      }));
+    },
+    [],
+  );
+
+  const handleMintIconError = React.useCallback(
+    (origin: string, url: string | null) => {
+      setMintIconUrlByMint((prev) => ({
+        ...prev,
+        [origin]: url,
+      }));
+    },
+    [],
+  );
+
+  const restoreMissingTokens = useRestoreMissingTokens({
+    cashuIsBusy,
+    cashuTokensAll: cashuTokensAllFiltered,
+    defaultMintUrl,
+    enqueueCashuOp,
+    upsert,
+    isMintDeleted,
+    logPaymentEvent,
+    mintInfoDeduped,
+    pushToast,
+    readSeenMintsFromStorage,
+    rememberSeenMint,
+    resolveOwnerIdForWrite,
+    setCashuIsBusy,
+    setTokensRestoreIsBusy,
+    t,
+    tokensRestoreIsBusy,
+  });
+
+  const mainMintForTokenList = React.useMemo(
+    () => normalizeMintUrl(defaultMintUrl ?? MAIN_MINT_URL),
+    [defaultMintUrl],
+  );
+
+  const largestForeignMintForTokenList = React.useMemo(() => {
+    if (!mainMintForTokenList) return null;
+
+    const groups = new Map<
+      string,
+      { mint: string; sum: number; tokens: string[] }
+    >();
+    for (const row of cashuTokensWithMeta) {
+      if (!isCashuTokenAcceptedState(row.state)) continue;
+
+      const mint = normalizeMintUrl(String(row.mint ?? "").trim());
+      if (!mint || mint === mainMintForTokenList) continue;
+
+      const tokenText = String(row.token ?? row.rawToken ?? "").trim();
+      if (!tokenText) continue;
+
+      const amount = Number(row.amount ?? 0);
+      const nextAmount = Number.isFinite(amount) && amount > 0 ? amount : 0;
+      const entry = groups.get(mint) ?? { mint, sum: 0, tokens: [] };
+      entry.sum += nextAmount;
+      entry.tokens.push(tokenText);
+      groups.set(mint, entry);
+    }
+
+    let selected: { mint: string; sum: number; tokens: string[] } | null = null;
+    for (const entry of groups.values()) {
+      if (!selected || entry.sum > selected.sum) {
+        selected = entry;
+      }
+    }
+
+    return selected;
+  }, [cashuTokensWithMeta, mainMintForTokenList]);
+
+  const formatMintButtonLabel = React.useCallback((mintUrl: string) => {
+    try {
+      return new URL(mintUrl).host || mintUrl.replace(/^https?:\/\//i, "");
+    } catch {
+      return mintUrl.replace(/^https?:\/\//i, "");
+    }
+  }, []);
+
+  const cashuMeltToMainMintButtonLabel =
+    mainMintForTokenList && largestForeignMintForTokenList
+      ? t("cashuMeltToMainMint").replace(
+          "{mint}",
+          formatMintButtonLabel(mainMintForTokenList),
+        )
+      : null;
+
+  const emitCashuToken = React.useCallback(async () => {
+    const amountSat = Number.parseInt(cashuEmitAmount.trim(), 10);
+    if (!Number.isFinite(amountSat) || amountSat <= 0) {
+      setStatus(t("payInvalidAmount"));
+      return;
+    }
+
+    if (cashuIsBusy) return;
+    if (cashuBalance < amountSat) {
+      setStatus(t("payInsufficient"));
+      return;
+    }
+
+    const insertCashuTokenRecord = async (args: {
+      amount?: number | null;
+      mint?: string | null;
+      state: "accepted" | "issued";
+      token: string;
+      unit?: string | null;
+    }) => {
+      const targetAliases = readCashuRowAliases({
+        rawToken: null,
+        token: args.token,
+      });
+      const targetId = String(createCashuTokenId(args.token));
+      const ownerId = await resolveOwnerIdForWrite();
+      const existingRow = cashuTokensAll.find((row) => {
+        return (
+          String(row.id ?? "") === targetId ||
+          readCashuRowAliases(row).some((alias) =>
+            targetAliases.includes(alias),
+          )
+        );
+      });
+
+      if (existingRow) {
+        return {
+          ownerId,
+          ok: true,
+          error: null,
+          rowId: existingRow.id,
+          skippedDuplicate: true,
+        };
+      }
+
+      const payload: {
+        id: CashuTokenId;
+        token: typeof Evolu.NonEmptyString.Type;
+        state: typeof Evolu.NonEmptyString100.Type;
+      } = {
+        id: createCashuTokenId(args.token),
+        token: args.token as typeof Evolu.NonEmptyString.Type,
+        state: args.state as typeof Evolu.NonEmptyString100.Type,
+      };
+
+      const result = ownerId
+        ? upsert("cashuToken", payload, { ownerId })
+        : upsert("cashuToken", payload);
+      return {
+        ownerId,
+        ok: result.ok,
+        error: result.ok
+          ? null
+          : getUnknownErrorMessage(result.error, "unknown"),
+        rowId: result.ok ? result.value.id : null,
+        skippedDuplicate: false,
+      };
+    };
+
+    const deleteCashuRows = async (
+      rows: readonly {
+        id?: CashuTokenId | string | null;
+        ownerId?: unknown;
+      }[],
+      fallbackOwnerId?: Evolu.OwnerId | null,
+    ) => {
+      for (const row of rows) {
+        if (!row.id) continue;
+        const payload = { id: row.id, isDeleted: Evolu.sqliteTrue };
+        const ownerId = resolveCashuRowStoredOwnerLane(row) ?? fallbackOwnerId;
+        const result = ownerId
+          ? update("cashuToken", payload, { ownerId })
+          : update("cashuToken", payload);
+        if (!result.ok) {
+          throw new Error(getUnknownErrorMessage(result.error, "unknown"));
+        }
+      }
+    };
+
+    setCashuIsBusy(true);
+    setStatus(t("cashuEmitting"));
+
+    try {
+      const mintGroups = new Map<string, { tokens: string[]; sum: number }>();
+      for (const row of cashuTokensWithMeta) {
+        if (!isCashuTokenAcceptedState(row.state)) continue;
+
+        const mint = String(row.mint ?? "").trim();
+        if (!mint) continue;
+
+        const tokenText = String(row.token ?? row.rawToken ?? "").trim();
+        if (!tokenText) continue;
+
+        const amount = Number(row.amount ?? 0) || 0;
+        const entry = mintGroups.get(mint) ?? { tokens: [], sum: 0 };
+        entry.tokens.push(tokenText);
+        entry.sum += amount;
+        mintGroups.set(mint, entry);
+      }
+
+      const preferredMint = normalizeMintUrl(defaultMintUrl ?? "");
+      const candidates = buildCashuMintCandidates(mintGroups, preferredMint);
+
+      if (candidates.length === 0) {
+        setStatus(t("payInsufficient"));
+        return;
+      }
+
+      const candidate = selectSingleMintCandidateForAmount(
+        candidates,
+        amountSat,
+      );
+      if (!candidate) {
+        setStatus(t("payInsufficient"));
+        return;
+      }
+
+      const maxReservedFeeSat = getPaymentAmountReserveCap(
+        amountSat,
+        candidate.sum,
+      );
+
+      let selectedTokenId: CashuTokenId | null = null;
+      let finalError: string | null = null;
+
+      const attempts = buildPaymentAmountAttempts(
+        amountSat,
+        candidate.sum,
+      ).filter((attemptAmountSat) => {
+        return amountSat - attemptAmountSat <= maxReservedFeeSat;
+      });
+
+      if (attempts.length === 0) {
+        setStatus(t("payInsufficient"));
+        return;
+      }
+
+      for (const attemptAmountSat of attempts) {
+        const split = await createSendTokenWithTokensAtMint({
+          amount: attemptAmountSat,
+          mint: candidate.mint,
+          tokens: candidate.tokens,
+          unit: "sat",
+        });
+
+        if (!split.ok) {
+          finalError = String(split.error ?? "unknown");
+
+          if (split.remainingToken && split.remainingAmount > 0) {
+            const recoveryInsert = await insertCashuTokenRecord({
+              token: split.remainingToken,
+              mint: split.mint,
+              unit: split.unit,
+              amount: split.remainingAmount,
+              state: "accepted",
+            });
+            if (!recoveryInsert.ok) {
+              throw new Error(String(recoveryInsert.error));
+            }
+
+            const spentRows = cashuTokensWithMeta.filter((row) => {
+              return (
+                isCashuTokenAcceptedState(row.state) &&
+                String(row.mint ?? "").trim() === candidate.mint
+              );
+            });
+            await deleteCashuRows(spentRows, recoveryInsert.ownerId);
+            break;
+          }
+
+          if (isRetryablePaymentAmountFailure(finalError)) {
+            continue;
+          }
+          break;
+        }
+
+        const spentRows = cashuTokensWithMeta.filter((row) => {
+          return (
+            isCashuTokenAcceptedState(row.state) &&
+            String(row.mint ?? "").trim() === candidate.mint
+          );
+        });
+        const spentOwnerId = await resolveOwnerIdForWrite();
+        await deleteCashuRows(spentRows, spentOwnerId);
+
+        if (split.remainingToken && split.remainingAmount > 0) {
+          const remainingInsert = await insertCashuTokenRecord({
+            token: split.remainingToken,
+            mint: split.mint,
+            unit: split.unit,
+            amount: split.remainingAmount,
+            state: "accepted",
+          });
+          if (!remainingInsert.ok) {
+            throw new Error(String(remainingInsert.error));
+          }
+        }
+
+        const issuedInsert = await insertCashuTokenRecord({
+          token: split.sendToken,
+          mint: split.mint,
+          unit: split.unit,
+          amount: split.sendAmount,
+          state: "issued",
+        });
+        if (!issuedInsert.ok || !issuedInsert.rowId) {
+          throw new Error(
+            String(issuedInsert.error ?? "missing issued token id"),
+          );
+        }
+
+        selectedTokenId = issuedInsert.rowId;
+        logPaymentEvent({
+          direction: "out",
+          status: "ok",
+          amount: split.sendAmount,
+          details: {
+            ...(split.remainingToken
+              ? { gainedToken: split.remainingToken }
+              : {}),
+            issuedToken: split.sendToken,
+            usedInputTokens: candidate.tokens,
+          },
+          fee: null,
+          mint: split.mint,
+          unit: split.unit,
+          error: null,
+          contactId: null,
+          method: "unknown",
+          phase: "swap",
+        });
+        break;
+      }
+
+      if (!selectedTokenId) {
+        const errorMessage = finalError ?? t("payInsufficient");
+        logPaymentEvent({
+          direction: "out",
+          status: "error",
+          amount: amountSat,
+          fee: null,
+          mint: null,
+          unit: "sat",
+          error: errorMessage,
+          contactId: null,
+          method: "unknown",
+          phase: "swap",
+        });
+        setStatus(`${t("payFailed")}: ${errorMessage}`);
+        return;
+      }
+
+      setCashuEmitAmount("");
+      navigateTo({ route: "cashuToken", id: selectedTokenId });
+    } catch (error) {
+      const errorMessage = getUnknownErrorMessage(error, "unknown");
+      logPaymentEvent({
+        direction: "out",
+        status: "error",
+        amount: amountSat,
+        fee: null,
+        mint: null,
+        unit: "sat",
+        error: errorMessage,
+        contactId: null,
+        method: "unknown",
+        phase: "swap",
+      });
+      setStatus(`${t("payFailed")}: ${errorMessage}`);
+    } finally {
+      setCashuIsBusy(false);
+    }
+  }, [
+    buildCashuMintCandidates,
+    cashuBalance,
+    cashuEmitAmount,
+    cashuIsBusy,
+    cashuTokensAll,
+    cashuTokensWithMeta,
+    defaultMintUrl,
+    logPaymentEvent,
+    readCashuRowAliases,
+    resolveOwnerIdForWrite,
+    setCashuEmitAmount,
+    setStatus,
+    t,
+    update,
+    upsert,
+  ]);
+
+  // Shared per-quote in-flight set so the inline claim trigger in the
+  // autoswap path and the 5s background tick can never both successfully
+  // call mintTopupProofs for the same quote. Without this, the second path
+  // would land in the NUT-09 restore branch, return proofs in a different
+  // order than the first, encode a different token string, miss the
+  // isCashuTokenKnownAny dedup, and insert a duplicate cashuToken row.
+  const autoswapClaimInFlightRef = React.useRef<Set<string>>(new Set());
+  // Cross-tick cache so the background claim effect doesn't reload the
+  // target-mint wallet (info+keysets+keys) every tick while a quote is
+  // still PENDING at the mint. Keyed by `mintUrl|unit`; entries cleared
+  // on logout (effect cleanup).
+  const autoswapClaimWalletCacheRef = React.useRef<
+    Map<string, LoadedCashuWallet>
+  >(new Map());
+
+  const meltLargestForeignMintToMainMint = React.useCallback(async () => {
+    if (cashuIsBusy) return;
+
+    const targetMint = normalizeMintUrl(defaultMintUrl ?? MAIN_MINT_URL);
+    if (!targetMint) {
+      setStatus(t("mintUrlInvalid"));
+      return;
+    }
+
+    const sourceGroups = new Map<string, { mint: string; sum: number }>();
+    for (const row of cashuTokensWithMeta) {
+      if (!isCashuTokenAcceptedState(row.state)) continue;
+
+      const mint = normalizeMintUrl(String(row.mint ?? "").trim());
+      if (!mint || mint === targetMint) continue;
+
+      const amount = Number(row.amount ?? 0);
+      const nextAmount = Number.isFinite(amount) && amount > 0 ? amount : 0;
+      const entry = sourceGroups.get(mint) ?? { mint, sum: 0 };
+      entry.sum += nextAmount;
+      sourceGroups.set(mint, entry);
+    }
+
+    let sourceMint: string | null = null;
+    let sourceBalance = 0;
+    for (const entry of sourceGroups.values()) {
+      if (!sourceMint || entry.sum > sourceBalance) {
+        sourceMint = entry.mint;
+        sourceBalance = entry.sum;
+      }
+    }
+
+    if (!sourceMint || sourceBalance <= 0) {
+      setStatus(t("cashuMeltToMainMintUnavailable"));
+      return;
+    }
+
+    const sourceRows = cashuTokensWithMeta.filter((row) => {
+      if (!isCashuTokenAcceptedState(row.state)) return false;
+      return normalizeMintUrl(String(row.mint ?? "").trim()) === sourceMint;
+    });
+    const sourceTokens = sourceRows
+      .map((row) => String(row.token ?? row.rawToken ?? "").trim())
+      .filter((tokenText) => tokenText.length > 0);
+
+    if (sourceTokens.length === 0) {
+      setStatus(t("cashuMeltToMainMintUnavailable"));
+      return;
+    }
+
+    interface AcceptedCashuTokenPayload {
+      id: CashuTokenId;
+      state: "accepted";
+      token: string;
+    }
+
+    const insertAcceptedToken = async (args: {
+      amount?: number | null;
+      mint?: string | null;
+      rawToken?: string | null;
+      token: string;
+      unit?: string | null;
+    }) => {
+      const targetAliases = readCashuRowAliases({
+        rawToken: args.rawToken ?? null,
+        token: args.token,
+      });
+      const targetId = String(createCashuTokenId(args.rawToken || args.token));
+      const ownerId = await resolveOwnerIdForWrite();
+      const existingRow = cashuTokensAll.find((row) => {
+        return (
+          String(row.id ?? "") === targetId ||
+          readCashuRowAliases(row).some((alias) =>
+            targetAliases.includes(alias),
+          )
+        );
+      });
+
+      if (existingRow) {
+        return {
+          ownerId,
+          ok: true,
+          error: null,
+          rowId: existingRow.id,
+          skippedDuplicate: true,
+        };
+      }
+
+      const payload: AcceptedCashuTokenPayload = {
+        id: createCashuTokenId(args.rawToken || args.token),
+        token: args.token,
+        state: "accepted",
+      };
+
+      const result = ownerId
+        ? upsert("cashuToken", payload, { ownerId })
+        : upsert("cashuToken", payload);
+      return {
+        ownerId,
+        ok: result.ok,
+        error: result.ok
+          ? null
+          : getUnknownErrorMessage(result.error, "unknown"),
+        rowId: result.ok ? result.value.id : null,
+        skippedDuplicate: false,
+      };
+    };
+
+    const markRowsDeleted = async (
+      rows: Array<{
+        id?: CashuTokenId | string | null;
+        ownerId?: unknown;
+      }>,
+      fallbackOwnerId?: Evolu.OwnerId | null,
+    ) => {
+      for (const row of rows) {
+        if (!row.id) continue;
+        const payload = { id: row.id, isDeleted: Evolu.sqliteTrue };
+        const ownerId = resolveCashuRowStoredOwnerLane(row) ?? fallbackOwnerId;
+        const result = ownerId
+          ? update("cashuToken", payload, { ownerId })
+          : update("cashuToken", payload);
+        if (!result.ok) {
+          throw new Error(getUnknownErrorMessage(result.error, "unknown"));
+        }
+      }
+    };
+
+    const initialAmountAttempts = buildPaymentAmountAttempts(
+      sourceBalance,
+      sourceBalance,
+    );
+    // Cap retries hard. Each iteration creates a fresh top-up quote at the
+    // target mint, and most mints rate-limit quote creation aggressively
+    // (we have hit 429 on `/v1/mint/quote/bolt11` and even `/v1/info` on
+    // mint.lnpay.cz). Eight matches buildPaymentAmountAttempts's natural
+    // stepping schedule [0,1,2,3,5,8,13,21] so we can reach a 21-sat drop
+    // off the source balance — enough headroom for percentage fee_reserve
+    // schedules (e.g. 1% with min) on borderline balances.
+    const MAX_AMOUNT_ATTEMPTS = 8;
+    const queuedAmountAttempts = [...initialAmountAttempts].slice(
+      0,
+      MAX_AMOUNT_ATTEMPTS,
+    );
+    const seenAmountAttempts = new Set(queuedAmountAttempts);
+    let finalError = t("cashuMeltToMainMintFailed");
+
+    setCashuIsBusy(true);
+    setStatus(t("cashuMeltToMainMintProcessing"));
+
+    try {
+      rememberSeenMint(targetMint);
+      // Skip refreshMintInfo here: the mint store already
+      // gates on a once-per-session ref (useMintInfoStore.ts) and the boot
+      // effect auto-refreshes the default mint at app startup. The wallet
+      // load below independently fetches info+keysets+keys via cashu-ts,
+      // which is what melt actually needs.
+
+      const { Mint, Wallet } = await getCashuLib();
+      const det = getCashuDeterministicSeedFromStorage();
+      const targetWallet = await createLoadedCashuWallet({
+        Mint,
+        Wallet,
+        mintUrl: targetMint,
+        unit: "sat",
+        ...(det ? { bip39seed: det.bip39seed } : {}),
+      });
+      const { meltInvoiceWithTokensAtMint, prepareMeltMintContext } =
+        await import("../../../cashuMelt");
+
+      // Pre-load source-mint context (info+keysets+keys+checkstate) once.
+      // Each retry only varies the amount; reusing the wallet handle and the
+      // already-state-checked spendable proofs across attempts cuts ~4
+      // mint round-trips per iteration. The melt-quote / swap / melt steps
+      // still run per-attempt because they bind to the per-attempt invoice.
+      let sourceMeltContext: Awaited<
+        ReturnType<typeof prepareMeltMintContext>
+      > | null = null;
+      try {
+        sourceMeltContext = await prepareMeltMintContext({
+          mint: sourceMint,
+          tokens: sourceTokens,
+          unit: "sat",
+        });
+      } catch (error) {
+        finalError = getUnknownErrorMessage(error, "unknown");
+      }
+
+      // Pre-flight fee discovery: ask source mint how much fee_reserve + input
+      // fee it will charge for a probe invoice of the full sourceBalance, then
+      // size the first target-mint invoice as
+      //   sourceAmount = sourceBalance - fee_reserve - input_fee
+      // so the first real melt attempt has the right headroom instead of
+      // burning the entire retry ladder hitting Insufficient.
+      if (sourceMeltContext) {
+        try {
+          const probe = await requestMintQuoteBolt11({
+            amountSat: sourceBalance,
+            mintUrl: targetMint,
+          });
+          const probeMeltQuote =
+            await sourceMeltContext.wallet.createMeltQuoteBolt11(probe.invoice);
+          const probeFeeReserve = cashuAmountToNumber(
+            probeMeltQuote.fee_reserve,
+          );
+          const probeInputFee = cashuAmountToNumber(
+            sourceMeltContext.wallet.getFeesForProofs(
+              sourceMeltContext.spendableProofs,
+            ),
+          );
+          const sizedAmount = Math.max(
+            1,
+            sourceBalance - probeFeeReserve - probeInputFee,
+          );
+          if (
+            Number.isFinite(sizedAmount) &&
+            sizedAmount >= 1 &&
+            sizedAmount < sourceBalance
+          ) {
+            // Drop the no-fee-reserve attempts that we now know will fail and
+            // promote the discovered sized amount to the front of the queue.
+            const tail = queuedAmountAttempts.filter(
+              (candidate) => candidate < sizedAmount,
+            );
+            queuedAmountAttempts.length = 0;
+            queuedAmountAttempts.push(sizedAmount, ...tail);
+            seenAmountAttempts.clear();
+            for (const candidate of queuedAmountAttempts) {
+              seenAmountAttempts.add(candidate);
+            }
+          }
+        } catch {
+          // Probe failed (rate-limited mint, network error, etc.). Fall
+          // through to the original retry strategy starting from sourceBalance.
+        }
+      }
+
+      let activeSourceRows: Array<{ id?: CashuTokenId | string | null }> =
+        sourceRows;
+      let activeSourceOwnerId = cashuOwnerId;
+      let activeSourceTokens = sourceTokens;
+
+      for (
+        let attemptIndex = 0;
+        attemptIndex < queuedAmountAttempts.length;
+        attemptIndex += 1
+      ) {
+        const amountSat = queuedAmountAttempts[attemptIndex];
+        let quoteId = "";
+        let invoice = "";
+
+        try {
+          const requestedQuote = await requestMintQuoteBolt11({
+            amountSat,
+            mintUrl: targetMint,
+          });
+          quoteId = requestedQuote.quoteId;
+          invoice = requestedQuote.invoice;
+
+          const meltResult = await meltInvoiceWithTokensAtMint({
+            invoice,
+            mint: sourceMint,
+            tokens: activeSourceTokens,
+            unit: "sat",
+            ...(sourceMeltContext ? { context: sourceMeltContext } : {}),
+          });
+
+          if (!meltResult.ok) {
+            const errorMessage = String(meltResult.error ?? "unknown");
+
+            if (meltResult.remainingToken && meltResult.remainingAmount > 0) {
+              const retryable = isRetryablePaymentAmountFailure(errorMessage);
+
+              if (retryable) {
+                const recoveryInsert = await insertAcceptedToken({
+                  token: meltResult.remainingToken,
+                  mint: meltResult.mint,
+                  unit: meltResult.unit,
+                  amount: meltResult.remainingAmount,
+                });
+                if (!recoveryInsert.ok || !recoveryInsert.rowId) {
+                  throw new Error(
+                    String(recoveryInsert.error ?? "missing recovery token id"),
+                  );
+                }
+
+                await markRowsDeleted(activeSourceRows, activeSourceOwnerId);
+
+                activeSourceRows = [
+                  {
+                    id: recoveryInsert.rowId,
+                  },
+                ];
+                activeSourceOwnerId = recoveryInsert.ownerId;
+                activeSourceTokens = [meltResult.remainingToken];
+
+                finalError = errorMessage;
+                break;
+              }
+
+              const recoveryInsert = await insertAcceptedToken({
+                token: meltResult.remainingToken,
+                mint: meltResult.mint,
+                unit: meltResult.unit,
+                amount: meltResult.remainingAmount,
+              });
+              if (!recoveryInsert.ok) {
+                throw new Error(String(recoveryInsert.error));
+              }
+              await markRowsDeleted(activeSourceRows, activeSourceOwnerId);
+              finalError = errorMessage;
+              break;
+            }
+
+            if (
+              isRetryablePaymentAmountFailure(errorMessage) &&
+              queuedAmountAttempts.length < MAX_AMOUNT_ATTEMPTS
+            ) {
+              // Prefer stepping by the exact shortage the mint reported
+              // (`need X, have Y`), then fall back through the fee ladder.
+              // For tiny balances this matters: 2 sats with a 1-sat input
+              // fee should retry 1 sat, not drop straight to 0.
+              const candidates = buildPaymentFailureAmountAttempts(
+                amountSat,
+                errorMessage,
+              );
+              for (const retryAmount of candidates) {
+                if (seenAmountAttempts.has(retryAmount)) continue;
+                seenAmountAttempts.add(retryAmount);
+                queuedAmountAttempts.push(retryAmount);
+                if (queuedAmountAttempts.length >= MAX_AMOUNT_ATTEMPTS) break;
+              }
+              // Brief pause before re-hitting the mint quote endpoint —
+              // back-to-back POSTs trigger 429 on most public mints.
+              await new Promise<void>((resolve) => {
+                window.setTimeout(resolve, 800);
+              });
+            }
+
+            finalError = errorMessage;
+            continue;
+          }
+
+          if (meltResult.remainingToken && meltResult.remainingAmount > 0) {
+            const remainingInsert = await insertAcceptedToken({
+              token: meltResult.remainingToken,
+              mint: meltResult.mint,
+              unit: meltResult.unit,
+              amount: meltResult.remainingAmount,
+            });
+            if (!remainingInsert.ok) {
+              throw new Error(String(remainingInsert.error));
+            }
+          }
+
+          const mintedUnit = targetWallet.unit ?? "sat";
+
+          // Persist the pending claim BEFORE deleting the source rows so
+          // the background autoswap-claim effect can recover after a crash.
+          // The actual mintProofs + insert is shared with that effect via
+          // claimAutoswapPendingEntry + a per-quote in-flight set, so we
+          // can fire it inline here for instant UX without any duplicate
+          // risk: if the 5s tick happens to overlap, the second caller
+          // sees in_flight and bails.
+          const pendingClaimOwnerKey = String(appOwnerId ?? "anon");
+          const pendingClaimsKey =
+            makePendingAutoswapClaimsKey(pendingClaimOwnerKey);
+          const pendingClaim: AutoswapPendingClaim = {
+            amount: amountSat,
+            createdAtMs: Date.now(),
+            invoice,
+            mintUrl: targetMint,
+            quote: quoteId,
+            unit: mintedUnit,
+          };
+          appendPendingAutoswapClaim(pendingClaimsKey, pendingClaim);
+
+          await markRowsDeleted(activeSourceRows, activeSourceOwnerId);
+
+          void (async () => {
+            // Best-effort instant claim. Failures (mint quote not yet
+            // claimable, network error, 429) are picked up by the
+            // background tick on its next 5s pass.
+            const outcome = await claimAutoswapPendingEntry({
+              claim: pendingClaim,
+              claimOwnerKey: pendingClaimOwnerKey,
+              claimsKey: pendingClaimsKey,
+              ctx: {
+                upsert,
+                isCashuTokenKnownAny,
+                resolveOwnerIdForWrite,
+              },
+              inFlightSet: autoswapClaimInFlightRef.current,
+              walletCache: autoswapClaimWalletCacheRef.current,
+            });
+            if (outcome.kind === "claimed") {
+              const okAmount = formatDisplayedAmountParts(amountSat);
+              setStatus(
+                t("cashuMeltToMainMintDone")
+                  .replace(
+                    "{amount}",
+                    `${okAmount.approxPrefix}${okAmount.amountText}`,
+                  )
+                  .replace("{unit}", okAmount.unitLabel)
+                  .replace("{mint}", formatMintButtonLabel(targetMint)),
+              );
+            }
+          })();
+
+          const displayAmount = formatDisplayedAmountParts(amountSat);
+          setStatus(
+            t("cashuMeltToMainMintPending")
+              .replace(
+                "{amount}",
+                `${displayAmount.approxPrefix}${displayAmount.amountText}`,
+              )
+              .replace("{unit}", displayAmount.unitLabel),
+          );
+          return;
+        } catch (error) {
+          finalError = getUnknownErrorMessage(error, "unknown");
+          if (!isRetryablePaymentAmountFailure(finalError)) {
+            break;
+          }
+        }
+      }
+
+      setStatus(`${t("cashuMeltToMainMintFailed")}: ${finalError}`);
+    } finally {
+      setCashuIsBusy(false);
+    }
+  }, [
+    cashuIsBusy,
+    cashuOwnerId,
+    cashuTokensAll,
+    cashuTokensWithMeta,
+    defaultMintUrl,
+    appOwnerId,
+    formatDisplayedAmountParts,
+    formatMintButtonLabel,
+    upsert,
+    isCashuTokenKnownAny,
+    readCashuRowAliases,
+    rememberSeenMint,
+    resolveOwnerIdForWrite,
+    setCashuIsBusy,
+    setStatus,
+    t,
+    update,
+  ]);
+
+  const autoswapAttemptedSignatureRef = React.useRef<string | null>(null);
+  const autoswapInFlightRef = React.useRef(false);
+  React.useEffect(() => {
+    meltLargestForeignMintToMainMintRef.current =
+      meltLargestForeignMintToMainMint;
+  }, [meltLargestForeignMintToMainMint]);
+
+  const closePaymentMintMeltConfirmation = React.useCallback(() => {
+    if (cashuIsBusy) return;
+    setPendingPaymentMintMeltConfirmation(null);
+  }, [cashuIsBusy]);
+
+  const confirmPaymentMintMelt = React.useCallback(async () => {
+    if (cashuIsBusy) return;
+    setPendingPaymentMintMeltConfirmation(null);
+    await meltLargestForeignMintToMainMintRef.current();
+  }, [cashuIsBusy]);
+
+  // Below this threshold the melt fee_reserve typically dominates the
+  // foreign-mint balance, so the swap fails with "Insufficient funds" and
+  // we end up with stranded dust at both the source and target mints. The
+  // user can still trigger the manual `Melt to <main mint>` button for any
+  // amount.
+  const autoswapSignature = React.useMemo(() => {
+    if (!largestForeignMintForTokenList) return null;
+    if (largestForeignMintForTokenList.sum < CASHU_AUTOSWAP_MIN_SOURCE_SUM) {
+      return null;
+    }
+    return `${largestForeignMintForTokenList.mint}|${largestForeignMintForTokenList.sum}|${largestForeignMintForTokenList.tokens.length}`;
+  }, [largestForeignMintForTokenList]);
+
+  React.useEffect(() => {
+    if (!cashuAutoswapEnabled) return;
+    if (cashuIsBusy) return;
+    if (autoswapInFlightRef.current) return;
+    if (!autoswapSignature) {
+      autoswapAttemptedSignatureRef.current = null;
+      return;
+    }
+    if (autoswapAttemptedSignatureRef.current === autoswapSignature) return;
+
+    const timeoutId = window.setTimeout(() => {
+      autoswapAttemptedSignatureRef.current = autoswapSignature;
+      autoswapInFlightRef.current = true;
+      void (async () => {
+        try {
+          await meltLargestForeignMintToMainMintRef.current();
+        } finally {
+          autoswapInFlightRef.current = false;
+        }
+      })();
+    }, 3000);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [autoswapSignature, cashuAutoswapEnabled, cashuIsBusy]);
+
+  const appOwnerIdValue = appOwnerId;
+  React.useEffect(() => {
+    const ownerKey = String(appOwnerIdValue ?? "anon");
+    const claimSources = [
+      {
+        claimsKey: makePendingAutoswapClaimsKey(ownerKey),
+        ownerKey,
+      },
+    ];
+    if (ownerKey !== "anon") {
+      claimSources.push({
+        claimsKey: makePendingAutoswapClaimsKey("anon"),
+        ownerKey: "anon",
+      });
+    }
+    const inFlightSet = autoswapClaimInFlightRef.current;
+    const walletCache = autoswapClaimWalletCacheRef.current;
+
+    let cancelled = false;
+    let tickInFlight = false;
+    let lastWarnedKey = "";
+
+    const tick = async () => {
+      if (cancelled || tickInFlight) return;
+      const pendingSources = claimSources
+        .map((source) => ({
+          ...source,
+          pending: readPendingAutoswapClaims(source.claimsKey),
+        }))
+        .filter((source) => source.pending.length > 0);
+      if (pendingSources.length === 0) return;
+      tickInFlight = true;
+      try {
+        for (const source of pendingSources) {
+          for (const claim of source.pending) {
+            if (cancelled) break;
+            const outcome = await claimAutoswapPendingEntry({
+              claim,
+              claimOwnerKey: source.ownerKey,
+              claimsKey: source.claimsKey,
+              ctx: {
+                upsert,
+                isCashuTokenKnownAny,
+                resolveOwnerIdForWrite,
+              },
+              inFlightSet,
+              walletCache,
+            });
+            if (outcome.kind === "failed") {
+              const warnKey = `${claim.mintUrl}:${claim.quote}:${outcome.reason}`;
+              if (warnKey !== lastWarnedKey) {
+                lastWarnedKey = warnKey;
+                console.warn("[linky][autoswap] background claim failed", {
+                  error: outcome.reason,
+                  mintUrl: claim.mintUrl,
+                  quote: claim.quote,
+                });
+              }
+            }
+          }
+        }
+      } finally {
+        tickInFlight = false;
+      }
+    };
+
+    void tick();
+    const intervalId = window.setInterval(() => {
+      void tick();
+    }, 5_000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+      walletCache.clear();
+    };
+  }, [appOwnerIdValue, isCashuTokenKnownAny, resolveOwnerIdForWrite, upsert]);
+
+  const requestSelectedContact = React.useCallback(async () => {
+    if (route.kind !== "contactPay") return;
+    if (!selectedContact) return;
+
+    const amountSat = Number.parseInt(String(payAmount ?? "").trim(), 10);
+    if (!Number.isFinite(amountSat) || amountSat <= 0) {
+      setStatus(t("payInvalidAmount"));
+      return;
+    }
+
+    const normalizedNpub = normalizeNpubIdentifier(selectedContact.npub);
+    if (!normalizedNpub) {
+      setStatus(t("chatMissingContactNpub"));
+      return;
+    }
+
+    let recipientPubkeyHex: string | null = null;
+    try {
+      const decoded = nip19.decode(currentNpub ?? "");
+      if (decoded.type === "npub" && typeof decoded.data === "string") {
+        recipientPubkeyHex = decoded.data;
+      }
+    } catch {
+      recipientPubkeyHex = null;
+    }
+
+    if (!recipientPubkeyHex) {
+      setStatus(t("profileMissingNpub"));
+      return;
+    }
+
+    const recipientNprofile = nip19.nprofileEncode({
+      pubkey: recipientPubkeyHex,
+      relays: NOSTR_RELAYS,
+    });
+    const preferredMint =
+      normalizeMintUrl(defaultMintUrl ?? MAIN_MINT_URL) ?? MAIN_MINT_URL;
+    const requestId = makeLocalId();
+    const requestText = buildCashuPaymentRequestMessage({
+      amount: amountSat,
+      mintUrls: [preferredMint],
+      recipientNprofile,
+      requestId,
+    });
+
+    await sendChatMessage({
+      clearDraft: false,
+      text: requestText,
+    });
+
+    logPaymentEvent({
+      amount: amountSat,
+      contactId: selectedContact.id,
+      details: {
+        mintUrls: [preferredMint],
+        recipientNprofile,
+        requestId,
+        requestText,
+      },
+      direction: "in",
+      method: "cashu_chat",
+      mint: preferredMint,
+      note: t("requestPaymentLabel"),
+      status: "ok",
+      unit: "sat",
+    });
+
+    if (
+      String(contactPayBackToChatRef.current ?? "") ===
+      String(selectedContact.id)
+    ) {
+      navigateTo({ route: "chat", id: selectedContact.id });
+      return;
+    }
+
+    navigateTo({ route: "contact", id: selectedContact.id });
+  }, [
+    currentNpub,
+    defaultMintUrl,
+    payAmount,
+    route.kind,
+    selectedContact,
+    sendChatMessage,
+    logPaymentEvent,
+    setStatus,
+    t,
+  ]);
+
+  const onPayChatPaymentRequest = React.useCallback(
+    async (
+      message: LocalNostrMessage,
+      requestInfo: CashuPaymentRequestMessageInfo,
+    ) => {
+      if (cashuIsBusy) return;
+      if (!selectedChatContact || selectedChatContact.isUnknownContact) return;
+      if (!selectedContact) return;
+
+      const requestRumorId = String(message.rumorId ?? "").trim();
+      if (!requestRumorId) return;
+
+      setCashuIsBusy(true);
+      try {
+        await payContactWithCashuMessage({
+          contact: selectedContact,
+          amountSat: requestInfo.amount,
+          paymentRequestId: requestInfo.requestId,
+          replyContext: {
+            replyToId: requestRumorId,
+            rootMessageId:
+              String(message.rootMessageId ?? "").trim() || requestRumorId,
+            replyToContent: String(message.content ?? "").trim() || null,
+          },
+        });
+      } finally {
+        setCashuIsBusy(false);
+      }
+    },
+    [
+      cashuIsBusy,
+      payContactWithCashuMessage,
+      selectedChatContact,
+      selectedContact,
+      setCashuIsBusy,
+    ],
+  );
+
+  const getCashuTokenMessageInfo = React.useCallback(
+    (text: string) =>
+      getCashuTokenMessageInfoBase(text, cashuTokensAllFiltered),
+    [cashuTokensAllFiltered],
+  );
+
+  const knownLnAddressPayContact = React.useMemo(() => {
+    if (route.kind !== "lnAddressPay") return null;
+
+    const inferredLnAddress = inferLightningAddressFromLnurlTarget(
+      route.lnAddress,
+    );
+    if (!inferredLnAddress) return null;
+
+    return (
+      contacts.find(
+        (contact) =>
+          String(contact.lnAddress ?? "")
+            .trim()
+            .toLowerCase() === inferredLnAddress.toLowerCase(),
+      ) ?? null
+    );
+  }, [contacts, route]);
+  const knownLnAddressPayContactPictureUrl = React.useMemo(() => {
+    const npub = normalizeNpubIdentifier(knownLnAddressPayContact?.npub);
+    return npub ? (nostrPictureByNpub[npub] ?? null) : null;
+  }, [knownLnAddressPayContact, nostrPictureByNpub]);
+
+  return {
+    applyDefaultMintSelection,
+    canPayWithCashu,
+    cancelPendingCashuContactSend,
+    cashuAutoswapEnabled,
+    cashuBalance,
+    cashuBalanceAfterMelt,
+    cashuBulkCheckIsBusy,
+    cashuDraft,
+    cashuDraftRef,
+    cashuEmitAmount,
+    cashuHasMultipleAcceptedMints,
+    cashuIsBusy,
+    cashuIssuedTokens,
+    cashuMeltToMainMintButtonLabel,
+    cashuOwnSpentTokens,
+    cashuOwnTokens,
+    cashuTokensAllFiltered,
+    cashuTokensFiltered,
+    cashuTokensHydratedRef,
+    cashuTotalBalance,
+    checkAllCashuTokensAndDeleteInvalid,
+    checkAndRefreshCashuToken,
+    checkIssuedCashuTokensAndDeleteClaimed,
+    checkSingleIssuedCashuTokenIsClaimed,
+    closeLightningInvoiceConfirmation,
+    closeLnurlWithdrawConfirmation,
+    closeMintAutoswapChangeConfirmation,
+    closePaymentMintMeltConfirmation,
+    confirmLightningInvoicePayment,
+    confirmLnurlWithdraw,
+    confirmMintAutoswapChangeConfirmation,
+    confirmPaymentMintMelt,
+    contactPayMethod,
+    defaultMintDisplay,
+    defaultMintUrl,
+    defaultMintUrlDraft,
+    deleteSpentCashuTokens,
+    deleteSpentCashuTokensIsBusy,
+    dismissWalletWarning,
+    emitCashuToken,
+    getCashuTokenMessageInfo,
+    getMintIconUrl,
+    getMintRuntime,
+    handleMintIconError,
+    handleMintIconLoad,
+    isCashuTokenKnownAny,
+    isCashuTokenStored,
+    knownLnAddressPayContact,
+    knownLnAddressPayContactPictureUrl,
+    lightningInvoiceAutoPayLimit,
+    lnAddressPayAmount,
+    lnurlWithdrawIsBusy,
+    makeNip98AuthHeader,
+    markCashuTokenIssued,
+    meltLargestForeignMintToMainMint,
+    mintInfoByUrl,
+    onPayChatPaymentRequest,
+    paidOverlayIsOpen,
+    paidOverlayTitle,
+    payCashuPaymentRequest,
+    payLightningAddressWithCashu,
+    payLightningInvoiceWithCashu,
+    paySelectedContact,
+    payWithCashuEnabled,
+    pendingCashuContactSend,
+    pendingCashuDeleteId,
+    pendingCashuTokenContactPickId,
+    pendingLightningInvoiceConfirmation,
+    pendingLnurlWithdrawConfirmation,
+    pendingMintAutoswapChangeConfirmation,
+    pendingMintDeleteUrl,
+    pendingPaymentMintMeltConfirmation,
+    postPaySaveContact,
+    refreshMintInfo,
+    requestDeleteCashuToken,
+    requestSelectedContact,
+    reserveCashuToken,
+    restoreMissingTokens,
+    returnCashuTokenToWallet,
+    saveCashuFromText,
+    sendCashuTokenToContact,
+    setCashuAutoswapEnabled,
+    setCashuDraft,
+    setCashuEmitAmount,
+    setContactPayMethod,
+    setDefaultMintUrlDraft,
+    setLightningInvoiceAutoPayLimit,
+    setLnAddressPayAmount,
+    setMintIconUrlByMint,
+    setMintInfoAll,
+    setPayWithCashuEnabled,
+    setPendingCashuDeleteId,
+    setPendingLightningInvoiceConfirmation,
+    setPendingLnurlWithdrawConfirmation,
+    setPendingMintDeleteUrl,
+    setPostPaySaveContact,
+    setTopupAmount,
+    settleBankPaymentOffer,
+    showPaidOverlay,
+    startSendCashuTokenToContact,
+    tokensRestoreIsBusy,
+    topupAmount,
+    topupInvoice,
+    topupInvoiceCashuRequest,
+    topupInvoiceError,
+    topupInvoiceIsBusy,
+    topupInvoiceQr,
+    topupInvoiceQrPayload,
+    topupMintQuote,
+    walletWarningApplies,
+    walletWarningDismissed,
+  };
+};

--- a/apps/web-app/src/app/hooks/composition/useContactsMessagingComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useContactsMessagingComposition.ts
@@ -1,0 +1,3352 @@
+import * as Evolu from "@evolu/common";
+import {
+  nip19,
+  type Event as NostrToolsEvent,
+  type UnsignedEvent,
+} from "nostr-tools";
+import React, { useMemo, useState } from "react";
+import {
+  deriveDefaultProfile,
+  omitSyntheticContactLightningAddress,
+} from "../../../derivedProfile";
+import { useEvolu, type ContactId } from "../../../evolu";
+import { navigateTo, useRouting } from "../../../hooks/useRouting";
+import { type Lang } from "../../../i18n";
+import {
+  cacheProfileAvatarFromUrl,
+  deleteCachedProfileAvatar,
+  fetchNostrProfileMetadata,
+  fetchNostrProfilePicture,
+  getNostrProfilePictureUrl,
+  isCachedProfilePictureStale,
+  loadCachedProfileAvatarObjectUrl,
+  loadCachedProfileMetadata,
+  loadCachedProfilePicture,
+  NOSTR_RELAYS,
+  saveCachedProfileMetadata,
+  saveCachedProfilePicture,
+  type NostrProfileMetadata,
+} from "../../../nostrProfile";
+import {
+  buildStatusFilterValue,
+  extractStatusFilterCurrencies,
+  isStatusFilterValue,
+  parseStatusFilterValue,
+} from "../../../nostrStatus";
+import {
+  ARCHIVED_CONTACTS_FILTER,
+  BLOCKED_NOSTR_PUBKEYS_STORAGE_KEY,
+  CONTACTS_ONBOARDING_HAS_BACKUPED_KEYS_STORAGE_KEY,
+  CONTACTS_ONBOARDING_HAS_PAID_STORAGE_KEY,
+  MAX_CONTACTS_PER_OWNER,
+  NO_GROUP_FILTER,
+} from "../../../utils/constants";
+import { formatShortNpub, getBestNostrName } from "../../../utils/formatting";
+import { normalizeNpubIdentifier } from "../../../utils/nostrNpub";
+import { setStoredPushContactNames } from "../../../utils/pushContactNamesStorage";
+import {
+  getInitialBankPaymentOfferRecipientCount,
+  safeLocalStorageGet,
+  safeLocalStorageGetJson,
+  safeLocalStorageSetJson,
+} from "../../../utils/storage";
+import { getUnknownErrorMessage } from "../../../utils/unknown";
+import { makeLocalId } from "../../../utils/validation";
+import { useIdentityOwnersComposition } from "./useIdentityOwnersComposition";
+import { useContactEditor } from "../contacts/useContactEditor";
+import { useVisibleContacts } from "../contacts/useVisibleContacts";
+import {
+  buildUnknownContactId,
+  isUnknownContactId,
+  normalizePubkeyHex,
+  readUnknownContactIdPubkey,
+} from "../messages/contactIdentity";
+import { useChatNostrSyncEffect } from "../messages/useChatNostrSyncEffect";
+import {
+  useEditChatMessage,
+  type EditChatContext,
+} from "../messages/useEditChatMessage";
+import { useInboxNotificationsSync } from "../messages/useInboxNotificationsSync";
+import { useNostrPendingFlush } from "../messages/useNostrPendingFlush";
+import {
+  useSendChatMessage,
+  type ReplyContext,
+} from "../messages/useSendChatMessage";
+import { useSendReaction } from "../messages/useSendReaction";
+import { useContactsDomain } from "../useContactsDomain";
+import { useContactsNostrPrefetchEffects } from "../useContactsNostrPrefetchEffects";
+import { useEvoluNostrBootstrapReady } from "../useEvoluNostrBootstrapReady";
+import { useFeedbackContact } from "../useFeedbackContact";
+import { useMessagesDomain } from "../useMessagesDomain";
+import { useRelayDomain } from "../useRelayDomain";
+import { findUniqueContactByLightningAddress } from "../../lib/contactIdentity";
+import { resolveContactRowOwnerLane } from "../../lib/contactOwnerLane";
+import {
+  createLinkyBankPaymentOfferEvent,
+  getLinkyBankPaymentOfferInfo,
+  getLinkyBankPaymentOfferStatusRank,
+  isLinkyBankPaymentOfferTerminalStatus,
+  LINKY_BANK_PAYMENT_OFFER_DEFAULT_RECIPIENT_COUNT,
+  LINKY_BANK_PAYMENT_OFFER_MAX_RECIPIENT_COUNT,
+  LINKY_BANK_PAYMENT_OFFER_MIN_RECIPIENT_COUNT,
+  LINKY_BANK_PAYMENT_OFFER_PHASE_TTL_SEC,
+  LINKY_BANK_PAYMENT_OFFER_RECIPIENT_STATUS_CURRENCY,
+  shouldPushLinkyBankPaymentOfferStatus,
+  type LinkyBankPaymentOfferStatus,
+} from "../../lib/bankPaymentOffer";
+import type { AppNostrPool } from "../../lib/nostrPool";
+import { getSharedAppNostrPool } from "../../lib/nostrPool";
+import {
+  publishSingleWrappedWithRetry as publishSingleWrappedWithRetryBase,
+  publishWrappedWithRetry as publishWrappedWithRetryBase,
+} from "../../lib/nostrPublishRetry";
+import { buildLinkyPaymentRequestDeclineMessage } from "../../lib/paymentRequestMessage";
+import {
+  parsePrivateImageMessage,
+  privateImagePreviewText,
+} from "../../lib/privateImageMessage";
+import {
+  wrapEventWithoutPushMarker,
+  wrapEventWithPushMarker,
+} from "../../lib/pushWrappedEvent";
+import type {
+  ContactRowLike,
+  LocalNostrMessage,
+  PaymentLogData,
+  PublishWrappedResult,
+} from "../../types/appTypes";
+
+const inMemoryNostrPictureCache = new Map<string, string | null>();
+
+const INLINE_NPUB_PATTERN =
+  /(?:nostr:)?npub1[023456789acdefghjklmnpqrstuvwxyz]+(?:@npub\.cash)?/gi;
+
+const readObjectField = (value: unknown, field: string): unknown => {
+  if (typeof value !== "object" || value === null) return undefined;
+  return Reflect.get(value, field);
+};
+
+const extractMentionedNpubs = (content: string): string[] => {
+  const matches = String(content ?? "").match(INLINE_NPUB_PATTERN);
+  if (!matches) return [];
+
+  const seen = new Set<string>();
+  const npubs: string[] = [];
+
+  for (const match of matches) {
+    const npub = normalizeNpubIdentifier(match);
+    if (!npub || seen.has(npub)) continue;
+    seen.add(npub);
+    npubs.push(npub);
+  }
+
+  return npubs;
+};
+
+const clampBankPaymentOfferRecipientCount = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return LINKY_BANK_PAYMENT_OFFER_DEFAULT_RECIPIENT_COUNT;
+  }
+
+  return Math.min(
+    LINKY_BANK_PAYMENT_OFFER_MAX_RECIPIENT_COUNT,
+    Math.max(LINKY_BANK_PAYMENT_OFFER_MIN_RECIPIENT_COUNT, Math.round(value)),
+  );
+};
+
+interface UnknownChatContact extends ContactRowLike {
+  id: string;
+  isUnknownContact: true;
+  unknownPubkeyHex: string | null;
+}
+
+export type DisplayContact = ContactRowLike & {
+  isUnknownContact?: boolean;
+  unknownPubkeyHex?: string | null;
+};
+
+interface ChatSelectedContact {
+  groupName?: string | null;
+  id: string;
+  isUnknownContact?: boolean;
+  lnAddress?: string | null;
+  name?: string | null;
+  npub?: string | null;
+  unknownPubkeyHex?: string | null;
+}
+
+const encodeUnknownNpub = (pubkeyHex: string | null): string | null => {
+  if (!pubkeyHex) return null;
+  try {
+    return nip19.npubEncode(pubkeyHex);
+  } catch {
+    return null;
+  }
+};
+
+type IdentityOwnersCompositionResult = ReturnType<
+  typeof useIdentityOwnersComposition
+>;
+type EvoluMutations = ReturnType<typeof useEvolu>;
+type NostrBootstrapParams = Parameters<typeof useEvoluNostrBootstrapReady>[0];
+
+interface UseContactsMessagingCompositionParams {
+  activeSyncedNostrIdentity: IdentityOwnersCompositionResult["activeSyncedNostrIdentity"];
+  appOwnerId: IdentityOwnersCompositionResult["appOwnerId"];
+  appOwnerIdRef: IdentityOwnersCompositionResult["appOwnerIdRef"];
+  cashuOwnerId: IdentityOwnersCompositionResult["cashuOwnerId"];
+  cashuTokensAll: NostrBootstrapParams["tokensSnapshot"];
+  contactPayBackToChatRef: React.MutableRefObject<ContactId | null>;
+  contactsOwnerId: IdentityOwnersCompositionResult["contactsOwnerId"];
+  contactsOwnerNewContactsCount: number;
+  contactsVisibleOwnerIds: IdentityOwnersCompositionResult["contactsVisibleOwnerIds"];
+  copyText: (value: string) => Promise<void>;
+  currentNpub: string | null;
+  currentNsec: string | null;
+  formatDisplayedAmountText: (amountSat: number) => string;
+  historicalOwnerSetsReady: boolean;
+  identityOwnerId: IdentityOwnersCompositionResult["identityOwnerId"];
+  insert: EvoluMutations["insert"];
+  isSeedLogin: boolean;
+  lang: Lang;
+  legacyIdentitiesOwnerId: IdentityOwnersCompositionResult["legacyIdentitiesOwnerId"];
+  legacyMessagesIdentityOwnerId: IdentityOwnersCompositionResult["legacyMessagesIdentityOwnerId"];
+  logPayStep: (step: string, data?: PaymentLogData) => void;
+  maybeShowPwaNotification: (
+    title: string,
+    body: string,
+    tag?: string,
+  ) => Promise<void>;
+  messagesOwnerId: IdentityOwnersCompositionResult["messagesOwnerId"];
+  messagesOwnerIdRef: IdentityOwnersCompositionResult["messagesOwnerIdRef"];
+  messagesVisibleOwnerIds: IdentityOwnersCompositionResult["messagesVisibleOwnerIds"];
+  metaOwnerId: IdentityOwnersCompositionResult["metaOwnerId"];
+  nostrIdentityRows: NostrBootstrapParams["identitiesSnapshot"];
+  pushToast: (message: string) => void;
+  recordContactsOwnerWrite: IdentityOwnersCompositionResult["recordContactsOwnerWrite"];
+  recordMessagesOwnerWrite: IdentityOwnersCompositionResult["recordMessagesOwnerWrite"];
+  recordTransactionsOwnerWrite: IdentityOwnersCompositionResult["recordTransactionsOwnerWrite"];
+  route: ReturnType<typeof useRouting>;
+  setContactPaymentIntent: React.Dispatch<
+    React.SetStateAction<"pay" | "request">
+  >;
+  setPayAmount: React.Dispatch<React.SetStateAction<string>>;
+  setStatus: React.Dispatch<React.SetStateAction<string | null>>;
+  syncedNostrIdentityMatchesLocal: boolean;
+  syncedNostrIdentityResolution: IdentityOwnersCompositionResult["syncedNostrIdentityResolution"];
+  t: (key: string) => string;
+  transactionsBootstrapSnapshot: NostrBootstrapParams["transactionsSnapshot"];
+  transactionsOwnerId: IdentityOwnersCompositionResult["transactionsOwnerId"];
+  update: EvoluMutations["update"];
+  upsert: EvoluMutations["upsert"];
+}
+
+export const useContactsMessagingComposition = ({
+  activeSyncedNostrIdentity,
+  appOwnerId,
+  appOwnerIdRef,
+  cashuOwnerId,
+  cashuTokensAll,
+  contactPayBackToChatRef,
+  contactsOwnerId,
+  contactsOwnerNewContactsCount,
+  contactsVisibleOwnerIds,
+  copyText,
+  currentNpub,
+  currentNsec,
+  formatDisplayedAmountText,
+  historicalOwnerSetsReady,
+  identityOwnerId,
+  insert,
+  isSeedLogin,
+  lang,
+  legacyIdentitiesOwnerId,
+  legacyMessagesIdentityOwnerId,
+  logPayStep,
+  maybeShowPwaNotification,
+  messagesOwnerId,
+  messagesOwnerIdRef,
+  messagesVisibleOwnerIds,
+  metaOwnerId,
+  nostrIdentityRows,
+  pushToast,
+  recordContactsOwnerWrite,
+  recordMessagesOwnerWrite,
+  recordTransactionsOwnerWrite,
+  route,
+  setContactPaymentIntent,
+  setPayAmount,
+  setStatus,
+  syncedNostrIdentityMatchesLocal,
+  syncedNostrIdentityResolution,
+  t,
+  transactionsBootstrapSnapshot,
+  transactionsOwnerId,
+  update,
+  upsert,
+}: UseContactsMessagingCompositionParams) => {
+  const [pendingDeleteId, setPendingDeleteId] = useState<ContactId | null>(
+    null,
+  );
+
+  const [recentlyAddedContactId, setRecentlyAddedContactId] =
+    useState<ContactId | null>(null);
+
+  const [contactsOnboardingHasPaid, setContactsOnboardingHasPaid] =
+    useState<boolean>(
+      () =>
+        safeLocalStorageGet(CONTACTS_ONBOARDING_HAS_PAID_STORAGE_KEY) === "1",
+    );
+
+  const [
+    contactsOnboardingHasBackedUpKeys,
+    setContactsOnboardingHasBackedUpKeys,
+  ] = useState<boolean>(
+    () =>
+      safeLocalStorageGet(CONTACTS_ONBOARDING_HAS_BACKUPED_KEYS_STORAGE_KEY) ===
+      "1",
+  );
+
+  const [contactAttentionById, setContactAttentionById] = useState<
+    Record<string, number>
+  >(() => ({}));
+
+  const [
+    bankPaymentOfferRecipientCount,
+    setBankPaymentOfferRecipientCountState,
+  ] = useState<number>(() =>
+    clampBankPaymentOfferRecipientCount(
+      getInitialBankPaymentOfferRecipientCount(
+        LINKY_BANK_PAYMENT_OFFER_DEFAULT_RECIPIENT_COUNT,
+      ),
+    ),
+  );
+
+  const setBankPaymentOfferRecipientCount = React.useCallback(
+    (value: number) => {
+      setBankPaymentOfferRecipientCountState(
+        clampBankPaymentOfferRecipientCount(value),
+      );
+    },
+    [],
+  );
+
+  const [chatOwnPubkeyHex, setChatOwnPubkeyHex] = useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!currentNsec) {
+      setChatOwnPubkeyHex(null);
+      return;
+    }
+
+    let cancelled = false;
+    void import("nostr-tools")
+      .then(({ getPublicKey, nip19 }) => {
+        const decoded = nip19.decode(currentNsec);
+        if (decoded.type !== "nsec" || !(decoded.data instanceof Uint8Array)) {
+          if (!cancelled) setChatOwnPubkeyHex(null);
+          return;
+        }
+        if (!cancelled) {
+          setChatOwnPubkeyHex(getPublicKey(decoded.data));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setChatOwnPubkeyHex(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentNsec]);
+
+  const [nostrPictureByNpub, setNostrPictureByNpub] = useState<
+    Record<string, string | null>
+  >(() => Object.fromEntries(inMemoryNostrPictureCache.entries()));
+
+  const [nostrStatusByNpub, setNostrStatusByNpub] = useState<
+    Record<string, string | null>
+  >({});
+
+  const avatarObjectUrlsByNpubRef = React.useRef<Map<string, string>>(
+    new Map(),
+  );
+
+  React.useEffect(() => {
+    const objectUrls = avatarObjectUrlsByNpubRef.current;
+    return () => {
+      for (const url of objectUrls.values()) {
+        if (!url.startsWith("blob:")) continue;
+        try {
+          URL.revokeObjectURL(url);
+        } catch {
+          // ignore
+        }
+      }
+      objectUrls.clear();
+      inMemoryNostrPictureCache.clear();
+    };
+  }, [currentNsec]);
+
+  const rememberBlobAvatarUrl = React.useCallback(
+    (npub: string, url: string | null): string | null => {
+      const key = String(npub ?? "").trim();
+      if (!key) return url;
+
+      const existing = avatarObjectUrlsByNpubRef.current.get(key);
+
+      if (url && url.startsWith("blob:")) {
+        if (existing && existing !== url) {
+          try {
+            URL.revokeObjectURL(existing);
+          } catch {
+            // ignore
+          }
+        }
+        avatarObjectUrlsByNpubRef.current.set(key, url);
+        return url;
+      }
+
+      if (existing && existing.startsWith("blob:")) {
+        try {
+          URL.revokeObjectURL(existing);
+        } catch {
+          // ignore
+        }
+      }
+
+      avatarObjectUrlsByNpubRef.current.delete(key);
+      return url;
+    },
+    [],
+  );
+
+  const [chatDraft, setChatDraft] = useState<string>("");
+
+  const [chatSendIsBusy, setChatSendIsBusy] = useState(false);
+
+  const [replyContext, setReplyContext] = useState<ReplyContext | null>(null);
+
+  const replyContextRef = React.useRef<ReplyContext | null>(null);
+
+  const [editContext, setEditContext] = useState<EditChatContext | null>(null);
+
+  const activeNostrMessagePublishClientIdsRef = React.useRef<Set<string>>(
+    new Set(),
+  );
+
+  const chatSeenWrapIdsRef = React.useRef<Set<string>>(new Set());
+
+  const autoAcceptedChatMessageIdsRef = React.useRef<Set<string>>(new Set());
+
+  const activeChatRouteId = route.kind === "chat" ? String(route.id ?? "") : "";
+
+  React.useEffect(() => {
+    if (route.kind === "chat") return;
+    setReplyContext(null);
+    setEditContext(null);
+  }, [route.kind]);
+
+  React.useEffect(() => {
+    if (!activeChatRouteId) return;
+    setReplyContext(null);
+    setEditContext(null);
+  }, [activeChatRouteId]);
+
+  React.useEffect(() => {
+    replyContextRef.current = replyContext;
+  }, [replyContext]);
+
+  React.useEffect(() => {
+    for (const [npub, url] of Object.entries(nostrPictureByNpub)) {
+      inMemoryNostrPictureCache.set(npub, url ?? null);
+    }
+  }, [nostrPictureByNpub]);
+
+  const chatMessagesRef = React.useRef<HTMLDivElement | null>(null);
+
+  const chatMessageElByIdRef = React.useRef<Map<string, HTMLDivElement>>(
+    new Map(),
+  );
+
+  const [bankPaymentOfferMessages, setBankPaymentOfferMessages] = useState<
+    LocalNostrMessage[]
+  >([]);
+
+  const bankPaymentOfferSpdPayloadByOfferIdRef = React.useRef<
+    Map<string, string>
+  >(new Map());
+
+  const autoSentBankDetailsOfferIdsRef = React.useRef<Set<string>>(new Set());
+
+  const bankPaymentOfferExpiryInFlightRef = React.useRef(false);
+
+  const chatDidInitialScrollForContactRef = React.useRef<string | null>(null);
+
+  const chatForceScrollToBottomRef = React.useRef(false);
+
+  const chatScrollTargetIdRef = React.useRef<string | null>(null);
+
+  const chatLastMessageCountRef = React.useRef<Record<string, number>>({});
+
+  const triggerChatScrollToBottom = React.useCallback((messageId?: string) => {
+    chatForceScrollToBottomRef.current = true;
+    if (messageId) chatScrollTargetIdRef.current = messageId;
+
+    const tryScroll = (attempt: number) => {
+      const targetId = chatScrollTargetIdRef.current;
+      if (targetId) {
+        const el = chatMessageElByIdRef.current.get(targetId);
+        if (el) {
+          el.scrollIntoView({ block: "end" });
+          return;
+        }
+      }
+
+      const c = chatMessagesRef.current;
+      if (c) c.scrollTop = c.scrollHeight;
+
+      if (attempt < 6) {
+        requestAnimationFrame(() => tryScroll(attempt + 1));
+      }
+    };
+
+    requestAnimationFrame(() => tryScroll(0));
+  }, []);
+
+  const upsertBankPaymentOfferMessage = React.useCallback(
+    (message: LocalNostrMessage) => {
+      const messageContactId = String(message.contactId ?? "").trim();
+      const messageWrapId = String(message.wrapId ?? "").trim();
+      const messageClientId = String(message.clientId ?? "").trim();
+      const messageId = String(message.id ?? "").trim();
+      const messageOfferId =
+        getLinkyBankPaymentOfferInfo(String(message.content ?? ""))?.offerId ??
+        "";
+      const messageOfferKey =
+        messageOfferId && messageContactId
+          ? `${messageContactId}:${messageOfferId}`
+          : "";
+
+      setBankPaymentOfferMessages((prev) => {
+        const existingOfferMessage = messageOfferKey
+          ? (prev.find((existing) => {
+              const existingContactId = String(existing.contactId ?? "").trim();
+              const existingOfferId = getLinkyBankPaymentOfferInfo(
+                String(existing.content ?? ""),
+              )?.offerId;
+              return (
+                `${existingContactId}:${existingOfferId ?? ""}` ===
+                messageOfferKey
+              );
+            }) ?? null)
+          : null;
+        const next = prev.filter((existing) => {
+          const existingContactId = String(existing.contactId ?? "").trim();
+          const existingOfferId = getLinkyBankPaymentOfferInfo(
+            String(existing.content ?? ""),
+          )?.offerId;
+          if (
+            messageOfferKey &&
+            `${existingContactId}:${existingOfferId ?? ""}` === messageOfferKey
+          ) {
+            return false;
+          }
+
+          const existingWrapId = String(existing.wrapId ?? "").trim();
+          const existingClientId = String(existing.clientId ?? "").trim();
+          const existingId = String(existing.id ?? "").trim();
+
+          if (messageWrapId && existingWrapId === messageWrapId) return false;
+          if (messageClientId && existingClientId === messageClientId) {
+            return false;
+          }
+          if (messageId && existingId === messageId) return false;
+          return true;
+        });
+
+        const mergedMessage = existingOfferMessage
+          ? (() => {
+              const existingInfo = getLinkyBankPaymentOfferInfo(
+                String(existingOfferMessage.content ?? ""),
+              );
+              const messageInfo = getLinkyBankPaymentOfferInfo(
+                String(message.content ?? ""),
+              );
+              const existingCreatedAt =
+                Number(existingOfferMessage.createdAtSec ?? 0) || 0;
+              const messageCreatedAt = Number(message.createdAtSec ?? 0) || 0;
+              const existingUpdatedAt =
+                existingInfo?.statusUpdatedAtSec ?? existingCreatedAt;
+              const messageUpdatedAt =
+                messageInfo?.statusUpdatedAtSec ?? messageCreatedAt;
+              const latest =
+                messageUpdatedAt > existingUpdatedAt
+                  ? message
+                  : messageUpdatedAt < existingUpdatedAt
+                    ? existingOfferMessage
+                    : messageInfo && existingInfo
+                      ? getLinkyBankPaymentOfferStatusRank(
+                          messageInfo.status,
+                        ) >=
+                        getLinkyBankPaymentOfferStatusRank(existingInfo.status)
+                        ? message
+                        : existingOfferMessage
+                      : messageCreatedAt >= existingCreatedAt
+                        ? message
+                        : existingOfferMessage;
+
+              return {
+                ...existingOfferMessage,
+                ...latest,
+                contactId: existingOfferMessage.contactId,
+                createdAtSec:
+                  existingCreatedAt && messageCreatedAt
+                    ? Math.min(existingCreatedAt, messageCreatedAt)
+                    : existingCreatedAt || messageCreatedAt,
+                direction: existingOfferMessage.direction,
+                id: messageOfferKey
+                  ? `bank-payment-offer:${messageOfferKey}`
+                  : latest.id,
+              };
+            })()
+          : messageOfferKey
+            ? {
+                ...message,
+                id: `bank-payment-offer:${messageOfferKey}`,
+              }
+            : message;
+
+        next.push(mergedMessage);
+        next.sort((a, b) => {
+          const createdA = Number(a.createdAtSec ?? 0);
+          const createdB = Number(b.createdAtSec ?? 0);
+          return createdA - createdB;
+        });
+        return next;
+      });
+    },
+    [],
+  );
+
+  const nostrInFlight = React.useRef<Set<string>>(new Set());
+
+  const nostrMetadataInFlight = React.useRef<Set<string>>(new Set());
+
+  const nostrStatusInFlight = React.useRef<Set<string>>(new Set());
+
+  const pendingUnknownContactAddRef = React.useRef<{
+    sourceContactId: string;
+    targetNpub: string;
+  } | null>(null);
+
+  const visibleMessageOwnerIds = React.useMemo(() => {
+    const ids = [
+      String(appOwnerId ?? "").trim(),
+      ...messagesVisibleOwnerIds.map((ownerId) => String(ownerId ?? "").trim()),
+    ].filter(Boolean);
+    return Array.from(new Set(ids));
+  }, [appOwnerId, messagesVisibleOwnerIds]);
+
+  const contactNameCollator = useMemo(
+    () =>
+      new Intl.Collator(lang, {
+        usage: "sort",
+        numeric: true,
+        sensitivity: "variant",
+      }),
+    [lang],
+  );
+
+  const reassignContactMessagesRef = React.useRef<
+    (fromContactId: string, toContactId: string) => number
+  >(() => 0);
+
+  const reassignContactMessages = React.useCallback(
+    (fromContactId: string, toContactId: string) =>
+      reassignContactMessagesRef.current(fromContactId, toContactId),
+    [],
+  );
+
+  const {
+    activeGroup,
+    contacts,
+    contactsSearch,
+    contactsSearchInputRef,
+    contactsSearchParts,
+    dedupeContacts,
+    dedupeContactsIsBusy,
+    groupCounts,
+    groupNames,
+    selectedContact,
+    setActiveGroup,
+    setContactsSearch,
+    ungroupedCount,
+  } = useContactsDomain({
+    appOwnerId: contactsOwnerId,
+    currentNsec,
+    isSeedLogin,
+    noGroupFilterValue: NO_GROUP_FILTER,
+    pushToast,
+    reassignContactMessages,
+    route,
+    t,
+    update,
+    upsert,
+    visibleOwnerIds: contactsVisibleOwnerIds,
+  });
+
+  const contactsLatestRef = React.useRef(contacts);
+
+  contactsLatestRef.current = contacts;
+
+  React.useEffect(() => {
+    const records = [];
+
+    for (const contact of contacts) {
+      const name = String(contact.name ?? "").trim();
+      const npub = normalizeNpubIdentifier(contact.npub);
+      if (!name || !npub) continue;
+
+      try {
+        const decoded = nip19.decode(npub);
+        if (decoded.type !== "npub" || typeof decoded.data !== "string") {
+          continue;
+        }
+
+        const pubkey = decoded.data.trim();
+        if (!pubkey) continue;
+        records.push({ name, npub, pubkey });
+      } catch {
+        // ignore invalid contact npubs
+      }
+    }
+
+    void setStoredPushContactNames(records);
+  }, [contacts]);
+
+  const activeContactsOwnerContactCount = contactsOwnerNewContactsCount;
+
+  const {
+    appendLocalNostrMessage,
+    appendLocalNostrReaction,
+    chatMessages,
+    chatMessagesLatestRef,
+    enqueuePendingPayment,
+    knownNostrMessageIdentityIndex,
+    lastMessageByContactId,
+    nostrMessageWrapIdsRef,
+    nostrMessagesLatestRef,
+    nostrMessagesLocal,
+    nostrMessagesRecent,
+    nostrReactionWrapIdsRef,
+    nostrReactionsLatestRef,
+    nostrReactionsLocal,
+    pendingPayments,
+    reactionsByMessageId,
+    reassignLocalNostrMessagesContactId,
+    removeLocalNostrMessagesByContactId,
+    removePendingPayment,
+    softDeleteLocalNostrReaction,
+    softDeleteLocalNostrReactionsByWrapIds,
+    updateLocalNostrMessage,
+    updateLocalNostrReaction,
+  } = useMessagesDomain({
+    appOwnerId,
+    appOwnerIdRef,
+    chatForceScrollToBottomRef,
+    chatMessagesRef,
+    messagesOwnerId,
+    messagesOwnerIdRef,
+    recordMessagesOwnerWrite,
+    route,
+    visibleMessageOwnerIds,
+  });
+
+  reassignContactMessagesRef.current = reassignLocalNostrMessagesContactId;
+
+  const pendingArchivedContactThreadIdsRef = React.useRef(
+    new Map<string, string>(),
+  );
+
+  const evoluOwnersReadyForNostr = isSeedLogin
+    ? Boolean(
+        cashuOwnerId &&
+        contactsOwnerId &&
+        identityOwnerId &&
+        legacyIdentitiesOwnerId &&
+        legacyMessagesIdentityOwnerId &&
+        messagesOwnerId &&
+        metaOwnerId &&
+        transactionsOwnerId,
+      ) && historicalOwnerSetsReady
+    : Boolean(appOwnerId);
+
+  const evoluNostrOwnerKey = React.useMemo(() => {
+    if (!currentNpub || !evoluOwnersReadyForNostr) return "";
+
+    return [
+      currentNpub,
+      appOwnerId,
+      cashuOwnerId,
+      contactsOwnerId,
+      identityOwnerId,
+      legacyIdentitiesOwnerId,
+      legacyMessagesIdentityOwnerId,
+      messagesOwnerId,
+      metaOwnerId,
+      transactionsOwnerId,
+    ]
+      .map((value) => String(value ?? "").trim())
+      .filter(Boolean)
+      .join("|");
+  }, [
+    appOwnerId,
+    cashuOwnerId,
+    contactsOwnerId,
+    currentNpub,
+    evoluOwnersReadyForNostr,
+    identityOwnerId,
+    legacyIdentitiesOwnerId,
+    legacyMessagesIdentityOwnerId,
+    messagesOwnerId,
+    metaOwnerId,
+    transactionsOwnerId,
+  ]);
+
+  const nostrIdentityBootstrapReady =
+    Boolean(activeSyncedNostrIdentity) &&
+    !syncedNostrIdentityResolution.shouldMigrateLegacyIdentity &&
+    syncedNostrIdentityMatchesLocal;
+
+  const [
+    missingSyncedIdentityFallbackKey,
+    setMissingSyncedIdentityFallbackKey,
+  ] = React.useState("");
+
+  React.useEffect(() => {
+    if (!isSeedLogin || !evoluNostrOwnerKey || activeSyncedNostrIdentity) {
+      setMissingSyncedIdentityFallbackKey("");
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setMissingSyncedIdentityFallbackKey(evoluNostrOwnerKey);
+    }, 8_000);
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [activeSyncedNostrIdentity, evoluNostrOwnerKey, isSeedLogin]);
+
+  const identityBootstrapReady = isSeedLogin
+    ? nostrIdentityBootstrapReady ||
+      missingSyncedIdentityFallbackKey === evoluNostrOwnerKey
+    : true;
+
+  const nostrBootstrapReady = useEvoluNostrBootstrapReady({
+    contactsSnapshot: contacts,
+    enabled: Boolean(currentNsec),
+    identitiesSnapshot: nostrIdentityRows,
+    identityReady: identityBootstrapReady,
+    messagesSnapshot: nostrMessagesLocal,
+    ownerKey: evoluNostrOwnerKey,
+    reactionsSnapshot: nostrReactionsLocal,
+    tokensSnapshot: cashuTokensAll,
+    transactionsSnapshot: transactionsBootstrapSnapshot,
+  });
+
+  const {
+    canSaveNewRelay,
+    connectedRelayCount,
+    newRelayUrl,
+    nostrFetchRelays,
+    nostrRelayOverallStatus,
+    pendingRelayDeleteUrl,
+    relayStatusByUrl,
+    relayUrls,
+    requestDeleteSelectedRelay,
+    saveNewRelay,
+    selectedRelayUrl,
+    setNewRelayUrl,
+  } = useRelayDomain({
+    currentNpub,
+    currentNsec,
+    networkEnabled: nostrBootstrapReady,
+    route,
+    setStatus,
+    t,
+  });
+
+  const [contactNewPrefill, setContactNewPrefill] = React.useState<null | {
+    lnAddress: string;
+    npub: string | null;
+    suggestedName: string | null;
+  }>(null);
+
+  useContactsNostrPrefetchEffects({
+    appOwnerId: contactsOwnerId,
+    canFetchFromNostr: nostrBootstrapReady,
+    contacts,
+    nostrFetchRelays,
+    nostrInFlight,
+    nostrMetadataInFlight,
+    nostrStatusByNpub,
+    nostrStatusInFlight,
+    rememberBlobAvatarUrl,
+    routeKind: route.kind,
+    setNostrPictureByNpub,
+    setNostrStatusByNpub,
+    update,
+    visibleOwnerIds: contactsVisibleOwnerIds,
+  });
+
+  const [unknownNameByNpub, setUnknownNameByNpub] = useState<
+    Record<string, string | null>
+  >({});
+
+  const buildUnknownDisplayName = React.useCallback(
+    (name: string | null, npub: string | null) => {
+      const prefix = t("unknownContactNamePrefix");
+      const normalizedName = String(name ?? "").trim();
+      const fallback = npub ? formatShortNpub(npub) : t("unknownContactTitle");
+      return `${prefix} ${normalizedName || fallback}`.trim();
+    },
+    [t],
+  );
+
+  const buildSavedContactName = React.useCallback(
+    (name: string | null, npub: string | null) => {
+      const normalizedName = String(name ?? "").trim();
+      return (
+        normalizedName ||
+        (npub ? formatShortNpub(npub) : t("unknownContactTitle"))
+      );
+    },
+    [t],
+  );
+
+  const unknownContacts = React.useMemo<UnknownChatContact[]>(() => {
+    const blockedPubkeys = new Set(
+      safeLocalStorageGetJson(BLOCKED_NOSTR_PUBKEYS_STORAGE_KEY, [])
+        .map((entry) => normalizePubkeyHex(entry))
+        .filter((entry): entry is string => Boolean(entry)),
+    );
+
+    const unknownById = new Map<string, UnknownChatContact>();
+
+    for (const [contactId, lastMessage] of lastMessageByContactId.entries()) {
+      const normalizedContactId = String(contactId ?? "").trim();
+      if (!normalizedContactId) continue;
+      if (!isUnknownContactId(normalizedContactId)) continue;
+
+      const candidatePubkeyFromLast = normalizePubkeyHex(lastMessage.pubkey);
+      const candidatePubkeyFromId =
+        readUnknownContactIdPubkey(normalizedContactId);
+      const candidatePubkeyFromThread = nostrMessagesLocal
+        .filter(
+          (message) =>
+            String(message.contactId ?? "").trim() === normalizedContactId,
+        )
+        .map((message) => normalizePubkeyHex(message.pubkey))
+        .find((pubkey) => {
+          if (!pubkey) return false;
+          if (blockedPubkeys.has(pubkey)) return false;
+          const ownPubkey = normalizePubkeyHex(chatOwnPubkeyHex);
+          if (ownPubkey && ownPubkey === pubkey) return false;
+          return true;
+        });
+
+      const unknownPubkeyHex =
+        candidatePubkeyFromId ??
+        candidatePubkeyFromThread ??
+        candidatePubkeyFromLast ??
+        null;
+      if (unknownPubkeyHex && blockedPubkeys.has(unknownPubkeyHex)) continue;
+      const ownPubkey = normalizePubkeyHex(chatOwnPubkeyHex);
+      if (unknownPubkeyHex && ownPubkey && unknownPubkeyHex === ownPubkey) {
+        continue;
+      }
+
+      const unknownNpub = encodeUnknownNpub(unknownPubkeyHex);
+      const bestName = unknownNpub
+        ? (unknownNameByNpub[unknownNpub] ?? null)
+        : null;
+
+      unknownById.set(normalizedContactId, {
+        id: normalizedContactId,
+        name: buildUnknownDisplayName(bestName, unknownNpub),
+        npub: unknownNpub,
+        lnAddress: null,
+        groupName: null,
+        isUnknownContact: true,
+        unknownPubkeyHex,
+      });
+    }
+
+    return Array.from(unknownById.values());
+  }, [
+    buildUnknownDisplayName,
+    chatOwnPubkeyHex,
+    lastMessageByContactId,
+    nostrMessagesLocal,
+    unknownNameByNpub,
+  ]);
+
+  React.useEffect(() => {
+    const activeContacts = contacts.filter((contact) => {
+      const archivedAtSec = Number(contact.archivedAtSec ?? 0);
+      return !Number.isFinite(archivedAtSec) || archivedAtSec <= 0;
+    });
+
+    for (const unknownContact of unknownContacts) {
+      const unknownContactId = String(unknownContact.id ?? "").trim();
+      const unknownNpub = normalizeNpubIdentifier(unknownContact.npub);
+      if (!unknownContactId || !unknownNpub) continue;
+
+      let knownContact = activeContacts.find((contact) => {
+        const knownContactId = String(contact.id ?? "").trim();
+        if (!knownContactId || knownContactId === unknownContactId) {
+          return false;
+        }
+        return normalizeNpubIdentifier(contact.npub) === unknownNpub;
+      });
+
+      let matchedByLightningAddress = false;
+      let matchedMetadata: NostrProfileMetadata | null = null;
+      if (!knownContact) {
+        matchedMetadata =
+          loadCachedProfileMetadata(unknownNpub)?.metadata ?? null;
+        const profileLightningAddress = matchedMetadata
+          ? omitSyntheticContactLightningAddress(
+              String(matchedMetadata.lud16 ?? "").trim() ||
+                String(matchedMetadata.lud06 ?? "").trim(),
+              unknownNpub,
+            )
+          : "";
+        const lightningContact = findUniqueContactByLightningAddress(
+          activeContacts,
+          profileLightningAddress,
+        );
+        if (lightningContact) {
+          knownContact = lightningContact;
+          matchedByLightningAddress = true;
+        }
+      }
+
+      const knownContactId = String(knownContact?.id ?? "").trim();
+      if (!knownContactId) continue;
+
+      if (matchedByLightningAddress && knownContact) {
+        const bestName = matchedMetadata
+          ? getBestNostrName(matchedMetadata)
+          : null;
+        const parsedNpub = Evolu.NonEmptyString1000.fromUnknown(unknownNpub);
+        if (!parsedNpub.ok) continue;
+        const parsedName = bestName
+          ? Evolu.NonEmptyString1000.fromUnknown(bestName)
+          : null;
+        const ownerId =
+          resolveContactRowOwnerLane(knownContact, contactsVisibleOwnerIds) ??
+          contactsOwnerId;
+        const payload = {
+          id: knownContact.id,
+          npub: parsedNpub.value,
+          ...(!String(knownContact.name ?? "").trim() && parsedName?.ok
+            ? { name: parsedName.value }
+            : {}),
+        };
+        const result = ownerId
+          ? update("contact", payload, { ownerId })
+          : update("contact", payload);
+        if (!result.ok) continue;
+      }
+
+      reassignLocalNostrMessagesContactId(unknownContactId, knownContactId);
+      setContactAttentionById((prev) => {
+        if (prev[unknownContactId] === undefined) return prev;
+        const next = { ...prev };
+        delete next[unknownContactId];
+        return next;
+      });
+    }
+  }, [
+    contacts,
+    contactsOwnerId,
+    contactsVisibleOwnerIds,
+    reassignLocalNostrMessagesContactId,
+    setContactAttentionById,
+    unknownContacts,
+    update,
+  ]);
+
+  const unknownContactNpubs = React.useMemo(() => {
+    const seen = new Set<string>();
+    const npubs: string[] = [];
+
+    for (const contact of unknownContacts) {
+      const npub = normalizeNpubIdentifier(contact.npub);
+      if (!npub) continue;
+      if (seen.has(npub)) continue;
+      seen.add(npub);
+      npubs.push(npub);
+    }
+
+    return npubs;
+  }, [unknownContacts]);
+
+  const chatMentionedNpubs = React.useMemo(() => {
+    const seen = new Set<string>();
+    const npubs: string[] = [];
+
+    for (const message of chatMessages) {
+      for (const npub of extractMentionedNpubs(String(message.content ?? ""))) {
+        if (seen.has(npub)) continue;
+        seen.add(npub);
+        npubs.push(npub);
+      }
+    }
+
+    return npubs;
+  }, [chatMessages]);
+
+  const prefetchedMessageNpubs = React.useMemo(() => {
+    const seen = new Set<string>();
+    const npubs: string[] = [];
+
+    for (const npub of unknownContactNpubs) {
+      if (seen.has(npub)) continue;
+      seen.add(npub);
+      npubs.push(npub);
+    }
+
+    for (const npub of chatMentionedNpubs) {
+      if (seen.has(npub)) continue;
+      seen.add(npub);
+      npubs.push(npub);
+    }
+
+    return npubs;
+  }, [chatMentionedNpubs, unknownContactNpubs]);
+
+  React.useEffect(() => {
+    const controller = new AbortController();
+    let cancelled = false;
+
+    const run = async () => {
+      for (const npub of prefetchedMessageNpubs) {
+        if (unknownNameByNpub[npub] !== undefined) continue;
+
+        const cached = loadCachedProfileMetadata(npub);
+        if (cached) {
+          const cachedName = cached.metadata
+            ? getBestNostrName(cached.metadata)
+            : null;
+          if (!cancelled) {
+            setUnknownNameByNpub((prev) =>
+              prev[npub] !== undefined ? prev : { ...prev, [npub]: cachedName },
+            );
+          }
+          continue;
+        }
+
+        if (!nostrBootstrapReady) continue;
+
+        if (nostrMetadataInFlight.current.has(npub)) continue;
+        nostrMetadataInFlight.current.add(npub);
+
+        try {
+          const metadata = await fetchNostrProfileMetadata(npub, {
+            signal: controller.signal,
+            relays: nostrFetchRelays,
+          });
+          saveCachedProfileMetadata(npub, metadata);
+          if (cancelled) return;
+          setUnknownNameByNpub((prev) => ({
+            ...prev,
+            [npub]: metadata ? getBestNostrName(metadata) : null,
+          }));
+        } catch {
+          saveCachedProfileMetadata(npub, null);
+          if (cancelled) return;
+          setUnknownNameByNpub((prev) => ({
+            ...prev,
+            [npub]: null,
+          }));
+        } finally {
+          nostrMetadataInFlight.current.delete(npub);
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [
+    nostrBootstrapReady,
+    nostrFetchRelays,
+    nostrMetadataInFlight,
+    prefetchedMessageNpubs,
+    unknownNameByNpub,
+  ]);
+
+  React.useEffect(() => {
+    const controller = new AbortController();
+    let cancelled = false;
+
+    const run = async () => {
+      for (const npub of prefetchedMessageNpubs) {
+        const cached = loadCachedProfilePicture(npub);
+        const shouldRefreshCachedPicture = isCachedProfilePictureStale(cached);
+
+        if (cached) {
+          setNostrPictureByNpub((prev) =>
+            prev[npub] === cached.url ? prev : { ...prev, [npub]: cached.url },
+          );
+        }
+
+        try {
+          const blobUrl = await loadCachedProfileAvatarObjectUrl(npub);
+          if (cancelled) return;
+          if (blobUrl) {
+            setNostrPictureByNpub((prev) => ({
+              ...prev,
+              [npub]: rememberBlobAvatarUrl(npub, blobUrl),
+            }));
+            if (!shouldRefreshCachedPicture) continue;
+          }
+        } catch {
+          // ignore
+        }
+
+        if (cached && !shouldRefreshCachedPicture) continue;
+
+        if (!nostrBootstrapReady) continue;
+
+        if (nostrInFlight.current.has(npub)) continue;
+        nostrInFlight.current.add(npub);
+
+        try {
+          if (cached && shouldRefreshCachedPicture) {
+            const metadata = await fetchNostrProfileMetadata(npub, {
+              signal: controller.signal,
+              relays: nostrFetchRelays,
+            });
+            if (cancelled) return;
+            if (!metadata) continue;
+
+            saveCachedProfileMetadata(npub, metadata);
+            const refreshedUrl = getNostrProfilePictureUrl(metadata);
+            if (refreshedUrl) {
+              saveCachedProfilePicture(npub, refreshedUrl);
+              const blobUrl = await cacheProfileAvatarFromUrl(
+                npub,
+                refreshedUrl,
+                {
+                  signal: controller.signal,
+                },
+              );
+              if (cancelled) return;
+              setNostrPictureByNpub((prev) => ({
+                ...prev,
+                [npub]: rememberBlobAvatarUrl(npub, blobUrl || refreshedUrl),
+              }));
+            } else {
+              saveCachedProfilePicture(npub, null);
+              void deleteCachedProfileAvatar(npub);
+              rememberBlobAvatarUrl(npub, null);
+              setNostrPictureByNpub((prev) => ({
+                ...prev,
+                [npub]: null,
+              }));
+            }
+          } else {
+            const url = await fetchNostrProfilePicture(npub, {
+              signal: controller.signal,
+              relays: nostrFetchRelays,
+            });
+            saveCachedProfilePicture(npub, url);
+            if (cancelled) return;
+
+            if (url) {
+              const blobUrl = await cacheProfileAvatarFromUrl(npub, url, {
+                signal: controller.signal,
+              });
+              if (cancelled) return;
+              setNostrPictureByNpub((prev) => ({
+                ...prev,
+                [npub]: rememberBlobAvatarUrl(npub, blobUrl || url),
+              }));
+            } else {
+              setNostrPictureByNpub((prev) => {
+                const existing = prev[npub];
+                if (typeof existing === "string" && existing.trim())
+                  return prev;
+                if (existing === null) return prev;
+                return { ...prev, [npub]: null };
+              });
+            }
+          }
+        } catch {
+          if (cancelled) return;
+          if (!cached) {
+            saveCachedProfilePicture(npub, null);
+            setNostrPictureByNpub((prev) => {
+              const existing = prev[npub];
+              if (typeof existing === "string" && existing.trim()) return prev;
+              if (existing === null) return prev;
+              return { ...prev, [npub]: null };
+            });
+          }
+        } finally {
+          nostrInFlight.current.delete(npub);
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [
+    nostrBootstrapReady,
+    nostrFetchRelays,
+    nostrInFlight,
+    prefetchedMessageNpubs,
+    rememberBlobAvatarUrl,
+    setNostrPictureByNpub,
+  ]);
+
+  const unknownContactById = React.useMemo(() => {
+    const byId = new Map<string, UnknownChatContact>();
+    for (const contact of unknownContacts) {
+      const id = String(contact.id ?? "").trim();
+      if (!id) continue;
+      byId.set(id, contact);
+    }
+    return byId;
+  }, [unknownContacts]);
+
+  const selectedChatContact = React.useMemo<ChatSelectedContact | null>(() => {
+    if (route.kind !== "chat" && route.kind !== "bankPaymentOffer") return null;
+
+    const chatId = String(
+      route.kind === "chat" ? route.id : route.chatId,
+    ).trim();
+    if (!chatId) return null;
+
+    const source = selectedContact ?? unknownContactById.get(chatId) ?? null;
+    if (!source) return null;
+
+    const normalizedId = String(source.id ?? "").trim();
+    if (!normalizedId) return null;
+
+    const normalizedNpub = normalizeNpubIdentifier(source.npub);
+    const normalizedUnknownPubkeyHex = normalizePubkeyHex(
+      readObjectField(source, "unknownPubkeyHex"),
+    );
+    const sourceGroupName = String(source.groupName ?? "").trim();
+    const isUnknownContact =
+      readObjectField(source, "isUnknownContact") === true;
+
+    return {
+      id: normalizedId,
+      ...(sourceGroupName ? { groupName: sourceGroupName } : {}),
+      ...(source.name !== undefined
+        ? { name: String(source.name ?? "").trim() || null }
+        : {}),
+      ...(source.lnAddress !== undefined
+        ? { lnAddress: String(source.lnAddress ?? "").trim() || null }
+        : {}),
+      ...(normalizedNpub ? { npub: normalizedNpub } : {}),
+      ...(normalizedUnknownPubkeyHex
+        ? { unknownPubkeyHex: normalizedUnknownPubkeyHex }
+        : {}),
+      ...(isUnknownContact ? { isUnknownContact: true } : {}),
+    };
+  }, [route, selectedContact, unknownContactById]);
+
+  const displayContacts = React.useMemo<DisplayContact[]>(() => {
+    return [...contacts, ...unknownContacts];
+  }, [contacts, unknownContacts]);
+
+  const displayContactById = React.useMemo(() => {
+    const byId = new Map<string, DisplayContact>();
+    for (const contact of displayContacts) {
+      const id = String(contact.id ?? "").trim();
+      if (!id) continue;
+      byId.set(id, contact);
+    }
+    return byId;
+  }, [displayContacts]);
+
+  const displayContactsSearchData = React.useMemo(() => {
+    return displayContacts.map((contact) => {
+      const idKey = String(contact.id ?? "").trim();
+      const groupName = String(contact.groupName ?? "").trim();
+      const normalizedNpub = normalizeNpubIdentifier(contact.npub);
+      const statusFilterValues = normalizedNpub
+        ? extractStatusFilterCurrencies(nostrStatusByNpub[normalizedNpub])
+        : [];
+      const haystack = [
+        contact.name,
+        contact.npub,
+        contact.lnAddress,
+        contact.groupName,
+        contact.unknownPubkeyHex,
+        ...statusFilterValues,
+      ]
+        .map((value) =>
+          String(value ?? "")
+            .trim()
+            .toLowerCase(),
+        )
+        .filter(Boolean)
+        .join(" ");
+
+      return {
+        contact,
+        idKey,
+        groupName,
+        haystack,
+        statusFilterValues,
+      };
+    });
+  }, [displayContacts, nostrStatusByNpub]);
+
+  const { statusFilterCounts, statusFilterCurrencies } = React.useMemo(() => {
+    const currencyCounts = new Map<string, number>();
+
+    for (const contact of displayContacts) {
+      const normalizedNpub = normalizeNpubIdentifier(contact.npub);
+      if (!normalizedNpub) continue;
+
+      for (const currency of extractStatusFilterCurrencies(
+        nostrStatusByNpub[normalizedNpub],
+      )) {
+        currencyCounts.set(currency, (currencyCounts.get(currency) ?? 0) + 1);
+      }
+    }
+
+    const currencies = [...currencyCounts.entries()]
+      .sort((left, right) => {
+        if (right[1] !== left[1]) return right[1] - left[1];
+        return left[0].localeCompare(right[0]);
+      })
+      .map(([currency]) => currency);
+    return {
+      statusFilterCounts: currencyCounts,
+      statusFilterCurrencies: currencies,
+    };
+  }, [displayContacts, nostrStatusByNpub]);
+
+  const contactFilterOptions = React.useMemo(() => {
+    const options: Array<{ count: number; label: string; value: string }> = [];
+    if (ungroupedCount > 0) {
+      options.push({
+        count: ungroupedCount,
+        label: t("noGroup"),
+        value: NO_GROUP_FILTER,
+      });
+    }
+    const archivedCount = displayContacts.filter(
+      (contact) => Number(contact.archivedAtSec ?? 0) > 0,
+    ).length;
+    options.push({
+      count: archivedCount,
+      label: t("archiveFilter"),
+      value: ARCHIVED_CONTACTS_FILTER,
+    });
+    for (const groupName of groupNames) {
+      options.push({
+        count: groupCounts.get(groupName) ?? 0,
+        label: groupName,
+        value: groupName,
+      });
+    }
+    for (const currency of statusFilterCurrencies) {
+      options.push({
+        count: statusFilterCounts.get(currency) ?? 0,
+        label: currency,
+        value: buildStatusFilterValue(currency),
+      });
+    }
+    return options.sort((left, right) => {
+      if (right.count !== left.count) return right.count - left.count;
+      return left.label.localeCompare(right.label);
+    });
+  }, [
+    displayContacts,
+    groupCounts,
+    groupNames,
+    statusFilterCounts,
+    statusFilterCurrencies,
+    t,
+    ungroupedCount,
+  ]);
+
+  React.useEffect(() => {
+    if (activeGroup === ARCHIVED_CONTACTS_FILTER) return;
+    if (!isStatusFilterValue(activeGroup)) return;
+
+    const selectedCurrency = parseStatusFilterValue(activeGroup);
+    if (!selectedCurrency) {
+      setActiveGroup(null);
+      return;
+    }
+
+    if (!statusFilterCurrencies.includes(selectedCurrency)) {
+      setActiveGroup(null);
+    }
+  }, [activeGroup, setActiveGroup, statusFilterCurrencies]);
+
+  const visibleContacts = useVisibleContacts<DisplayContact>({
+    activeGroup,
+    contactAttentionById,
+    contactNameCollator,
+    contactsSearchData: displayContactsSearchData,
+    contactsSearchParts,
+    lastMessageByContactId,
+    noGroupFilterValue: NO_GROUP_FILTER,
+    pinnedContactId: recentlyAddedContactId,
+  });
+
+  const bankPaymentOfferContacts = React.useMemo(() => {
+    const sortedContacts = [
+      ...visibleContacts.pinned,
+      ...visibleContacts.conversations,
+      ...visibleContacts.others,
+    ];
+    return sortedContacts.flatMap((contact) => {
+      const normalizedNpub = normalizeNpubIdentifier(contact.npub);
+      if (!normalizedNpub) return [];
+      if (
+        !extractStatusFilterCurrencies(
+          nostrStatusByNpub[normalizedNpub],
+        ).includes(LINKY_BANK_PAYMENT_OFFER_RECIPIENT_STATUS_CURRENCY)
+      ) {
+        return [];
+      }
+
+      return [
+        {
+          ...contact,
+          pictureUrl: nostrPictureByNpub[normalizedNpub] ?? null,
+        },
+      ];
+    });
+  }, [
+    nostrPictureByNpub,
+    nostrStatusByNpub,
+    visibleContacts.pinned,
+    visibleContacts.conversations,
+    visibleContacts.others,
+  ]);
+
+  const {
+    addNewContactFromIdentifier,
+    addNewContactFromSearchResult,
+    clearContactForm,
+    contactEditsSavable,
+    contactSuggestions,
+    editingId,
+    form,
+    handleSaveContact,
+    isSavingContact,
+    openScannedContactPendingNpubRef,
+    refreshContactFromNostr,
+    resetEditedContactFieldFromNostr,
+    searchNewContact,
+    setForm,
+  } = useContactEditor({
+    activeOwnerContactsCount: activeContactsOwnerContactCount,
+    appOwnerId: contactsOwnerId,
+    contactNewPrefill,
+    contacts,
+    currentNpub,
+    insert,
+    nostrFetchRelays,
+    recordTransactionsOwnerWrite,
+    route,
+    selectedContact,
+    setContactNewPrefill,
+    setPendingDeleteId,
+    setRecentlyAddedContactId,
+    recordContactsOwnerWrite,
+    setStatus,
+    t,
+    transactionsOwnerId,
+    update,
+    upsert,
+  });
+
+  const closeContactDetail = React.useCallback(() => {
+    clearContactForm();
+    setPendingDeleteId(null);
+    navigateTo({ route: "contacts" });
+  }, [clearContactForm]);
+
+  const openNewContactPage = React.useCallback(() => {
+    if (activeContactsOwnerContactCount >= MAX_CONTACTS_PER_OWNER) {
+      const message = t("contactsLimitReached").replace(
+        "{max}",
+        String(MAX_CONTACTS_PER_OWNER),
+      );
+      pushToast(message);
+      return;
+    }
+
+    setPendingDeleteId(null);
+    setPayAmount("");
+    clearContactForm();
+    const prefill = contactNewPrefill;
+    setContactNewPrefill(null);
+    if (prefill) {
+      setForm({
+        name: String(prefill.suggestedName ?? ""),
+        npub: String(prefill.npub ?? ""),
+        lnAddress: String(prefill.lnAddress ?? ""),
+        group: "",
+      });
+    }
+    navigateTo({ route: "contactNew" });
+  }, [
+    activeContactsOwnerContactCount,
+    clearContactForm,
+    contactNewPrefill,
+    pushToast,
+    setContactNewPrefill,
+    setForm,
+    t,
+  ]);
+
+  const canAddContact =
+    activeContactsOwnerContactCount < MAX_CONTACTS_PER_OWNER;
+
+  const publishWrappedWithRetry = React.useCallback(
+    async (
+      pool: AppNostrPool,
+      relays: string[],
+      wrapForMe: NostrToolsEvent,
+      wrapForContact: NostrToolsEvent,
+    ): Promise<PublishWrappedResult> => {
+      return await publishWrappedWithRetryBase({
+        pool,
+        relays,
+        wrapForMe,
+        wrapForContact,
+      });
+    },
+    [],
+  );
+
+  const publishSingleWrappedWithRetry = React.useCallback(
+    async (
+      pool: AppNostrPool,
+      relays: string[],
+      event: NostrToolsEvent,
+    ): Promise<{ anySuccess: boolean; error: string | null }> => {
+      return await publishSingleWrappedWithRetryBase({
+        event,
+        pool,
+        relays,
+      });
+    },
+    [],
+  );
+
+  const requestBankPaymentOffer = React.useCallback(
+    async (args: {
+      amountSat?: unknown;
+      amountText: string;
+      contacts: readonly { id?: unknown; name?: unknown; npub?: unknown }[];
+      spdPayload?: unknown;
+    }): Promise<boolean> => {
+      const amountSatRaw = Number(args.amountSat ?? 0);
+      const amountSat =
+        Number.isFinite(amountSatRaw) && amountSatRaw > 0
+          ? Math.round(amountSatRaw)
+          : null;
+      const amountText = String(args.amountText ?? "").trim();
+      const spdPayload = String(args.spdPayload ?? "").trim();
+      if (!amountText) {
+        setStatus(t("spdPaymentOfferMissingAmount"));
+        return false;
+      }
+      if (args.contacts.length === 0) {
+        setStatus(t("spdPaymentOfferFailed"));
+        return false;
+      }
+      if (!currentNsec) {
+        setStatus(t("profileMissingNpub"));
+        return false;
+      }
+
+      try {
+        const { getPublicKey } = await import("nostr-tools");
+        const decodedMe = nip19.decode(currentNsec);
+        if (
+          decodedMe.type !== "nsec" ||
+          !(decodedMe.data instanceof Uint8Array)
+        ) {
+          throw new Error("invalid nsec");
+        }
+        const privBytes = decodedMe.data;
+        const myPubHex = getPublicKey(privBytes);
+
+        const recipients: {
+          contactId: string;
+          contactPubHex: string;
+        }[] = [];
+        for (const contact of args.contacts) {
+          const contactId = String(contact.id ?? "").trim();
+          const contactNpub = normalizeNpubIdentifier(contact.npub);
+          if (!contactId || !contactNpub) continue;
+
+          const decodedContact = nip19.decode(contactNpub);
+          if (
+            decodedContact.type !== "npub" ||
+            typeof decodedContact.data !== "string"
+          ) {
+            continue;
+          }
+          const contactPubHex = decodedContact.data.trim();
+          if (!contactPubHex) continue;
+          recipients.push({ contactId, contactPubHex });
+        }
+
+        if (recipients.length === 0) {
+          setStatus(t("chatMissingContactNpub"));
+          return false;
+        }
+
+        const offerId = makeLocalId();
+        if (spdPayload) {
+          bankPaymentOfferSpdPayloadByOfferIdRef.current.set(
+            offerId,
+            spdPayload,
+          );
+        }
+
+        const pool = await getSharedAppNostrPool();
+        let sentCount = 0;
+
+        for (const recipient of recipients) {
+          const clientId = makeLocalId();
+          const baseEvent = createLinkyBankPaymentOfferEvent({
+            amountSat,
+            amountText,
+            clientId,
+            createdAt: Math.ceil(Date.now() / 1e3),
+            offerId,
+            offererPublicKey: myPubHex,
+            recipientPublicKey: recipient.contactPubHex,
+            senderPublicKey: myPubHex,
+            status: "offered",
+          });
+
+          const wrapForMe = wrapEventWithoutPushMarker(
+            baseEvent,
+            privBytes,
+            myPubHex,
+          );
+          const wrapForContact = wrapEventWithPushMarker(
+            baseEvent,
+            privBytes,
+            recipient.contactPubHex,
+          );
+
+          const publishOutcome = await publishWrappedWithRetry(
+            pool,
+            NOSTR_RELAYS,
+            wrapForMe,
+            wrapForContact,
+          );
+
+          if (!publishOutcome.anySuccess) continue;
+          sentCount += 1;
+
+          const messageWrapId =
+            String(wrapForMe.id ?? "").trim() ||
+            String(wrapForContact.id ?? "").trim() ||
+            `bank-payment-offer:${clientId}`;
+          upsertBankPaymentOfferMessage({
+            clientId,
+            contactId: recipient.contactId,
+            content: baseEvent.content,
+            createdAtSec: baseEvent.created_at,
+            direction: "out",
+            id: `bank-payment-offer:${recipient.contactId}:${offerId}`,
+            localOnly: true,
+            pubkey: myPubHex,
+            rumorId: null,
+            status: "sent",
+            wrapId: messageWrapId,
+          });
+        }
+
+        if (sentCount === 0) {
+          setStatus(t("spdPaymentOfferFailed"));
+          return false;
+        }
+
+        return true;
+      } catch (error) {
+        setStatus(
+          `${t("errorPrefix")}: ${getUnknownErrorMessage(error, "publish failed")}`,
+        );
+        return false;
+      }
+    },
+    [
+      currentNsec,
+      publishWrappedWithRetry,
+      setStatus,
+      t,
+      upsertBankPaymentOfferMessage,
+    ],
+  );
+
+  const respondToBankPaymentOffer = React.useCallback(
+    async (
+      message: LocalNostrMessage,
+      nextStatus: Exclude<LinkyBankPaymentOfferStatus, "offered">,
+      options?: { spdPayload?: string | null; withPush?: boolean },
+    ): Promise<boolean> => {
+      const offerInfo = getLinkyBankPaymentOfferInfo(
+        String(message.content ?? ""),
+      );
+      if (!offerInfo) {
+        setStatus(t("spdPaymentOfferFailed"));
+        return false;
+      }
+      if (!currentNsec) {
+        setStatus(t("profileMissingNpub"));
+        return false;
+      }
+
+      try {
+        const { getPublicKey } = await import("nostr-tools");
+        const decodedMe = nip19.decode(currentNsec);
+        if (
+          decodedMe.type !== "nsec" ||
+          !(decodedMe.data instanceof Uint8Array)
+        ) {
+          throw new Error("invalid nsec");
+        }
+        const privBytes = decodedMe.data;
+        const myPubHex = getPublicKey(privBytes);
+        const messageDirection = String(message.direction ?? "").trim();
+        const offererPublicKey =
+          String(offerInfo.offererPublicKey ?? "").trim() ||
+          (messageDirection === "out"
+            ? myPubHex
+            : String(message.pubkey ?? "").trim());
+
+        if (!offererPublicKey) {
+          setStatus(t("spdPaymentOfferFailed"));
+          return false;
+        }
+
+        const messageContactId = String(message.contactId ?? "").trim();
+        const messageContact =
+          contacts.find(
+            (contact) => String(contact.id ?? "").trim() === messageContactId,
+          ) ?? null;
+        const contactNpub = normalizeNpubIdentifier(messageContact?.npub);
+        let contactPubkey: string | null = null;
+        if (contactNpub) {
+          const decodedContact = nip19.decode(contactNpub);
+          if (
+            decodedContact.type === "npub" &&
+            typeof decodedContact.data === "string"
+          ) {
+            contactPubkey = decodedContact.data.trim() || null;
+          }
+        }
+
+        const messagePubkey = String(message.pubkey ?? "").trim();
+        const recipientPublicKey =
+          offererPublicKey === myPubHex
+            ? (contactPubkey ??
+              (messagePubkey !== myPubHex ? messagePubkey : ""))
+            : offererPublicKey;
+        if (!recipientPublicKey || recipientPublicKey === myPubHex) {
+          setStatus(t("spdPaymentOfferFailed"));
+          return false;
+        }
+
+        const clientId = makeLocalId();
+        const baseEvent = createLinkyBankPaymentOfferEvent({
+          amountSat: offerInfo.amountSat,
+          amountText: offerInfo.amountText,
+          clientId,
+          createdAt: Math.ceil(Date.now() / 1e3),
+          offerId: offerInfo.offerId,
+          offererPublicKey,
+          recipientPublicKey,
+          senderPublicKey: myPubHex,
+          spdPayload: options?.spdPayload ?? offerInfo.spdPayload,
+          status: nextStatus,
+        });
+
+        const wrapForMe = wrapEventWithoutPushMarker(
+          baseEvent,
+          privBytes,
+          myPubHex,
+        );
+        const withPush =
+          options?.withPush ??
+          shouldPushLinkyBankPaymentOfferStatus(nextStatus);
+        const wrapForContact = withPush
+          ? wrapEventWithPushMarker(baseEvent, privBytes, recipientPublicKey)
+          : wrapEventWithoutPushMarker(
+              baseEvent,
+              privBytes,
+              recipientPublicKey,
+            );
+
+        const pool = await getSharedAppNostrPool();
+        const publishOutcome = await publishWrappedWithRetry(
+          pool,
+          NOSTR_RELAYS,
+          wrapForMe,
+          wrapForContact,
+        );
+
+        if (!publishOutcome.anySuccess) {
+          setStatus(t("spdPaymentOfferFailed"));
+          return false;
+        }
+
+        const messageWrapId =
+          String(wrapForMe.id ?? "").trim() ||
+          String(wrapForContact.id ?? "").trim() ||
+          `bank-payment-offer:${clientId}`;
+        upsertBankPaymentOfferMessage({
+          clientId,
+          contactId: String(message.contactId ?? "").trim(),
+          content: baseEvent.content,
+          createdAtSec: baseEvent.created_at,
+          direction: offererPublicKey === myPubHex ? "out" : "in",
+          id: `bank-payment-offer:${offerInfo.offerId}`,
+          localOnly: true,
+          pubkey: offererPublicKey === myPubHex ? myPubHex : offererPublicKey,
+          rumorId: null,
+          status: "sent",
+          wrapId: messageWrapId,
+        });
+
+        return true;
+      } catch (error) {
+        setStatus(
+          `${t("errorPrefix")}: ${getUnknownErrorMessage(error, "publish failed")}`,
+        );
+        return false;
+      }
+    },
+    [
+      currentNsec,
+      contacts,
+      publishWrappedWithRetry,
+      setStatus,
+      t,
+      upsertBankPaymentOfferMessage,
+    ],
+  );
+
+  const getBankPaymentOfferGroupMessages = React.useCallback(
+    (message: LocalNostrMessage): LocalNostrMessage[] => {
+      const offerInfo = getLinkyBankPaymentOfferInfo(
+        String(message.content ?? ""),
+      );
+      if (!offerInfo) return [message];
+
+      const group = bankPaymentOfferMessages.filter((candidate) => {
+        const candidateInfo = getLinkyBankPaymentOfferInfo(
+          String(candidate.content ?? ""),
+        );
+        return candidateInfo?.offerId === offerInfo.offerId;
+      });
+
+      if (
+        !group.some(
+          (candidate) =>
+            String(candidate.contactId ?? "").trim() ===
+            String(message.contactId ?? "").trim(),
+        )
+      ) {
+        group.push(message);
+      }
+
+      return group;
+    },
+    [bankPaymentOfferMessages],
+  );
+
+  const isBankPaymentOfferCanceled = React.useCallback(
+    (offerId: string): boolean => {
+      const normalizedOfferId = String(offerId ?? "").trim();
+      if (!normalizedOfferId) return false;
+
+      return bankPaymentOfferMessages.some((message) => {
+        const info = getLinkyBankPaymentOfferInfo(
+          String(message.content ?? ""),
+        );
+        return (
+          info?.offerId === normalizedOfferId && info.status === "canceled"
+        );
+      });
+    },
+    [bankPaymentOfferMessages],
+  );
+
+  const respondToBankPaymentOfferWithGroupState = React.useCallback(
+    async (
+      message: LocalNostrMessage,
+      nextStatus: Exclude<LinkyBankPaymentOfferStatus, "offered">,
+      options?: { spdPayload?: string | null; withPush?: boolean },
+    ): Promise<boolean> => {
+      if (nextStatus !== "canceled" && nextStatus !== "settled") {
+        return await respondToBankPaymentOffer(message, nextStatus, options);
+      }
+
+      const group = getBankPaymentOfferGroupMessages(message);
+      const cancellationPushContactId =
+        nextStatus === "canceled"
+          ? (group
+              .filter((candidate) => {
+                const info = getLinkyBankPaymentOfferInfo(
+                  String(candidate.content ?? ""),
+                );
+                return (
+                  info?.status === "accepted" ||
+                  info?.status === "bank_details_sent" ||
+                  info?.status === "bank_paid"
+                );
+              })
+              .sort((left, right) => {
+                const leftInfo = getLinkyBankPaymentOfferInfo(
+                  String(left.content ?? ""),
+                );
+                const rightInfo = getLinkyBankPaymentOfferInfo(
+                  String(right.content ?? ""),
+                );
+                const rank = (status: LinkyBankPaymentOfferStatus): number =>
+                  status === "bank_paid"
+                    ? 0
+                    : status === "bank_details_sent"
+                      ? 1
+                      : 2;
+                const rankDifference =
+                  rank(leftInfo?.status ?? "accepted") -
+                  rank(rightInfo?.status ?? "accepted");
+                if (rankDifference !== 0) return rankDifference;
+                return (
+                  Number(leftInfo?.statusUpdatedAtSec ?? left.createdAtSec) -
+                  Number(rightInfo?.statusUpdatedAtSec ?? right.createdAtSec)
+                );
+              })[0]?.contactId ?? null)
+          : null;
+      let sentAny = false;
+
+      for (const groupMessage of group) {
+        const info = getLinkyBankPaymentOfferInfo(
+          String(groupMessage.content ?? ""),
+        );
+        if (!info) continue;
+        if (info.status === nextStatus) {
+          sentAny = true;
+          continue;
+        }
+        if (nextStatus === "canceled" && info.status === "settled") continue;
+
+        const sent = await respondToBankPaymentOffer(groupMessage, nextStatus, {
+          ...(options?.spdPayload !== undefined
+            ? { spdPayload: options.spdPayload }
+            : {}),
+          withPush:
+            nextStatus === "canceled" &&
+            String(groupMessage.contactId ?? "").trim() ===
+              String(cancellationPushContactId ?? "").trim(),
+        });
+        sentAny = sentAny || sent;
+      }
+
+      return sentAny;
+    },
+    [getBankPaymentOfferGroupMessages, respondToBankPaymentOffer],
+  );
+
+  React.useEffect(() => {
+    if (!currentNsec) return;
+    if (bankPaymentOfferMessages.length === 0) return;
+
+    let cancelled = false;
+
+    const run = async () => {
+      try {
+        const { getPublicKey } = await import("nostr-tools");
+        const decodedMe = nip19.decode(currentNsec);
+        if (
+          decodedMe.type !== "nsec" ||
+          !(decodedMe.data instanceof Uint8Array)
+        ) {
+          return;
+        }
+
+        const myPubHex = getPublicKey(decodedMe.data);
+        const groups = new Map<
+          string,
+          {
+            info: ReturnType<typeof getLinkyBankPaymentOfferInfo>;
+            message: LocalNostrMessage;
+          }[]
+        >();
+
+        for (const message of bankPaymentOfferMessages) {
+          const info = getLinkyBankPaymentOfferInfo(
+            String(message.content ?? ""),
+          );
+          if (!info) continue;
+          if (String(info.offererPublicKey ?? "").trim() !== myPubHex) {
+            continue;
+          }
+
+          const group = groups.get(info.offerId) ?? [];
+          group.push({ info, message });
+          groups.set(info.offerId, group);
+        }
+
+        for (const [offerId, group] of groups) {
+          if (cancelled) return;
+
+          const hasActiveBankDetails = group.some(
+            (entry) =>
+              entry.info?.status === "bank_details_sent" ||
+              entry.info?.status === "bank_paid",
+          );
+          if (hasActiveBankDetails) continue;
+
+          const accepted = group
+            .filter((entry) => entry.info?.status === "accepted")
+            .sort((a, b) => {
+              const aSec =
+                a.info?.statusUpdatedAtSec ??
+                Number(a.message.createdAtSec ?? 0);
+              const bSec =
+                b.info?.statusUpdatedAtSec ??
+                Number(b.message.createdAtSec ?? 0);
+              if (aSec !== bSec) return aSec - bSec;
+              return String(a.message.contactId ?? "").localeCompare(
+                String(b.message.contactId ?? ""),
+              );
+            });
+
+          const candidate = accepted[0] ?? null;
+          if (!candidate?.info) continue;
+
+          const spdPayload =
+            bankPaymentOfferSpdPayloadByOfferIdRef.current.get(offerId) ?? "";
+          if (!spdPayload) continue;
+
+          const candidateKey = `${offerId}:${String(candidate.message.contactId ?? "").trim()}`;
+          if (autoSentBankDetailsOfferIdsRef.current.has(candidateKey)) {
+            continue;
+          }
+
+          autoSentBankDetailsOfferIdsRef.current.add(candidateKey);
+          const sent = await respondToBankPaymentOffer(
+            candidate.message,
+            "bank_details_sent",
+            { spdPayload },
+          );
+          if (!sent) {
+            autoSentBankDetailsOfferIdsRef.current.delete(candidateKey);
+          }
+        }
+      } catch {
+        // Best effort; the sender can retry when the accepted event reappears.
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [bankPaymentOfferMessages, currentNsec, respondToBankPaymentOffer]);
+
+  const bankPaymentOfferExpiryGroups = React.useMemo(() => {
+    if (!currentNpub || bankPaymentOfferMessages.length === 0) return [];
+
+    let myPubHex: string;
+    try {
+      const decoded = nip19.decode(currentNpub);
+      if (decoded.type !== "npub" || typeof decoded.data !== "string") {
+        return [];
+      }
+      myPubHex = decoded.data;
+    } catch {
+      return [];
+    }
+
+    const groups = new Map<
+      string,
+      {
+        info: NonNullable<ReturnType<typeof getLinkyBankPaymentOfferInfo>>;
+        message: LocalNostrMessage;
+      }[]
+    >();
+    for (const message of bankPaymentOfferMessages) {
+      const info = getLinkyBankPaymentOfferInfo(String(message.content ?? ""));
+      if (
+        !info ||
+        String(info.offererPublicKey ?? "").trim() !== myPubHex ||
+        isLinkyBankPaymentOfferTerminalStatus(info.status)
+      ) {
+        continue;
+      }
+      const group = groups.get(info.offerId) ?? [];
+      group.push({ info, message });
+      groups.set(info.offerId, group);
+    }
+
+    const nowSec = Math.floor(Date.now() / 1e3);
+    const statusPriority: LinkyBankPaymentOfferStatus[] = [
+      "bank_paid",
+      "bank_details_sent",
+      "accepted",
+      "offered",
+    ];
+    return Array.from(groups.values()).flatMap((group) => {
+      const activeStatus = statusPriority.find((status) =>
+        group.some((entry) => entry.info.status === status),
+      );
+      if (!activeStatus) return [];
+
+      const phaseStartedAtSec = Math.min(
+        ...group
+          .filter((entry) => entry.info.status === activeStatus)
+          .map(
+            (entry) =>
+              entry.info.statusUpdatedAtSec ||
+              Number(entry.message.createdAtSec ?? 0) ||
+              nowSec,
+          ),
+      );
+      return [
+        {
+          expiresAtMs:
+            (phaseStartedAtSec + LINKY_BANK_PAYMENT_OFFER_PHASE_TTL_SEC) *
+            1_000,
+          messages: group.map((entry) => entry.message),
+        },
+      ];
+    });
+  }, [bankPaymentOfferMessages, currentNpub]);
+
+  React.useEffect(() => {
+    const nextExpiryMs = Math.min(
+      ...bankPaymentOfferExpiryGroups.map((group) => group.expiresAtMs),
+    );
+    if (!Number.isFinite(nextExpiryMs)) return;
+
+    let cancelled = false;
+    let timeoutId = 0;
+    const expireDueGroups = () => {
+      if (cancelled) return;
+      if (bankPaymentOfferExpiryInFlightRef.current) {
+        timeoutId = window.setTimeout(expireDueGroups, 100);
+        return;
+      }
+
+      bankPaymentOfferExpiryInFlightRef.current = true;
+      void (async () => {
+        try {
+          const nowMs = Date.now();
+          for (const group of bankPaymentOfferExpiryGroups) {
+            if (group.expiresAtMs > nowMs) continue;
+            for (const message of group.messages) {
+              if (cancelled) return;
+              await respondToBankPaymentOffer(message, "canceled");
+            }
+          }
+        } finally {
+          bankPaymentOfferExpiryInFlightRef.current = false;
+        }
+      })();
+    };
+    timeoutId = window.setTimeout(
+      expireDueGroups,
+      Math.max(0, nextExpiryMs - Date.now()),
+    );
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [bankPaymentOfferExpiryGroups, respondToBankPaymentOffer]);
+
+  useNostrPendingFlush({
+    activePublishClientIdsRef: activeNostrMessagePublishClientIdsRef,
+    chatSeenWrapIdsRef,
+    contacts,
+    currentNsec,
+    enabled: nostrBootstrapReady,
+    nostrMessagesLocal,
+    nostrReactionsLocal,
+    publishWrappedWithRetry,
+    updateLocalNostrReaction,
+    updateLocalNostrMessage,
+  });
+
+  const contactsOnboardingHasSentMessage = useMemo(() => {
+    return nostrMessagesRecent.some((m) => String(m.direction ?? "") === "out");
+  }, [nostrMessagesRecent]);
+
+  const handleDelete = (id: ContactId) => {
+    const normalizedContactId = String(id ?? "").trim();
+    const contactToArchive =
+      contacts.find(
+        (contact) => String(contact.id ?? "").trim() === normalizedContactId,
+      ) ?? null;
+    const archivedContactNpub = normalizeNpubIdentifier(contactToArchive?.npub);
+    let unknownThreadContactId: string | null = null;
+    if (archivedContactNpub) {
+      try {
+        const decodedContact = nip19.decode(archivedContactNpub);
+        if (
+          decodedContact.type === "npub" &&
+          typeof decodedContact.data === "string"
+        ) {
+          unknownThreadContactId = buildUnknownContactId(decodedContact.data);
+        }
+      } catch {
+        unknownThreadContactId = null;
+      }
+    }
+
+    const archivedAtSec = Math.ceil(Date.now() / 1e3);
+    const storedContactOwnerId = contactToArchive
+      ? resolveContactRowOwnerLane(contactToArchive, contactsVisibleOwnerIds)
+      : null;
+    const archiveOwnerId = storedContactOwnerId ?? contactsOwnerId;
+    const result = archiveOwnerId
+      ? update("contact", { id, archivedAtSec }, { ownerId: archiveOwnerId })
+      : update("contact", { id, archivedAtSec });
+    if (result.ok) {
+      if (
+        unknownThreadContactId &&
+        unknownThreadContactId !== normalizedContactId
+      ) {
+        pendingArchivedContactThreadIdsRef.current.set(
+          normalizedContactId,
+          unknownThreadContactId,
+        );
+      }
+      recordContactsOwnerWrite();
+      setStatus(t("contactArchived"));
+      closeContactDetail();
+      return;
+    }
+    setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
+  };
+
+  const restoreArchivedContact = React.useCallback(
+    (id: ContactId) => {
+      const contactToRestore =
+        contacts.find((contact) => contact.id === id) ?? null;
+      const storedContactOwnerId = contactToRestore
+        ? resolveContactRowOwnerLane(contactToRestore, contactsVisibleOwnerIds)
+        : null;
+      const restoreOwnerId = storedContactOwnerId ?? contactsOwnerId;
+      const result = restoreOwnerId
+        ? update(
+            "contact",
+            { id, archivedAtSec: null },
+            { ownerId: restoreOwnerId },
+          )
+        : update("contact", { id, archivedAtSec: null });
+
+      if (result.ok) {
+        const restoredNpub = normalizeNpubIdentifier(contactToRestore?.npub);
+        if (restoredNpub) {
+          try {
+            const decodedContact = nip19.decode(restoredNpub);
+            if (
+              decodedContact.type === "npub" &&
+              typeof decodedContact.data === "string"
+            ) {
+              const unknownContactId = buildUnknownContactId(
+                decodedContact.data,
+              );
+              if (unknownContactId) {
+                reassignLocalNostrMessagesContactId(
+                  unknownContactId,
+                  String(id),
+                );
+              }
+            }
+          } catch {
+            // Ignore malformed archived contact identifiers.
+          }
+        }
+        recordContactsOwnerWrite();
+        setStatus(t("contactRestored"));
+        closeContactDetail();
+        return;
+      }
+
+      setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
+    },
+    [
+      closeContactDetail,
+      contacts,
+      contactsOwnerId,
+      contactsVisibleOwnerIds,
+      recordContactsOwnerWrite,
+      reassignLocalNostrMessagesContactId,
+      setStatus,
+      t,
+      update,
+    ],
+  );
+
+  const blockPubkeyAndPublishMuteList = React.useCallback(
+    async (pubkeyHex: string): Promise<boolean> => {
+      const normalizedPubkey = normalizePubkeyHex(pubkeyHex);
+      if (!normalizedPubkey) return false;
+
+      const mergedBlockedPubkeys = Array.from(
+        new Set(
+          safeLocalStorageGetJson(BLOCKED_NOSTR_PUBKEYS_STORAGE_KEY, [])
+            .map((entry) => normalizePubkeyHex(entry))
+            .filter((entry): entry is string => Boolean(entry))
+            .concat(normalizedPubkey),
+        ),
+      );
+
+      safeLocalStorageSetJson(
+        BLOCKED_NOSTR_PUBKEYS_STORAGE_KEY,
+        mergedBlockedPubkeys,
+      );
+
+      if (!currentNsec) return true;
+
+      try {
+        const { finalizeEvent, getPublicKey } = await import("nostr-tools");
+
+        const decodedMe = nip19.decode(currentNsec);
+        if (
+          decodedMe.type !== "nsec" ||
+          !(decodedMe.data instanceof Uint8Array)
+        ) {
+          return true;
+        }
+
+        const relays = Array.from(
+          new Set(
+            nostrFetchRelays
+              .map((relay) => String(relay ?? "").trim())
+              .filter(Boolean),
+          ),
+        );
+        if (relays.length === 0) return true;
+
+        const privBytes = decodedMe.data;
+        const pubkey = getPublicKey(privBytes);
+        const baseEvent = {
+          kind: 10000,
+          created_at: Math.ceil(Date.now() / 1e3),
+          tags: mergedBlockedPubkeys.map((blockedPubkey) => [
+            "p",
+            blockedPubkey,
+          ]),
+          content: "",
+          pubkey,
+        } satisfies UnsignedEvent;
+
+        const signed = finalizeEvent(baseEvent, privBytes);
+        const pool = await getSharedAppNostrPool();
+        void Promise.allSettled(pool.publish(relays, signed));
+      } catch {
+        // Local blocklist still applies even if mute-list publish fails.
+      }
+
+      return true;
+    },
+    [currentNsec, nostrFetchRelays],
+  );
+
+  const requestDeleteCurrentContact = () => {
+    if (!editingId) return;
+    if (pendingDeleteId === editingId) {
+      setPendingDeleteId(null);
+      handleDelete(editingId);
+      return;
+    }
+    setPendingDeleteId(editingId);
+  };
+
+  const { openFeedbackContact } = useFeedbackContact<(typeof contacts)[number]>(
+    {
+      appOwnerId: contactsOwnerId,
+      contacts,
+      insert,
+      pushToast,
+      t,
+      update,
+    },
+  );
+
+  const clearContactAttention = React.useCallback((contactId: string) => {
+    const normalizedContactId = String(contactId ?? "").trim();
+    if (!normalizedContactId) return;
+
+    setContactAttentionById((prev) => {
+      if (prev[normalizedContactId] === undefined) return prev;
+      const next = { ...prev };
+      delete next[normalizedContactId];
+      return next;
+    });
+  }, []);
+
+  React.useEffect(() => {
+    for (const contact of contacts) {
+      const contactId = String(contact.id ?? "").trim();
+      if (!contactId) continue;
+      const unknownContactId =
+        pendingArchivedContactThreadIdsRef.current.get(contactId);
+      if (!unknownContactId) continue;
+
+      const archivedAtSec = Number(contact.archivedAtSec ?? 0);
+      if (!Number.isFinite(archivedAtSec) || archivedAtSec <= 0) continue;
+
+      pendingArchivedContactThreadIdsRef.current.delete(contactId);
+      reassignLocalNostrMessagesContactId(contactId, unknownContactId);
+      clearContactAttention(unknownContactId);
+    }
+  }, [clearContactAttention, contacts, reassignLocalNostrMessagesContactId]);
+
+  const blockArchivedContact = React.useCallback(async () => {
+    if (route.kind !== "contactEdit") return;
+    if (!selectedContact?.id) return;
+
+    const normalizedNpub = normalizeNpubIdentifier(selectedContact.npub);
+    if (!normalizedNpub) {
+      setStatus(t("chatMissingContactNpub"));
+      return;
+    }
+
+    const confirmed = window.confirm(t("chatUnknownContactBlockConfirm"));
+    if (!confirmed) return;
+
+    let blockedPubkey: string | null = null;
+    try {
+      const decoded = nip19.decode(normalizedNpub);
+      if (decoded.type === "npub" && typeof decoded.data === "string") {
+        blockedPubkey = normalizePubkeyHex(decoded.data);
+      }
+    } catch {
+      blockedPubkey = null;
+    }
+
+    if (!blockedPubkey) {
+      setStatus(t("chatMissingContactNpub"));
+      return;
+    }
+
+    await blockPubkeyAndPublishMuteList(blockedPubkey);
+
+    const contactId = String(selectedContact.id ?? "").trim();
+    if (contactId) {
+      removeLocalNostrMessagesByContactId(contactId);
+      clearContactAttention(contactId);
+    }
+
+    const result = contactsOwnerId
+      ? (() => {
+          const scoped = update(
+            "contact",
+            { id: selectedContact.id, isDeleted: Evolu.sqliteTrue },
+            { ownerId: contactsOwnerId },
+          );
+          if (scoped.ok) return scoped;
+          return update("contact", {
+            id: selectedContact.id,
+            isDeleted: Evolu.sqliteTrue,
+          });
+        })()
+      : update("contact", {
+          id: selectedContact.id,
+          isDeleted: Evolu.sqliteTrue,
+        });
+
+    if (result.ok) {
+      recordContactsOwnerWrite();
+      setStatus(t("contactBlocked"));
+      closeContactDetail();
+      return;
+    }
+
+    setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
+  }, [
+    blockPubkeyAndPublishMuteList,
+    clearContactAttention,
+    closeContactDetail,
+    contactsOwnerId,
+    recordContactsOwnerWrite,
+    removeLocalNostrMessagesByContactId,
+    route.kind,
+    selectedContact,
+    setStatus,
+    t,
+    update,
+  ]);
+
+  const openContactPay = React.useCallback(
+    (
+      contactId: string,
+      fromChat = false,
+      intent: "pay" | "request" = "pay",
+    ) => {
+      const knownContact =
+        contacts.find((row) => String(row.id ?? "").trim() === contactId) ??
+        null;
+      if (!knownContact) return;
+
+      contactPayBackToChatRef.current = fromChat ? knownContact.id : null;
+      setContactPaymentIntent(intent);
+      navigateTo({ route: "contactPay", id: knownContact.id });
+    },
+    [contacts],
+  );
+
+  const openContactDetail = React.useCallback(
+    (contact: DisplayContact) => {
+      const contactId = String(contact.id ?? "").trim();
+      if (!contactId) return;
+
+      setPendingDeleteId(null);
+      clearContactAttention(contactId);
+      contactPayBackToChatRef.current = null;
+
+      if (contact.isUnknownContact) {
+        navigateTo({ route: "chat", id: contactId });
+        return;
+      }
+
+      const knownContact =
+        contacts.find((row) => String(row.id ?? "").trim() === contactId) ??
+        null;
+      if (!knownContact) {
+        navigateTo({ route: "contacts" });
+        return;
+      }
+
+      const npub = String(knownContact.npub ?? "").trim();
+      const ln = String(knownContact.lnAddress ?? "").trim();
+      if (!npub) {
+        if (ln) {
+          openContactPay(knownContact.id);
+          return;
+        }
+        navigateTo({ route: "contact", id: knownContact.id });
+        return;
+      }
+      navigateTo({ route: "chat", id: String(knownContact.id) });
+    },
+    [clearContactAttention, contacts, openContactPay],
+  );
+
+  const addUnknownContactFromChat = React.useCallback(async () => {
+    if (route.kind !== "chat") return;
+    if (!selectedChatContact?.isUnknownContact) return;
+
+    const contactId = String(selectedChatContact.id ?? "").trim();
+    const npub = normalizeNpubIdentifier(selectedChatContact.npub);
+    if (!contactId || !npub) {
+      setStatus(t("chatUnknownContactAddFailed"));
+      return;
+    }
+
+    const existing = contacts.find(
+      (contact) => normalizeNpubIdentifier(contact.npub) === npub,
+    );
+
+    if (existing?.id) {
+      reassignLocalNostrMessagesContactId(contactId, existing.id);
+      clearContactAttention(contactId);
+      setStatus(t("contactSaved"));
+      navigateTo({ route: "chat", id: String(existing.id) });
+      return;
+    }
+
+    const bestName = unknownNameByNpub[npub] ?? null;
+    const savedName = buildSavedContactName(bestName, npub);
+    const payload = {
+      name: savedName as typeof Evolu.NonEmptyString1000.Type,
+      npub: npub as typeof Evolu.NonEmptyString1000.Type,
+      lnAddress: null,
+      groupName: null,
+    };
+
+    pendingUnknownContactAddRef.current = {
+      sourceContactId: contactId,
+      targetNpub: npub,
+    };
+
+    const result = contactsOwnerId
+      ? (() => {
+          const scoped = insert("contact", payload, {
+            ownerId: contactsOwnerId,
+          });
+          if (scoped.ok) return scoped;
+          return insert("contact", payload);
+        })()
+      : insert("contact", payload);
+
+    if (!result.ok) {
+      pendingUnknownContactAddRef.current = null;
+      setStatus(`${t("errorPrefix")}: ${String(result.error ?? "")}`);
+      return;
+    }
+
+    recordContactsOwnerWrite();
+  }, [
+    clearContactAttention,
+    contactsOwnerId,
+    buildSavedContactName,
+    contacts,
+    insert,
+    pendingUnknownContactAddRef,
+    recordContactsOwnerWrite,
+    reassignLocalNostrMessagesContactId,
+    route.kind,
+    selectedChatContact,
+    setStatus,
+    t,
+    unknownNameByNpub,
+  ]);
+
+  const blockUnknownContactFromChat = React.useCallback(async () => {
+    if (route.kind !== "chat") return;
+    if (!selectedChatContact?.isUnknownContact) return;
+
+    const confirmed = window.confirm(t("chatUnknownContactBlockConfirm"));
+    if (!confirmed) return;
+
+    const contactId = String(selectedChatContact.id ?? "").trim();
+    if (!contactId) return;
+
+    const unknownPubkeyHex = (() => {
+      const directPubkey = normalizePubkeyHex(
+        selectedChatContact.unknownPubkeyHex,
+      );
+      if (directPubkey) return directPubkey;
+
+      const normalizedNpub = normalizeNpubIdentifier(selectedChatContact.npub);
+      if (!normalizedNpub) return null;
+
+      try {
+        const decoded = nip19.decode(normalizedNpub);
+        if (decoded.type !== "npub" || typeof decoded.data !== "string") {
+          return null;
+        }
+        return normalizePubkeyHex(decoded.data);
+      } catch {
+        return null;
+      }
+    })();
+
+    if (!unknownPubkeyHex) return;
+
+    await blockPubkeyAndPublishMuteList(unknownPubkeyHex);
+
+    removeLocalNostrMessagesByContactId(contactId);
+    clearContactAttention(contactId);
+    setStatus(t("chatUnknownContactBlocked"));
+    navigateTo({ route: "contacts" });
+  }, [
+    blockPubkeyAndPublishMuteList,
+    clearContactAttention,
+    removeLocalNostrMessagesByContactId,
+    route.kind,
+    selectedChatContact?.npub,
+    selectedChatContact?.unknownPubkeyHex,
+    selectedChatContact,
+    setStatus,
+    t,
+  ]);
+
+  const getNpubMessageContactInfo = React.useCallback(
+    (rawNpub: string) => {
+      const npub = normalizeNpubIdentifier(rawNpub);
+      if (!npub) return null;
+
+      const knownContact =
+        contacts.find(
+          (contact) => normalizeNpubIdentifier(contact.npub) === npub,
+        ) ?? null;
+      const derivedProfile = deriveDefaultProfile(npub, lang);
+      const displayName = buildSavedContactName(
+        String(knownContact?.name ?? "").trim() ||
+          unknownNameByNpub[npub] ||
+          null,
+        npub,
+      );
+      const pictureUrl =
+        nostrPictureByNpub[npub] ?? derivedProfile.pictureUrl ?? null;
+
+      return {
+        displayName,
+        isSaved:
+          Boolean(knownContact) ||
+          normalizeNpubIdentifier(currentNpub) === npub,
+        npub,
+        pictureUrl,
+      };
+    },
+    [
+      buildSavedContactName,
+      contacts,
+      currentNpub,
+      lang,
+      nostrPictureByNpub,
+      unknownNameByNpub,
+    ],
+  );
+
+  const mentionContacts = React.useMemo(
+    () =>
+      contacts.flatMap((contact) => {
+        const name = String(contact.name ?? "").trim();
+        const npub = normalizeNpubIdentifier(contact.npub);
+        if (!name || !npub) return [];
+        const groupName = String(contact.groupName ?? "").trim();
+        return [
+          {
+            name,
+            npub,
+            groupName: groupName || null,
+            statusNames: extractStatusFilterCurrencies(nostrStatusByNpub[npub]),
+          },
+        ];
+      }),
+    [contacts, nostrStatusByNpub],
+  );
+
+  const openNpubMessageContact = React.useCallback(
+    (rawNpub: string) => {
+      const npub = normalizeNpubIdentifier(rawNpub);
+      if (!npub) return;
+
+      const existing = contacts.find(
+        (contact) => normalizeNpubIdentifier(contact.npub) === npub,
+      );
+      if (existing?.id) {
+        navigateTo({ route: "contact", id: existing.id as ContactId });
+        return;
+      }
+
+      const myNpub = normalizeNpubIdentifier(currentNpub);
+      if (myNpub && myNpub === npub) {
+        navigateTo({ route: "profile" });
+        return;
+      }
+
+      if (activeContactsOwnerContactCount >= MAX_CONTACTS_PER_OWNER) {
+        setStatus(
+          t("contactsLimitReached").replace(
+            "{max}",
+            String(MAX_CONTACTS_PER_OWNER),
+          ),
+        );
+        return;
+      }
+
+      const defaultProfile = deriveDefaultProfile(npub, lang);
+      const payload = {
+        name: buildSavedContactName(
+          unknownNameByNpub[npub] ?? defaultProfile.name,
+          npub,
+        ) as typeof Evolu.NonEmptyString1000.Type,
+        npub: npub as typeof Evolu.NonEmptyString1000.Type,
+        lnAddress: null,
+        groupName: null,
+      };
+
+      const result = contactsOwnerId
+        ? (() => {
+            const scoped = insert("contact", payload, {
+              ownerId: contactsOwnerId,
+            });
+            if (scoped.ok) return scoped;
+            return insert("contact", payload);
+          })()
+        : insert("contact", payload);
+
+      if (!result.ok) {
+        setStatus(`${t("errorPrefix")}: ${String(result.error ?? "")}`);
+        return;
+      }
+
+      openScannedContactPendingNpubRef.current = npub;
+      recordContactsOwnerWrite();
+      setStatus(t("contactSaved"));
+    },
+    [
+      activeContactsOwnerContactCount,
+      buildSavedContactName,
+      contacts,
+      contactsOwnerId,
+      currentNpub,
+      insert,
+      lang,
+      openScannedContactPendingNpubRef,
+      recordContactsOwnerWrite,
+      setStatus,
+      t,
+      unknownNameByNpub,
+    ],
+  );
+
+  React.useEffect(() => {
+    const pending = pendingUnknownContactAddRef.current;
+    if (!pending) return;
+
+    const existing = contacts.find(
+      (contact) =>
+        normalizeNpubIdentifier(contact.npub) === pending.targetNpub &&
+        Boolean(contact.id),
+    );
+    if (!existing?.id) return;
+
+    pendingUnknownContactAddRef.current = null;
+    reassignLocalNostrMessagesContactId(pending.sourceContactId, existing.id);
+    clearContactAttention(pending.sourceContactId);
+    setStatus(t("contactSaved"));
+    navigateTo({ route: "chat", id: String(existing.id) });
+  }, [
+    clearContactAttention,
+    contacts,
+    reassignLocalNostrMessagesContactId,
+    setStatus,
+    t,
+  ]);
+
+  useChatNostrSyncEffect({
+    appendLocalNostrMessage,
+    appendLocalNostrReaction,
+    chatMessages,
+    chatMessagesLatestRef,
+    chatSeenWrapIdsRef,
+    currentNsec,
+    enabled: nostrBootstrapReady,
+    knownNostrMessageIdentityIndex,
+    logPayStep,
+    nostrMessageWrapIdsRef,
+    nostrReactionWrapIdsRef,
+    nostrReactionsLatestRef,
+    route,
+    selectedContact: selectedChatContact,
+    softDeleteLocalNostrReactionsByWrapIds,
+    updateLocalNostrMessage,
+    updateLocalNostrReaction,
+  });
+
+  const sendChatMessage = useSendChatMessage({
+    activePublishClientIdsRef: activeNostrMessagePublishClientIdsRef,
+    appendLocalNostrMessage,
+    chatDraft,
+    chatSeenWrapIdsRef,
+    chatSendIsBusy,
+    currentNsec,
+    publishWrappedWithRetry,
+    route,
+    replyContext,
+    replyContextRef,
+    selectedContact:
+      route.kind === "chat" || route.kind === "bankPaymentOffer"
+        ? selectedChatContact
+        : selectedContact,
+    setReplyContext,
+    setChatDraft,
+    setChatSendIsBusy,
+    setStatus,
+    t,
+    triggerChatScrollToBottom,
+    updateLocalNostrMessage,
+  });
+
+  const editChatMessage = useEditChatMessage({
+    chatDraft,
+    chatSendIsBusy,
+    currentNsec,
+    editContext,
+    publishWrappedWithRetry,
+    route,
+    selectedContact: selectedChatContact,
+    setChatDraft,
+    setChatSendIsBusy,
+    setEditContext,
+    setStatus,
+    t,
+    updateLocalNostrMessage,
+  });
+
+  const sendReaction = useSendReaction({
+    appendLocalNostrReaction,
+    currentNsec,
+    publishWrappedWithRetry,
+    reactionsByMessageId,
+    route,
+    selectedContact: selectedChatContact,
+    setStatus,
+    softDeleteLocalNostrReaction,
+    t,
+    updateLocalNostrReaction,
+  });
+
+  const sendChatOrEditMessage = React.useCallback(async () => {
+    if (editContext) {
+      await editChatMessage();
+      return;
+    }
+    await sendChatMessage();
+  }, [editChatMessage, editContext, sendChatMessage]);
+
+  const sendChatImage = React.useCallback(
+    async (file: File) => {
+      if (editContext) return;
+      await sendChatMessage({
+        clearDraft: false,
+        imageFile: file,
+      });
+    },
+    [editContext, sendChatMessage],
+  );
+
+  const onReplyToChatMessage = React.useCallback(
+    (message: LocalNostrMessage) => {
+      const rumorId = String(message.rumorId ?? "").trim();
+      if (!rumorId) return;
+      setEditContext(null);
+      setReplyContext({
+        replyToId: rumorId,
+        rootMessageId: String(message.rootMessageId ?? "").trim() || rumorId,
+        replyToContent: String(message.content ?? "").trim() || null,
+      });
+    },
+    [],
+  );
+
+  const onEditChatMessage = React.useCallback((message: LocalNostrMessage) => {
+    const isOut = String(message.direction ?? "") === "out";
+    if (!isOut) return;
+    const rumorId = String(message.rumorId ?? "").trim();
+    if (!rumorId) return;
+    const messageId = String(message.id ?? "").trim();
+    if (!messageId) return;
+
+    setReplyContext(null);
+    const content = String(message.content ?? "");
+    setEditContext({
+      messageId,
+      rumorId,
+      originalContent:
+        String(message.originalContent ?? "").trim() || content || "",
+    });
+    setChatDraft(content);
+  }, []);
+
+  const onReactToChatMessage = React.useCallback(
+    (message: LocalNostrMessage, emoji: string) => {
+      const messageRumorId = String(message.rumorId ?? "").trim();
+      const messageAuthorPubkey = String(message.pubkey ?? "").trim();
+      if (!messageRumorId || !messageAuthorPubkey) return;
+      void sendReaction({
+        emoji,
+        messageAuthorPubkey,
+        messageKind: parsePrivateImageMessage(message.content) ? 15 : 14,
+        messageRumorId,
+      });
+    },
+    [sendReaction],
+  );
+
+  const onCopyChatMessage = React.useCallback(
+    (message: LocalNostrMessage) => {
+      const content = String(message.content ?? "");
+      const copyContent = parsePrivateImageMessage(content)
+        ? privateImagePreviewText(t)
+        : content;
+      void copyText(copyContent);
+    },
+    [copyText, t],
+  );
+
+  const onDeclineChatPaymentRequest = React.useCallback(
+    async (message: LocalNostrMessage) => {
+      const requestRumorId = String(message.rumorId ?? "").trim();
+      if (!requestRumorId) return;
+
+      await sendChatMessage({
+        clearDraft: false,
+        replyContext: {
+          replyToId: requestRumorId,
+          rootMessageId:
+            String(message.rootMessageId ?? "").trim() || requestRumorId,
+          replyToContent: String(message.content ?? "").trim() || null,
+        },
+        text: buildLinkyPaymentRequestDeclineMessage(requestRumorId),
+      });
+    },
+    [sendChatMessage],
+  );
+
+  const onCancelReply = React.useCallback(() => {
+    setReplyContext(null);
+  }, []);
+
+  const onCancelEdit = React.useCallback(() => {
+    setEditContext(null);
+    setChatDraft("");
+  }, []);
+
+  const openInboxMessageToast = React.useCallback(
+    (params: { contactId: string; messageId?: string }) => {
+      const contactId = String(params.contactId ?? "").trim();
+      if (!contactId) return;
+      const messageId = String(params.messageId ?? "").trim();
+
+      navigateTo({ route: "chat", id: contactId });
+      triggerChatScrollToBottom(messageId || undefined);
+    },
+    [triggerChatScrollToBottom],
+  );
+
+  useInboxNotificationsSync({
+    appendLocalNostrMessage,
+    appendLocalNostrReaction,
+    bankPaymentOfferMessages,
+    contacts,
+    currentNsec,
+    enabled: nostrBootstrapReady,
+    formatDisplayedAmountText,
+    maybeShowPwaNotification,
+    nostrFetchRelays,
+    knownNostrMessageIdentityIndex,
+    nostrMessageWrapIdsRef,
+    nostrMessagesLatestRef,
+    nostrMessagesRecent,
+    nostrReactionWrapIdsRef,
+    nostrReactionsLatestRef,
+    onBankPaymentOfferMessage: upsertBankPaymentOfferMessage,
+    onOpenInboxMessageToast: openInboxMessageToast,
+    pushToast,
+    route,
+    setContactAttentionById,
+    softDeleteLocalNostrReactionsByWrapIds,
+    t,
+    updateLocalNostrMessage,
+    updateLocalNostrReaction,
+  });
+
+  const chatMessagesWithBankPaymentOffers = React.useMemo(() => {
+    if (route.kind !== "chat") return chatMessages;
+
+    const activeContactId = String(route.id ?? "").trim();
+    if (!activeContactId) return chatMessages;
+
+    const offerMessages = bankPaymentOfferMessages.filter(
+      (message) => String(message.contactId ?? "").trim() === activeContactId,
+    );
+    if (offerMessages.length === 0) return chatMessages;
+
+    const seenKeys = new Set<string>();
+    for (const message of chatMessages) {
+      const offerId = getLinkyBankPaymentOfferInfo(
+        String(message.content ?? ""),
+      )?.offerId;
+      if (offerId) seenKeys.add(`offer:${offerId}`);
+      const wrapId = String(message.wrapId ?? "").trim();
+      if (wrapId) seenKeys.add(`wrap:${wrapId}`);
+      const clientId = String(message.clientId ?? "").trim();
+      if (clientId) seenKeys.add(`client:${clientId}`);
+      const id = String(message.id ?? "").trim();
+      if (id) seenKeys.add(`id:${id}`);
+    }
+
+    const merged = [...chatMessages];
+    for (const message of offerMessages) {
+      const offerId = getLinkyBankPaymentOfferInfo(
+        String(message.content ?? ""),
+      )?.offerId;
+      const wrapId = String(message.wrapId ?? "").trim();
+      const clientId = String(message.clientId ?? "").trim();
+      const id = String(message.id ?? "").trim();
+      if (offerId && seenKeys.has(`offer:${offerId}`)) continue;
+      if (wrapId && seenKeys.has(`wrap:${wrapId}`)) continue;
+      if (clientId && seenKeys.has(`client:${clientId}`)) continue;
+      if (id && seenKeys.has(`id:${id}`)) continue;
+
+      merged.push(message);
+      if (offerId) seenKeys.add(`offer:${offerId}`);
+      if (wrapId) seenKeys.add(`wrap:${wrapId}`);
+      if (clientId) seenKeys.add(`client:${clientId}`);
+      if (id) seenKeys.add(`id:${id}`);
+    }
+
+    merged.sort((a, b) => {
+      const createdA = Number(a.createdAtSec ?? 0);
+      const createdB = Number(b.createdAtSec ?? 0);
+      if (createdA !== createdB) return createdA - createdB;
+      return String(a.id ?? "").localeCompare(String(b.id ?? ""));
+    });
+
+    return merged;
+  }, [bankPaymentOfferMessages, chatMessages, route]);
+
+  return {
+    activeContactsOwnerContactCount,
+    activeGroup,
+    activeNostrMessagePublishClientIdsRef,
+    addNewContactFromIdentifier,
+    addNewContactFromSearchResult,
+    addUnknownContactFromChat,
+    appendLocalNostrMessage,
+    appendLocalNostrReaction,
+    autoAcceptedChatMessageIdsRef,
+    bankPaymentOfferContacts,
+    bankPaymentOfferMessages,
+    bankPaymentOfferRecipientCount,
+    blockArchivedContact,
+    blockUnknownContactFromChat,
+    buildSavedContactName,
+    canAddContact,
+    canSaveNewRelay,
+    chatDidInitialScrollForContactRef,
+    chatDraft,
+    chatForceScrollToBottomRef,
+    chatLastMessageCountRef,
+    chatMessageElByIdRef,
+    chatMessages,
+    chatMessagesLatestRef,
+    chatMessagesRef,
+    chatMessagesWithBankPaymentOffers,
+    chatOwnPubkeyHex,
+    chatScrollTargetIdRef,
+    chatSeenWrapIdsRef,
+    chatSendIsBusy,
+    closeContactDetail,
+    connectedRelayCount,
+    contactAttentionById,
+    contactEditsSavable,
+    contactFilterOptions,
+    contactSuggestions,
+    contacts,
+    contactsLatestRef,
+    contactsOnboardingHasBackedUpKeys,
+    contactsOnboardingHasPaid,
+    contactsOnboardingHasSentMessage,
+    contactsSearch,
+    contactsSearchInputRef,
+    dedupeContacts,
+    dedupeContactsIsBusy,
+    displayContactById,
+    displayContacts,
+    editContext,
+    editingId,
+    enqueuePendingPayment,
+    form,
+    getNpubMessageContactInfo,
+    groupNames,
+    handleSaveContact,
+    isBankPaymentOfferCanceled,
+    isSavingContact,
+    knownNostrMessageIdentityIndex,
+    lastMessageByContactId,
+    mentionContacts,
+    newRelayUrl,
+    nostrBootstrapReady,
+    nostrFetchRelays,
+    nostrMessageWrapIdsRef,
+    nostrMessagesLatestRef,
+    nostrMessagesLocal,
+    nostrMessagesRecent,
+    nostrPictureByNpub,
+    nostrReactionWrapIdsRef,
+    nostrReactionsLatestRef,
+    nostrReactionsLocal,
+    nostrRelayOverallStatus,
+    nostrStatusByNpub,
+    onCancelEdit,
+    onCancelReply,
+    onCopyChatMessage,
+    onDeclineChatPaymentRequest,
+    onEditChatMessage,
+    onReactToChatMessage,
+    onReplyToChatMessage,
+    openContactDetail,
+    openContactPay,
+    openFeedbackContact,
+    openInboxMessageToast,
+    openNewContactPage,
+    openNpubMessageContact,
+    openScannedContactPendingNpubRef,
+    pendingDeleteId,
+    pendingPayments,
+    pendingRelayDeleteUrl,
+    publishSingleWrappedWithRetry,
+    publishWrappedWithRetry,
+    reactionsByMessageId,
+    reassignLocalNostrMessagesContactId,
+    refreshContactFromNostr,
+    relayStatusByUrl,
+    relayUrls,
+    rememberBlobAvatarUrl,
+    removeLocalNostrMessagesByContactId,
+    removePendingPayment,
+    replyContext,
+    requestBankPaymentOffer,
+    requestDeleteCurrentContact,
+    requestDeleteSelectedRelay,
+    resetEditedContactFieldFromNostr,
+    respondToBankPaymentOfferWithGroupState,
+    restoreArchivedContact,
+    saveNewRelay,
+    searchNewContact,
+    selectedChatContact,
+    selectedContact,
+    selectedRelayUrl,
+    sendChatImage,
+    sendChatMessage,
+    sendChatOrEditMessage,
+    setActiveGroup,
+    setBankPaymentOfferRecipientCount,
+    setChatDraft,
+    setContactNewPrefill,
+    setContactsOnboardingHasBackedUpKeys,
+    setContactsOnboardingHasPaid,
+    setContactsSearch,
+    setForm,
+    setNewRelayUrl,
+    setPendingDeleteId,
+    softDeleteLocalNostrReaction,
+    softDeleteLocalNostrReactionsByWrapIds,
+    statusFilterCurrencies,
+    triggerChatScrollToBottom,
+    ungroupedCount,
+    unknownNameByNpub,
+    updateLocalNostrMessage,
+    updateLocalNostrReaction,
+    upsertBankPaymentOfferMessage,
+    visibleContacts,
+  };
+};

--- a/apps/web-app/src/app/hooks/composition/useContactsMessagingComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useContactsMessagingComposition.ts
@@ -307,6 +307,9 @@ export const useContactsMessagingComposition = ({
       "1",
   );
 
+  // Ephemeral per-contact activity indicator.
+  // When a message/payment arrives, we show a dot and temporarily bump the
+  // contact to the top until the user opens it.
   const [contactAttentionById, setContactAttentionById] = useState<
     Record<string, number>
   >(() => ({}));

--- a/apps/web-app/src/app/hooks/composition/useIdentityOwnersComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useIdentityOwnersComposition.ts
@@ -1,0 +1,308 @@
+import * as Evolu from "@evolu/common";
+import { useOwner, useQuery } from "@evolu/react";
+import React from "react";
+import type { evolu, useEvolu } from "../../../evolu";
+import { useEvoluSyncOwner } from "../../../evolu";
+import type { Lang } from "../../../i18n";
+import {
+  persistSyncedActiveNostrIdentity,
+  readStoredNostrNsec,
+} from "../../../platform/identitySecrets";
+import {
+  clearStoredPushNsec,
+  setStoredPushNsec,
+} from "../../../utils/pushNsecStorage";
+import {
+  getInitialNostrIdentitySource,
+  getInitialNostrIdentitySwitchedAtSec,
+  getInitialNostrNsec,
+} from "../../../utils/storage";
+import type { IdentityChangeMessageSource } from "../../lib/identityChangeMessage";
+import {
+  ACTIVE_NOSTR_IDENTITY_ROW_ID,
+  resolveSyncedNostrIdentity,
+} from "../../lib/nostrIdentitySync";
+import { useEvoluContactsOwnerRotation } from "../useEvoluContactsOwnerRotation";
+import { useProfileAuthComposition } from "./useProfileAuthComposition";
+
+interface IdentityOwnersNavigation {
+  reload: () => void;
+}
+
+interface UseIdentityOwnersCompositionParams {
+  evolu: typeof evolu;
+  lang: Lang;
+  navigation: IdentityOwnersNavigation;
+  pushToast: (message: string) => void;
+  t: (key: string) => string;
+  upsert: ReturnType<typeof useEvolu>["upsert"];
+}
+
+export const useIdentityOwnersComposition = ({
+  evolu,
+  lang,
+  navigation,
+  pushToast,
+  t,
+  upsert,
+}: UseIdentityOwnersCompositionParams) => {
+  const appOwnerIdRef = React.useRef<Evolu.OwnerId | null>(null);
+  const cashuOwnerIdRef = React.useRef<Evolu.OwnerId | null>(null);
+  const messagesOwnerIdRef = React.useRef<Evolu.OwnerId | null>(null);
+  const transactionsOwnerIdRef = React.useRef<Evolu.OwnerId | null>(null);
+  const recordTransactionsOwnerWriteRef = React.useRef<
+    ((count?: number) => void) | null
+  >(null);
+
+  const [currentNsec, setCurrentNsec] = React.useState<string | null>(() =>
+    getInitialNostrNsec(),
+  );
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      const storedNsec = await readStoredNostrNsec();
+      if (cancelled) return;
+      setCurrentNsec((current) =>
+        current === storedNsec ? current : storedNsec,
+      );
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const syncOwner = useEvoluSyncOwner(Boolean(currentNsec));
+
+  useOwner(syncOwner);
+
+  React.useEffect(() => {
+    void (async () => {
+      try {
+        if (currentNsec) {
+          await setStoredPushNsec(currentNsec);
+        } else {
+          await clearStoredPushNsec();
+        }
+      } catch {
+        // ignore
+      }
+    })();
+  }, [currentNsec]);
+
+  const appOwnerId = syncOwner?.id ?? null;
+
+  const appendIdentityChangeNoticesRef = React.useRef<
+    | ((args: {
+        changedAtSec: number;
+        identitySource: IdentityChangeMessageSource;
+      }) => void)
+    | null
+  >(null);
+
+  const profileAuth = useProfileAuthComposition({
+    appendIdentityChangeNoticesRef,
+    currentNsec,
+    lang,
+    pushToast,
+    t,
+    upsert,
+  });
+
+  const ownerRotation = useEvoluContactsOwnerRotation({
+    appOwnerId,
+    isSeedLogin: profileAuth.isSeedLogin,
+    pushToast,
+    slip39Seed: profileAuth.slip39Seed,
+    t,
+    upsert,
+  });
+
+  useOwner(ownerRotation.contactsSyncOwner);
+  useOwner(ownerRotation.cashuSyncOwner);
+  useOwner(ownerRotation.messagesSyncOwner);
+  useOwner(ownerRotation.transactionsSyncOwner);
+  useOwner(ownerRotation.metaSyncOwner);
+  useOwner(ownerRotation.identitySyncOwner);
+
+  const historicalOwnerSetsReady = profileAuth.isSeedLogin
+    ? ownerRotation.cashuVisibleOwnerIds.length ===
+        ownerRotation.cashuOwnerIndex + 1 &&
+      ownerRotation.contactsVisibleOwnerIds.length ===
+        ownerRotation.contactsOwnerIndex + 1 &&
+      ownerRotation.messagesVisibleOwnerIds.length ===
+        ownerRotation.messagesOwnerIndex + 1 &&
+      ownerRotation.transactionsVisibleOwnerIds.length ===
+        ownerRotation.transactionsOwnerIndex + 1
+    : true;
+  React.useEffect(() => {
+    if (!profileAuth.isSeedLogin || !historicalOwnerSetsReady) return;
+
+    // Evolu does not expose an initial-sync-complete signal. Keep historical
+    // lanes subscribed for the whole authenticated session instead of
+    // guessing completion from a quiet timer and disconnecting them while
+    // their stored messages may still be arriving.
+    const stopUsingOwners = ownerRotation.historicalBootstrapSyncOwners.map(
+      (owner) => evolu.useOwner(owner),
+    );
+    return () => {
+      for (const stopUsingOwner of stopUsingOwners) stopUsingOwner();
+    };
+  }, [
+    evolu,
+    historicalOwnerSetsReady,
+    ownerRotation.historicalBootstrapSyncOwners,
+    profileAuth.isSeedLogin,
+  ]);
+
+  React.useEffect(() => {
+    cashuOwnerIdRef.current = ownerRotation.cashuOwnerId;
+  }, [ownerRotation.cashuOwnerId]);
+
+  React.useEffect(() => {
+    messagesOwnerIdRef.current = ownerRotation.messagesOwnerId;
+  }, [ownerRotation.messagesOwnerId]);
+
+  React.useEffect(() => {
+    transactionsOwnerIdRef.current = ownerRotation.transactionsOwnerId;
+  }, [ownerRotation.transactionsOwnerId]);
+
+  React.useEffect(() => {
+    recordTransactionsOwnerWriteRef.current =
+      ownerRotation.recordTransactionsOwnerWrite;
+  }, [ownerRotation.recordTransactionsOwnerWrite]);
+
+  const nostrIdentityQuery = React.useMemo(
+    () =>
+      evolu.createQuery((db) =>
+        db
+          .selectFrom("nostrIdentity")
+          .selectAll()
+          .where("isDeleted", "is not", Evolu.sqliteTrue)
+          .orderBy("createdAt", "desc"),
+      ),
+    [evolu],
+  );
+  const nostrIdentityRows = useQuery(nostrIdentityQuery);
+
+  const activeIdentityOwnerId = String(
+    ownerRotation.identityOwnerId ?? "",
+  ).trim();
+  const legacyNostrIdentityOwnerIds = React.useMemo(
+    () =>
+      new Set(
+        [
+          ...ownerRotation.messagesVisibleOwnerIds,
+          ownerRotation.legacyIdentitiesOwnerId,
+          ownerRotation.legacyMessagesIdentityOwnerId,
+          ownerRotation.metaOwnerId,
+        ]
+          .map((ownerId) => String(ownerId ?? "").trim())
+          .filter(Boolean),
+      ),
+    [
+      ownerRotation.legacyIdentitiesOwnerId,
+      ownerRotation.legacyMessagesIdentityOwnerId,
+      ownerRotation.messagesVisibleOwnerIds,
+      ownerRotation.metaOwnerId,
+    ],
+  );
+  const syncedNostrIdentityResolution = React.useMemo(
+    () =>
+      resolveSyncedNostrIdentity(
+        nostrIdentityRows,
+        activeIdentityOwnerId,
+        legacyNostrIdentityOwnerIds,
+      ),
+    [activeIdentityOwnerId, legacyNostrIdentityOwnerIds, nostrIdentityRows],
+  );
+  const activeSyncedNostrIdentity = syncedNostrIdentityResolution.identity;
+  const syncedNostrIdentityMatchesLocal = React.useMemo(() => {
+    if (!activeSyncedNostrIdentity) return true;
+
+    const localSource = getInitialNostrIdentitySource();
+    const localSwitchedAtSec = getInitialNostrIdentitySwitchedAtSec();
+    const localNsec = String(currentNsec ?? "").trim();
+    const syncedSwitchedAtSec = activeSyncedNostrIdentity.switchedAtSec;
+    const switchedAtMatches =
+      localSwitchedAtSec === syncedSwitchedAtSec ||
+      (!localSwitchedAtSec && !syncedSwitchedAtSec);
+
+    return (
+      localNsec === activeSyncedNostrIdentity.nsec &&
+      localSource === activeSyncedNostrIdentity.source &&
+      switchedAtMatches
+    );
+  }, [activeSyncedNostrIdentity, currentNsec]);
+
+  React.useEffect(() => {
+    if (!syncedNostrIdentityResolution.shouldMigrateLegacyIdentity) return;
+    if (!activeSyncedNostrIdentity || !ownerRotation.identityOwnerId) return;
+
+    upsert(
+      "nostrIdentity",
+      {
+        id: ACTIVE_NOSTR_IDENTITY_ROW_ID,
+        nsec: activeSyncedNostrIdentity.nsec,
+        source: activeSyncedNostrIdentity.source,
+        ...(activeSyncedNostrIdentity.npub
+          ? { npub: activeSyncedNostrIdentity.npub }
+          : {}),
+        ...(activeSyncedNostrIdentity.switchedAtSec
+          ? { switchedAtSec: activeSyncedNostrIdentity.switchedAtSec }
+          : {}),
+      },
+      { ownerId: ownerRotation.identityOwnerId },
+    );
+  }, [
+    activeSyncedNostrIdentity,
+    ownerRotation.identityOwnerId,
+    syncedNostrIdentityResolution.shouldMigrateLegacyIdentity,
+    upsert,
+  ]);
+
+  React.useEffect(() => {
+    if (!activeSyncedNostrIdentity) return;
+    if (syncedNostrIdentityMatchesLocal) return;
+
+    void persistSyncedActiveNostrIdentity({
+      identitySource: activeSyncedNostrIdentity.source,
+      nsec: activeSyncedNostrIdentity.nsec,
+      switchedAtSec: activeSyncedNostrIdentity.switchedAtSec,
+    }).then(() => {
+      setCurrentNsec((current) =>
+        current === activeSyncedNostrIdentity.nsec
+          ? current
+          : activeSyncedNostrIdentity.nsec,
+      );
+      navigation.reload();
+    });
+  }, [
+    activeSyncedNostrIdentity,
+    navigation,
+    syncedNostrIdentityMatchesLocal,
+    setCurrentNsec,
+  ]);
+
+  return {
+    ...profileAuth,
+    ...ownerRotation,
+    activeSyncedNostrIdentity,
+    appOwnerId,
+    appOwnerIdRef,
+    appendIdentityChangeNoticesRef,
+    cashuOwnerIdRef,
+    currentNsec,
+    historicalOwnerSetsReady,
+    messagesOwnerIdRef,
+    nostrIdentityRows,
+    recordTransactionsOwnerWriteRef,
+    setCurrentNsec,
+    syncedNostrIdentityMatchesLocal,
+    syncedNostrIdentityResolution,
+    syncOwner,
+    transactionsOwnerIdRef,
+  };
+};

--- a/apps/web-app/src/app/hooks/composition/useProfileComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useProfileComposition.ts
@@ -180,6 +180,9 @@ export const useProfileComposition = ({
     }
   }, [isProfileEditing, route.kind, toggleProfileEditing]);
 
+  // Intentionally no automatic publishing of kind-0 profile metadata.
+  // We only publish profile changes when the user does so explicitly.
+
   const openProfileQr = React.useCallback(() => {
     navigateTo({ route: "profile" });
   }, []);

--- a/apps/web-app/src/app/hooks/composition/useProfileComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useProfileComposition.ts
@@ -1,0 +1,244 @@
+import React from "react";
+import {
+  DEFAULT_LIGHTNING_ADDRESS_DOMAIN,
+  deriveDefaultLightningAddress,
+  deriveDefaultProfile,
+} from "../../../derivedProfile";
+import type { Lang } from "../../../i18n";
+import type { NostrProfileMetadata } from "../../../nostrProfile";
+import { navigateTo, type useRouting } from "../../../hooks/useRouting";
+import { resolveNpubCashServerBaseUrl } from "../../../utils/npubCashServer";
+import { getInitialShowProfileQrOnTiltEnabled } from "../../../utils/storage";
+import { usePortraitOrientationLock } from "../usePortraitOrientationLock";
+import { useProfileEditor } from "../profile/useProfileEditor";
+import { useProfileMetadataSyncEffect } from "../profile/useProfileMetadataSyncEffect";
+import { useProfileStatusEditor } from "../profile/useProfileStatusEditor";
+import { useProfileStatusSyncEffect } from "../profile/useProfileStatusSyncEffect";
+
+interface UseProfileCompositionParams {
+  currentNpub: string | null;
+  currentNsec: string | null;
+  lang: Lang;
+  nostrBootstrapReady: boolean;
+  nostrFetchRelays: string[];
+  rememberBlobAvatarUrl: (npub: string, url: string | null) => string | null;
+  route: ReturnType<typeof useRouting>;
+  setStatus: React.Dispatch<React.SetStateAction<string | null>>;
+  t: (key: string) => string;
+}
+
+export const useProfileComposition = ({
+  currentNpub,
+  currentNsec,
+  lang,
+  nostrBootstrapReady,
+  nostrFetchRelays,
+  rememberBlobAvatarUrl,
+  route,
+  setStatus,
+  t,
+}: UseProfileCompositionParams) => {
+  const [showProfileQrOnTiltEnabled, setShowProfileQrOnTiltEnabled] =
+    React.useState<boolean>(() => getInitialShowProfileQrOnTiltEnabled());
+  const [myProfileName, setMyProfileName] = React.useState<string | null>(null);
+  const [myProfilePicture, setMyProfilePicture] = React.useState<string | null>(
+    null,
+  );
+  const [myProfileQr, setMyProfileQr] = React.useState<string | null>(null);
+  const [myProfileLnAddress, setMyProfileLnAddress] = React.useState<
+    string | null
+  >(null);
+  const [ownedProfileLightningAddresses, setOwnedProfileLightningAddresses] =
+    React.useState<string[]>([]);
+  const [
+    ownedProfileLightningAddressesLoading,
+    setOwnedProfileLightningAddressesLoading,
+  ] = React.useState(true);
+  const [myProfileStatus, setMyProfileStatus] = React.useState<string | null>(
+    null,
+  );
+  const [myProfileMetadata, setMyProfileMetadata] =
+    React.useState<NostrProfileMetadata | null>(null);
+
+  const npubCashInfoInFlightRef = React.useRef(false);
+  const npubCashInfoLoadedForNpubRef = React.useRef<string | null>(null);
+  const npubCashInfoLoadedAtMsRef = React.useRef<number>(0);
+
+  usePortraitOrientationLock(showProfileQrOnTiltEnabled);
+
+  const defaultLightningAddress = React.useMemo(() => {
+    if (!currentNpub) return null;
+    return deriveDefaultLightningAddress(currentNpub);
+  }, [currentNpub]);
+
+  const derivedProfile = React.useMemo(() => {
+    if (!currentNpub) return null;
+    return deriveDefaultProfile(currentNpub, lang);
+  }, [currentNpub, lang]);
+
+  const effectiveProfileName = myProfileName ?? derivedProfile?.name ?? null;
+  const effectiveProfilePicture =
+    myProfilePicture ?? derivedProfile?.pictureUrl ?? null;
+
+  const effectiveMyLightningAddress =
+    myProfileLnAddress ?? defaultLightningAddress;
+
+  const npubCashServerBaseUrl = React.useMemo(() => {
+    return resolveNpubCashServerBaseUrl(effectiveMyLightningAddress);
+  }, [effectiveMyLightningAddress]);
+
+  const profileClaimLightningAddressServerBaseUrl = React.useMemo(() => {
+    return resolveNpubCashServerBaseUrl(
+      `claim@${DEFAULT_LIGHTNING_ADDRESS_DOMAIN}`,
+    );
+  }, []);
+
+  const {
+    cycleProfileAvatarControl,
+    isProfileEditing,
+    onPickProfilePhoto,
+    onProfilePhotoError,
+    onProfilePhotoSelected,
+    profileCustomPictureUrl,
+    profileEditInitialRef,
+    profileEditLnAddress,
+    profileEditName,
+    profileEditPicture,
+    profileEditStatus,
+    profileEditsSavable,
+    profilePhotoInputRef,
+    profileSelectedPictureKind,
+    saveClaimedLightningAddress,
+    saveProfileEdits,
+    setIsProfileEditing,
+    setProfileEditLnAddress,
+    setProfileEditName,
+    setProfileEditStatus,
+    toggleProfileEditing,
+    unregisteredOwnLightningAddress,
+  } = useProfileEditor({
+    currentNpub,
+    currentNsec,
+    defaultLightningAddress,
+    effectiveMyLightningAddress,
+    effectiveProfileName,
+    effectiveProfilePicture,
+    myProfileMetadata,
+    myProfileStatus,
+    nostrFetchRelays,
+    ownedLightningAddresses: ownedProfileLightningAddresses,
+    ownedLightningAddressesLoading: ownedProfileLightningAddressesLoading,
+    setMyProfileLnAddress,
+    setMyProfileMetadata,
+    setMyProfileName,
+    setMyProfilePicture,
+    setMyProfileStatus,
+    setStatus,
+    t,
+  });
+
+  useProfileMetadataSyncEffect({
+    canFetchFromNostr: nostrBootstrapReady,
+    currentNpub,
+    nostrFetchRelays,
+    rememberBlobAvatarUrl,
+    setMyProfileLnAddress,
+    setMyProfileMetadata,
+    setMyProfileName,
+    setMyProfilePicture,
+  });
+
+  useProfileStatusSyncEffect({
+    canFetchFromNostr: nostrBootstrapReady,
+    currentNpub,
+    nostrFetchRelays,
+    setMyProfileStatus,
+  });
+
+  const {
+    profileStatusCurrencies,
+    profileStatusIsSaving,
+    selectedProfileStatusCurrencies,
+    toggleProfileStatusCurrency,
+  } = useProfileStatusEditor({
+    currentNpub,
+    currentNsec,
+    myProfileStatus,
+    nostrFetchRelays,
+    setMyProfileStatus,
+    setStatus,
+    t,
+  });
+
+  React.useEffect(() => {
+    if (route.kind !== "profileEdit") {
+      return;
+    }
+
+    if (!isProfileEditing) {
+      toggleProfileEditing();
+    }
+  }, [isProfileEditing, route.kind, toggleProfileEditing]);
+
+  const openProfileQr = React.useCallback(() => {
+    navigateTo({ route: "profile" });
+  }, []);
+
+  return {
+    cycleProfileAvatarControl,
+    defaultLightningAddress,
+    derivedProfile,
+    effectiveMyLightningAddress,
+    effectiveProfileName,
+    effectiveProfilePicture,
+    isProfileEditing,
+    myProfileLnAddress,
+    myProfileMetadata,
+    myProfileName,
+    myProfilePicture,
+    myProfileQr,
+    myProfileStatus,
+    npubCashInfoInFlightRef,
+    npubCashInfoLoadedAtMsRef,
+    npubCashInfoLoadedForNpubRef,
+    npubCashServerBaseUrl,
+    onPickProfilePhoto,
+    onProfilePhotoError,
+    onProfilePhotoSelected,
+    openProfileQr,
+    ownedProfileLightningAddresses,
+    ownedProfileLightningAddressesLoading,
+    profileClaimLightningAddressServerBaseUrl,
+    profileCustomPictureUrl,
+    profileEditInitialRef,
+    profileEditLnAddress,
+    profileEditName,
+    profileEditPicture,
+    profileEditStatus,
+    profileEditsSavable,
+    profilePhotoInputRef,
+    profileSelectedPictureKind,
+    profileStatusCurrencies,
+    profileStatusIsSaving,
+    saveClaimedLightningAddress,
+    saveProfileEdits,
+    selectedProfileStatusCurrencies,
+    setIsProfileEditing,
+    setMyProfileLnAddress,
+    setMyProfileMetadata,
+    setMyProfileName,
+    setMyProfilePicture,
+    setMyProfileQr,
+    setMyProfileStatus,
+    setOwnedProfileLightningAddresses,
+    setOwnedProfileLightningAddressesLoading,
+    setProfileEditLnAddress,
+    setProfileEditName,
+    setProfileEditStatus,
+    setShowProfileQrOnTiltEnabled,
+    showProfileQrOnTiltEnabled,
+    toggleProfileEditing,
+    toggleProfileStatusCurrency,
+    unregisteredOwnLightningAddress,
+  };
+};

--- a/apps/web-app/src/app/hooks/composition/useScanNativeComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useScanNativeComposition.ts
@@ -1,0 +1,1368 @@
+import { Share } from "@capacitor/share";
+import { nip19 } from "nostr-tools";
+import React from "react";
+import type { CashuTokenId, useEvolu } from "../../../evolu";
+import { navigateTo, useRouting } from "../../../hooks/useRouting";
+import { NOSTR_RELAYS } from "../../../nostrProfile";
+import {
+  cancelNativeNfcWrite,
+  consumePendingIosNativeDeepLinkUrl,
+  consumePendingNativeDeepLinkUrl,
+  consumePendingNativeNotificationOpenDetail,
+  consumePendingNativeNotificationRoute,
+  NATIVE_DEEP_LINK_EVENT,
+  NATIVE_NOTIFICATION_OPEN_EVENT,
+  NATIVE_PUSH_ACTION_EVENT,
+  startNativeNfcWrite,
+  supportsNativeNfcWrite,
+} from "../../../platform/nativeBridge";
+import { isNativePlatform } from "../../../platform/runtime";
+import { PENDING_DEEP_LINK_TEXT_STORAGE_KEY } from "../../../utils/constants";
+import {
+  buildCashuDeepLink,
+  parseNativeDeepLinkUrl,
+} from "../../../utils/deepLinks";
+import { normalizeNpubIdentifier } from "../../../utils/nostrNpub";
+import {
+  safeLocalStorageGet,
+  safeLocalStorageRemove,
+  safeLocalStorageSet,
+} from "../../../utils/storage";
+import { useContactsOnboardingProgress } from "../guide/useContactsOnboardingProgress";
+import {
+  extractClientTag,
+  extractEditedFromTag,
+  extractReplyContextFromTags,
+  isInvalidInnerRumorPubkey,
+  isNestedEncryptedNip44PayloadForAnyPubkey,
+} from "../messages/chatNostrProtocol";
+import {
+  buildUnknownContactId,
+  normalizePubkeyHex,
+} from "../messages/contactIdentity";
+import { hasKnownNostrMessageIdentity } from "../messages/messageHelpers";
+import { useGuideScannerDomain } from "../useGuideScannerDomain";
+import { useScannedTextHandler } from "../useScannedTextHandler";
+import { useScannedTextHandlerRefBridge } from "../useScannedTextHandlerRefBridge";
+import {
+  getLinkyBankPaymentOfferInfo,
+  isLinkyBankPaymentOfferEvent,
+  setLinkyBankPaymentOfferMinimized,
+} from "../../lib/bankPaymentOffer";
+import {
+  CASHU_TOKEN_STATE_EXTERNALIZED,
+  isCashuTokenAcceptedState,
+} from "../../lib/cashuTokenState";
+import {
+  consumeNotificationOpenDetailFromHash,
+  readNotificationOpenRoute,
+  readNotificationOpenTarget,
+} from "../../lib/notificationOpenTarget";
+import { getSharedAppNostrPool } from "../../lib/nostrPool";
+import { privateImageMessageFromEvent } from "../../lib/privateImageMessage";
+import {
+  getLinkyBankPaymentOfferPaymentNoticeOfferId,
+  isLinkyBankPaymentOfferPaymentNoticeEvent,
+} from "../../lib/pushWrappedEvent";
+import {
+  extractCashuTokenFromText,
+  extractCashuTokenFromText as extractCashuTokenFromTextFromUrl,
+} from "../../lib/tokenText";
+import type { LocalNostrMessage } from "../../types/appTypes";
+import type { useCashuWalletComposition } from "./useCashuWalletComposition";
+import type { useContactsMessagingComposition } from "./useContactsMessagingComposition";
+import type { useIdentityOwnersComposition } from "./useIdentityOwnersComposition";
+
+type CashuWalletCompositionResult = ReturnType<
+  typeof useCashuWalletComposition
+>;
+type ContactsMessagingCompositionResult = ReturnType<
+  typeof useContactsMessagingComposition
+>;
+type EvoluMutations = ReturnType<typeof useEvolu>;
+type IdentityOwnersCompositionResult = ReturnType<
+  typeof useIdentityOwnersComposition
+>;
+
+interface QueuedNotificationOpenDetail {
+  value: unknown;
+}
+
+interface UseScanNativeCompositionParams {
+  addNewContactFromIdentifier: ContactsMessagingCompositionResult["addNewContactFromIdentifier"];
+  appendLocalNostrMessage: ContactsMessagingCompositionResult["appendLocalNostrMessage"];
+  bankPaymentOfferMessages: ContactsMessagingCompositionResult["bankPaymentOfferMessages"];
+  cashuBalance: CashuWalletCompositionResult["cashuBalance"];
+  cashuOwnerId: IdentityOwnersCompositionResult["cashuOwnerId"];
+  cashuTokensAllFiltered: CashuWalletCompositionResult["cashuTokensAllFiltered"];
+  contacts: ContactsMessagingCompositionResult["contacts"];
+  contactsLatestRef: ContactsMessagingCompositionResult["contactsLatestRef"];
+  contactsOnboardingDismissedSynced: boolean;
+  contactsOnboardingHasBackedUpKeys: ContactsMessagingCompositionResult["contactsOnboardingHasBackedUpKeys"];
+  contactsOnboardingHasPaid: ContactsMessagingCompositionResult["contactsOnboardingHasPaid"];
+  contactsOnboardingHasSentMessage: ContactsMessagingCompositionResult["contactsOnboardingHasSentMessage"];
+  contactsOwnerId: IdentityOwnersCompositionResult["contactsOwnerId"];
+  copyText: (value: string) => Promise<void>;
+  currentNpub: string | null;
+  currentNsec: string | null;
+  insert: EvoluMutations["insert"];
+  knownNostrMessageIdentityIndex: ContactsMessagingCompositionResult["knownNostrMessageIdentityIndex"];
+  lightningInvoiceAutoPayLimit: CashuWalletCompositionResult["lightningInvoiceAutoPayLimit"];
+  markCashuTokenIssued: CashuWalletCompositionResult["markCashuTokenIssued"];
+  nostrBootstrapReady: ContactsMessagingCompositionResult["nostrBootstrapReady"];
+  nostrFetchRelays: ContactsMessagingCompositionResult["nostrFetchRelays"];
+  nostrMessagesLatestRef: ContactsMessagingCompositionResult["nostrMessagesLatestRef"];
+  nostrMessageWrapIdsRef: ContactsMessagingCompositionResult["nostrMessageWrapIdsRef"];
+  openNewContactPage: ContactsMessagingCompositionResult["openNewContactPage"];
+  openScannedContactPendingNpubRef: ContactsMessagingCompositionResult["openScannedContactPendingNpubRef"];
+  payCashuPaymentRequest: CashuWalletCompositionResult["payCashuPaymentRequest"];
+  payLightningInvoiceWithCashu: CashuWalletCompositionResult["payLightningInvoiceWithCashu"];
+  persistContactsOnboardingDismissed: () => void;
+  pushToast: (message: string) => void;
+  refreshContactFromNostr: ContactsMessagingCompositionResult["refreshContactFromNostr"];
+  route: ReturnType<typeof useRouting>;
+  saveCashuFromText: CashuWalletCompositionResult["saveCashuFromText"];
+  setPendingDeleteId: ContactsMessagingCompositionResult["setPendingDeleteId"];
+  setPendingLightningInvoiceConfirmation: CashuWalletCompositionResult["setPendingLightningInvoiceConfirmation"];
+  setPendingLnurlWithdrawConfirmation: CashuWalletCompositionResult["setPendingLnurlWithdrawConfirmation"];
+  setStatus: React.Dispatch<React.SetStateAction<string | null>>;
+  t: (key: string) => string;
+  triggerChatScrollToBottom: ContactsMessagingCompositionResult["triggerChatScrollToBottom"];
+  update: EvoluMutations["update"];
+  updateLocalNostrMessage: ContactsMessagingCompositionResult["updateLocalNostrMessage"];
+  upsertBankPaymentOfferMessage: ContactsMessagingCompositionResult["upsertBankPaymentOfferMessage"];
+}
+
+export const useScanNativeComposition = ({
+  addNewContactFromIdentifier,
+  appendLocalNostrMessage,
+  bankPaymentOfferMessages,
+  cashuBalance,
+  cashuOwnerId,
+  cashuTokensAllFiltered,
+  contacts,
+  contactsLatestRef,
+  contactsOnboardingDismissedSynced,
+  contactsOnboardingHasBackedUpKeys,
+  contactsOnboardingHasPaid,
+  contactsOnboardingHasSentMessage,
+  contactsOwnerId,
+  copyText,
+  currentNpub,
+  currentNsec,
+  insert,
+  knownNostrMessageIdentityIndex,
+  lightningInvoiceAutoPayLimit,
+  markCashuTokenIssued,
+  nostrBootstrapReady,
+  nostrFetchRelays,
+  nostrMessagesLatestRef,
+  nostrMessageWrapIdsRef,
+  openNewContactPage,
+  openScannedContactPendingNpubRef,
+  payCashuPaymentRequest,
+  payLightningInvoiceWithCashu,
+  persistContactsOnboardingDismissed,
+  pushToast,
+  refreshContactFromNostr,
+  route,
+  saveCashuFromText,
+  setPendingDeleteId,
+  setPendingLightningInvoiceConfirmation,
+  setPendingLnurlWithdrawConfirmation,
+  setStatus,
+  t,
+  triggerChatScrollToBottom,
+  update,
+  updateLocalNostrMessage,
+  upsertBankPaymentOfferMessage,
+}: UseScanNativeCompositionParams) => {
+  const pendingNotificationOpenDetailsRef = React.useRef<
+    QueuedNotificationOpenDetail[]
+  >([]);
+  const [shareOptionsText, setShareOptionsText] = React.useState<string | null>(
+    null,
+  );
+  const [pendingDeepLinkText, setPendingDeepLinkText] = React.useState<
+    string | null
+  >(() => {
+    const stored = String(
+      safeLocalStorageGet(PENDING_DEEP_LINK_TEXT_STORAGE_KEY) ?? "",
+    ).trim();
+    return stored || null;
+  });
+
+  const updatePendingDeepLinkText = React.useCallback(
+    (value: string | null) => {
+      const normalized = String(value ?? "").trim();
+
+      if (!normalized) {
+        safeLocalStorageRemove(PENDING_DEEP_LINK_TEXT_STORAGE_KEY);
+        setPendingDeepLinkText(null);
+        return;
+      }
+
+      safeLocalStorageSet(PENDING_DEEP_LINK_TEXT_STORAGE_KEY, normalized);
+      setPendingDeepLinkText(normalized);
+    },
+    [],
+  );
+
+  const scannedTextHandlerRef = React.useRef<
+    (rawValue: string) => Promise<void>
+  >(async () => {});
+
+  const {
+    closeScan,
+    contactsGuide,
+    contactsGuideActiveStep,
+    contactsGuideHighlightRect,
+    contactsGuideNav,
+    openScan,
+    openReceiveScan,
+    openWalletScan,
+    scanAllowsManualContact,
+    scanEntryPoint,
+    scanIsOpen,
+    scanVideoRef,
+    startContactsGuide,
+    stopContactsGuide,
+  } = useGuideScannerDomain({
+    cashuBalance,
+    contacts,
+    contactsOnboardingHasBackedUpKeys,
+    contactsOnboardingHasPaid,
+    contactsOnboardingHasSentMessage,
+    openNewContactPage,
+    onScannedText: (rawValue: string) =>
+      scannedTextHandlerRef.current(rawValue),
+    pushToast,
+    route,
+    t,
+  });
+  const contactsGuideNavRef = React.useRef(contactsGuideNav);
+  React.useLayoutEffect(() => {
+    contactsGuideNavRef.current = contactsGuideNav;
+  }, [contactsGuideNav]);
+  const stableContactsGuideNav = React.useMemo(
+    () => ({
+      back: () => {
+        contactsGuideNavRef.current.back();
+      },
+      next: () => {
+        contactsGuideNavRef.current.next();
+      },
+    }),
+    [],
+  );
+
+  const openManualContactFromScan = React.useCallback(() => {
+    closeScan();
+    if (route.kind === "contactNew") return;
+    openNewContactPage();
+  }, [closeScan, openNewContactPage, route.kind]);
+
+  const scanImageInputRef = React.useRef<HTMLInputElement | null>(null);
+
+  const openIssueTokenFromScan = React.useCallback(() => {
+    closeScan();
+    if (route.kind === "cashuTokenEmit") return;
+    navigateTo({ route: "cashuTokenEmit" });
+  }, [closeScan, route.kind]);
+
+  const openManualPayFromScan = React.useCallback(() => {
+    closeScan();
+    if (route.kind === "manualPay") return;
+    navigateTo({ route: "manualPay" });
+  }, [closeScan, route.kind]);
+
+  const onPickScanImage = React.useCallback(() => {
+    scanImageInputRef.current?.click();
+  }, []);
+
+  const {
+    contactsOnboardingCelebrating,
+    contactsOnboardingTasks,
+    dismissContactsOnboarding,
+    showContactsOnboarding,
+  } = useContactsOnboardingProgress({
+    cashuBalance,
+    contactsCount: contacts.length,
+    contactsOnboardingDismissedSynced,
+    contactsOnboardingHasBackedUpKeys,
+    contactsOnboardingHasPaid,
+    contactsOnboardingHasSentMessage,
+    persistContactsOnboardingDismissed,
+    routeKind: route.kind,
+    stopContactsGuide,
+    t,
+  });
+
+  const closeShareOptions = React.useCallback(() => {
+    setShareOptionsText(null);
+  }, []);
+
+  const openShareOptionsUrl = React.useCallback((url: string) => {
+    if (typeof window === "undefined") return;
+    window.open(url, "_blank", "noopener,noreferrer");
+    setShareOptionsText(null);
+  }, []);
+
+  const copyShareOptionsText = React.useCallback(async () => {
+    const text = String(shareOptionsText ?? "").trim();
+    if (!text) return;
+    await copyText(text);
+    setShareOptionsText(null);
+  }, [copyText, shareOptionsText]);
+
+  const shareOptionsViaEmail = React.useCallback(() => {
+    const text = String(shareOptionsText ?? "").trim();
+    if (!text) return;
+    openShareOptionsUrl(`mailto:?body=${encodeURIComponent(text)}`);
+  }, [openShareOptionsUrl, shareOptionsText]);
+
+  const shareOptionsViaSms = React.useCallback(() => {
+    const text = String(shareOptionsText ?? "").trim();
+    if (!text) return;
+    openShareOptionsUrl(`sms:?body=${encodeURIComponent(text)}`);
+  }, [openShareOptionsUrl, shareOptionsText]);
+
+  const shareOptionsViaWhatsApp = React.useCallback(() => {
+    const text = String(shareOptionsText ?? "").trim();
+    if (!text) return;
+    openShareOptionsUrl(`https://wa.me/?text=${encodeURIComponent(text)}`);
+  }, [openShareOptionsUrl, shareOptionsText]);
+
+  const shareText = React.useCallback(
+    async (value: string) => {
+      const text = String(value ?? "").trim();
+      if (!text) {
+        pushToast(t("errorPrefix"));
+        return;
+      }
+
+      if (isNativePlatform()) {
+        try {
+          await Share.share({ text });
+          return;
+        } catch (error) {
+          const errorMessage =
+            typeof error === "object" &&
+            error !== null &&
+            "message" in error &&
+            typeof error.message === "string"
+              ? error.message
+              : "";
+          if (
+            /cancel/i.test(errorMessage) ||
+            /abort/i.test(errorMessage) ||
+            /dismiss/i.test(errorMessage)
+          ) {
+            return;
+          }
+          pushToast(t("shareFailed"));
+          return;
+        }
+      }
+
+      if (typeof navigator.share === "function") {
+        try {
+          await navigator.share({ text });
+          return;
+        } catch (error) {
+          const errorName =
+            typeof error === "object" &&
+            error !== null &&
+            "name" in error &&
+            typeof error.name === "string"
+              ? error.name
+              : "";
+          if (errorName === "AbortError") return;
+          pushToast(t("shareFailed"));
+          return;
+        }
+      }
+
+      pushToast(t("shareUnavailable"));
+    },
+    [pushToast, t],
+  );
+
+  const canWriteNfc = supportsNativeNfcWrite();
+  const [nfcWritePromptKind, setNfcWritePromptKind] = React.useState<
+    "profile" | "token" | null
+  >(null);
+  const nfcWriteCancelledByUserRef = React.useRef(false);
+
+  const cancelPendingNfcWrite = React.useCallback(() => {
+    nfcWriteCancelledByUserRef.current = true;
+    setNfcWritePromptKind(null);
+    cancelNativeNfcWrite();
+  }, []);
+
+  const writeNfcUriWithToast = React.useCallback(
+    async (
+      url: string,
+      successKey: "nfcWriteProfileSuccess" | "nfcWriteTokenSuccess",
+      promptKind: "profile" | "token",
+    ): Promise<boolean> => {
+      nfcWriteCancelledByUserRef.current = false;
+
+      const result = await startNativeNfcWrite(url, (progress) => {
+        if (progress.status === "armed" && progress.prompt === "web") {
+          setNfcWritePromptKind(promptKind);
+        }
+      });
+
+      setNfcWritePromptKind(null);
+
+      if (result === null || result.status === "unsupported") {
+        pushToast(t("nfcWriteUnsupported"));
+        return false;
+      }
+
+      if (result.status === "success") {
+        pushToast(t(successKey));
+        return true;
+      }
+
+      if (result.status === "disabled") {
+        pushToast(t("nfcWriteDisabled"));
+        return false;
+      }
+
+      if (result.status === "busy") {
+        pushToast(t("nfcWriteBusy"));
+        return false;
+      }
+
+      if (result.status === "cancelled") {
+        if (nfcWriteCancelledByUserRef.current) {
+          nfcWriteCancelledByUserRef.current = false;
+          return false;
+        }
+
+        pushToast(t("nfcWriteCancelled"));
+        return false;
+      }
+
+      nfcWriteCancelledByUserRef.current = false;
+
+      const message = String(result.message ?? "").trim();
+      pushToast(
+        message ? `${t("nfcWriteFailed")}: ${message}` : t("nfcWriteFailed"),
+      );
+
+      return false;
+    },
+    [pushToast, t],
+  );
+
+  const writeCashuTokenToNfc = React.useCallback(
+    async (id: CashuTokenId, tokenText: string) => {
+      const trimmed = String(tokenText ?? "").trim();
+      const deepLink = buildCashuDeepLink(trimmed);
+      if (!deepLink) {
+        pushToast(t("cashuInvalid"));
+        return;
+      }
+
+      const wrote = await writeNfcUriWithToast(
+        deepLink,
+        "nfcWriteTokenSuccess",
+        "token",
+      );
+
+      if (!wrote) return;
+
+      const payload = {
+        id,
+        state: CASHU_TOKEN_STATE_EXTERNALIZED,
+        error: null,
+      };
+
+      const result = cashuOwnerId
+        ? update("cashuToken", payload, { ownerId: cashuOwnerId })
+        : update("cashuToken", payload);
+
+      if (!result.ok) {
+        setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
+      }
+    },
+    [cashuOwnerId, pushToast, setStatus, t, update, writeNfcUriWithToast],
+  );
+
+  const shareCashuTokenText = React.useCallback(
+    async (id: CashuTokenId, text: string) => {
+      const trimmed = String(text ?? "").trim();
+      if (!trimmed) {
+        pushToast(t("cashuInvalid"));
+        return;
+      }
+
+      const row = cashuTokensAllFiltered.find(
+        (candidate) => candidate.id === id && !candidate.isDeleted,
+      );
+      if (!row) {
+        pushToast(t("cashuInvalid"));
+        return;
+      }
+
+      if (isNativePlatform() || typeof navigator.share === "function") {
+        await shareText(trimmed);
+      } else {
+        setShareOptionsText(trimmed);
+      }
+
+      if (isCashuTokenAcceptedState(row.state)) {
+        await markCashuTokenIssued(id);
+      }
+    },
+    [cashuTokensAllFiltered, markCashuTokenIssued, pushToast, shareText, t],
+  );
+
+  const writeCurrentNpubToNfc = React.useCallback(async () => {
+    const npub = normalizeNpubIdentifier(currentNpub);
+    if (!npub) {
+      pushToast(t("profileMissingNpub"));
+      return;
+    }
+
+    await writeNfcUriWithToast(
+      `nostr://${npub}`,
+      "nfcWriteProfileSuccess",
+      "profile",
+    );
+  }, [currentNpub, pushToast, t, writeNfcUriWithToast]);
+
+  const openNotificationChat = React.useCallback(
+    async (rawDetail: unknown): Promise<boolean> => {
+      const target = readNotificationOpenTarget(rawDetail);
+      if (!target || !currentNsec) {
+        return false;
+      }
+
+      let openedFromNotificationData = false;
+      try {
+        const decoded = nip19.decode(currentNsec);
+        if (decoded.type !== "nsec" || !(decoded.data instanceof Uint8Array)) {
+          return false;
+        }
+
+        const { getPublicKey } = await import("nostr-tools");
+        const { unwrapEvent } = await import("nostr-tools/nip17");
+
+        const privBytes = decoded.data;
+        const myPubHex = getPublicKey(privBytes);
+        if (target.recipientPubkey !== myPubHex) {
+          return false;
+        }
+
+        const findKnownContact = (peerPubkey: string) =>
+          contactsLatestRef.current.find((contact) => {
+            const normalizedNpub = normalizeNpubIdentifier(contact.npub);
+            if (!normalizedNpub) {
+              return false;
+            }
+
+            try {
+              const decodedContact = nip19.decode(normalizedNpub);
+              return (
+                decodedContact.type === "npub" &&
+                typeof decodedContact.data === "string" &&
+                normalizePubkeyHex(decodedContact.data) === peerPubkey
+              );
+            } catch {
+              return false;
+            }
+          }) ?? null;
+
+        const openKnownNotificationContact = (peerPubkey: string): boolean => {
+          const knownContact = findKnownContact(peerPubkey);
+          const knownContactId = String(knownContact?.id ?? "").trim();
+          if (!knownContactId) {
+            return false;
+          }
+
+          setPendingDeleteId(null);
+          navigateTo({ route: "chat", id: knownContactId });
+          return true;
+        };
+
+        openedFromNotificationData = target.senderPubkey
+          ? openKnownNotificationContact(target.senderPubkey)
+          : false;
+
+        const relays = Array.from(
+          new Set([...target.relayHints, ...nostrFetchRelays, ...NOSTR_RELAYS]),
+        );
+        const pool = await getSharedAppNostrPool();
+        const wraps = await pool.querySync(
+          relays,
+          {
+            ids: [target.outerEventId],
+            kinds: [1059],
+            "#p": [myPubHex],
+            limit: 1,
+          },
+          { maxWait: 2500 },
+        );
+        const wrap = wraps[0] ?? null;
+        if (!wrap) {
+          return (
+            openedFromNotificationData ||
+            (target.senderPubkey
+              ? openKnownNotificationContact(target.senderPubkey)
+              : false)
+          );
+        }
+
+        const wrapId = String(wrap.id ?? "").trim();
+        if (!wrapId) {
+          return openedFromNotificationData;
+        }
+
+        const inner = unwrapEvent(wrap, privBytes);
+        if (!inner) {
+          return openedFromNotificationData;
+        }
+
+        const senderPub = normalizePubkeyHex(inner.pubkey);
+        const tags = Array.isArray(inner.tags) ? inner.tags : [];
+        const pTags = tags
+          .filter((tag) => Array.isArray(tag) && tag[0] === "p")
+          .map((tag) => normalizePubkeyHex(tag[1]))
+          .filter((pubkey): pubkey is string => Boolean(pubkey));
+
+        const peerPubkey =
+          senderPub && senderPub !== myPubHex
+            ? senderPub
+            : (pTags.find((pubkey) => pubkey !== myPubHex) ?? null);
+        if (!peerPubkey) {
+          return openedFromNotificationData;
+        }
+
+        const knownContact = findKnownContact(peerPubkey);
+
+        const contactId = knownContact
+          ? String(knownContact.id ?? "").trim()
+          : String(buildUnknownContactId(peerPubkey) ?? "").trim();
+        if (!contactId) {
+          return false;
+        }
+
+        let insertedMessageId: string | null = null;
+
+        if (isLinkyBankPaymentOfferPaymentNoticeEvent(inner)) {
+          const taggedOfferId =
+            getLinkyBankPaymentOfferPaymentNoticeOfferId(inner);
+          const matchingOffer = taggedOfferId
+            ? null
+            : bankPaymentOfferMessages.reduce<{
+                createdAtSec: number;
+                offerId: string;
+              } | null>((latest, message) => {
+                if (String(message.contactId ?? "").trim() !== contactId) {
+                  return latest;
+                }
+
+                const info = getLinkyBankPaymentOfferInfo(
+                  String(message.content ?? ""),
+                );
+                if (!info) return latest;
+
+                const createdAtSec = Number(message.createdAtSec ?? 0);
+                if (latest && latest.createdAtSec >= createdAtSec) {
+                  return latest;
+                }
+                return { createdAtSec, offerId: info.offerId };
+              }, null);
+          const offerId =
+            taggedOfferId ?? matchingOffer?.offerId ?? `expired:${wrapId}`;
+
+          if (taggedOfferId || matchingOffer) {
+            setLinkyBankPaymentOfferMinimized(contactId, offerId, false);
+          }
+          setPendingDeleteId(null);
+          navigateTo({
+            route: "bankPaymentOffer",
+            chatId: contactId,
+            offerId,
+          });
+          return true;
+        }
+
+        if (isLinkyBankPaymentOfferEvent(inner)) {
+          const content = String(inner.content ?? "");
+          const offerInfo = getLinkyBankPaymentOfferInfo(content);
+          if (!offerInfo || !pTags.includes(myPubHex)) {
+            return openedFromNotificationData;
+          }
+
+          const offererPubkey =
+            String(offerInfo.offererPublicKey ?? "").trim() ||
+            senderPub ||
+            peerPubkey;
+          const isOutgoing = offererPubkey === myPubHex;
+          const tagClientId = extractClientTag(tags);
+          const createdAtSecRaw = Number(inner.created_at ?? 0);
+          const createdAtSec =
+            Number.isFinite(createdAtSecRaw) && createdAtSecRaw > 0
+              ? Math.trunc(createdAtSecRaw)
+              : Math.floor(Date.now() / 1_000);
+          const offerMessage: LocalNostrMessage = {
+            contactId,
+            content,
+            createdAtSec,
+            direction: isOutgoing ? "out" : "in",
+            id: `bank-payment-offer:${wrapId}`,
+            localOnly: true,
+            pubkey: isOutgoing ? myPubHex : offererPubkey,
+            rumorId: null,
+            status: "sent",
+            wrapId,
+          };
+          if (tagClientId) {
+            offerMessage.clientId = tagClientId;
+          }
+          upsertBankPaymentOfferMessage(offerMessage);
+          setLinkyBankPaymentOfferMinimized(
+            contactId,
+            offerInfo.offerId,
+            false,
+          );
+          setPendingDeleteId(null);
+          navigateTo({
+            route: "bankPaymentOffer",
+            chatId: contactId,
+            offerId: offerInfo.offerId,
+          });
+          return true;
+        }
+
+        if (inner.kind === 14 || inner.kind === 15) {
+          const existingByWrap = nostrMessagesLatestRef.current.find(
+            (message) => String(message.wrapId ?? "").trim() === wrapId,
+          );
+          if (existingByWrap) {
+            insertedMessageId = String(existingByWrap.id ?? "").trim() || null;
+          } else if (
+            !hasKnownNostrMessageIdentity(knownNostrMessageIdentityIndex, {
+              wrapId,
+            }) &&
+            !isInvalidInnerRumorPubkey(senderPub, wrap.pubkey)
+          ) {
+            const content =
+              inner.kind === 15
+                ? (privateImageMessageFromEvent(inner) ?? "")
+                : String(inner.content ?? "");
+
+            if (content.trim()) {
+              const taggedPeerPub =
+                pTags.find((pubkey) => pubkey !== myPubHex) ?? "";
+              const nestedEncryptedPayload =
+                inner.kind === 14 &&
+                isNestedEncryptedNip44PayloadForAnyPubkey(
+                  content,
+                  [senderPub, taggedPeerPub, wrap.pubkey],
+                  privBytes,
+                );
+
+              if (!nestedEncryptedPayload) {
+                const tagClientId = extractClientTag(tags);
+                const rumorId = inner.id ? String(inner.id).trim() : "";
+                const matchedOutgoingMessage =
+                  senderPub === myPubHex
+                    ? null
+                    : (nostrMessagesLatestRef.current.find((message) => {
+                        if (String(message.direction ?? "").trim() !== "out") {
+                          return false;
+                        }
+                        if (
+                          tagClientId &&
+                          String(message.clientId ?? "").trim() ===
+                            String(tagClientId).trim()
+                        ) {
+                          return true;
+                        }
+                        return (
+                          rumorId &&
+                          String(message.rumorId ?? "").trim() === rumorId
+                        );
+                      }) ?? null);
+
+                const addressesMe = pTags.includes(myPubHex);
+                const isOutgoing =
+                  senderPub === myPubHex ||
+                  (addressesMe && Boolean(matchedOutgoingMessage));
+
+                if (addressesMe || isOutgoing) {
+                  const messageDirection = isOutgoing ? "out" : "in";
+                  const { replyToId, rootMessageId } =
+                    extractReplyContextFromTags(tags);
+                  const editedFromId = extractEditedFromTag(tags);
+                  const effectivePubkey = isOutgoing ? myPubHex : peerPubkey;
+                  const normalizedIncomingPeerPubkey = isOutgoing
+                    ? null
+                    : normalizePubkeyHex(effectivePubkey);
+                  const createdAtSecRaw = Number(inner.created_at ?? 0);
+                  const createdAtSec =
+                    Number.isFinite(createdAtSecRaw) && createdAtSecRaw > 0
+                      ? Math.trunc(createdAtSecRaw)
+                      : Math.ceil(Date.now() / 1e3);
+
+                  const matchesStoredIncomingPeer = (
+                    message: LocalNostrMessage,
+                  ): boolean => {
+                    if (isOutgoing || !normalizedIncomingPeerPubkey) {
+                      return false;
+                    }
+
+                    return (
+                      normalizePubkeyHex(message.pubkey) ===
+                      normalizedIncomingPeerPubkey
+                    );
+                  };
+
+                  if (
+                    !hasKnownNostrMessageIdentity(
+                      knownNostrMessageIdentityIndex,
+                      {
+                        contactId,
+                        direction: messageDirection,
+                        ...(tagClientId ? { clientId: tagClientId } : {}),
+                        ...(rumorId ? { rumorId } : {}),
+                        wrapId,
+                      },
+                    )
+                  ) {
+                    if (editedFromId) {
+                      const targetMessage = nostrMessagesLatestRef.current.find(
+                        (message) => {
+                          const matchesContactId =
+                            String(message.contactId ?? "") ===
+                            String(contactId);
+                          if (
+                            !matchesContactId &&
+                            !matchesStoredIncomingPeer(message)
+                          ) {
+                            return false;
+                          }
+                          if (
+                            String(message.direction ?? "") !== messageDirection
+                          ) {
+                            return false;
+                          }
+                          return (
+                            String(message.rumorId ?? "").trim() ===
+                              editedFromId ||
+                            String(message.editedFromId ?? "").trim() ===
+                              editedFromId
+                          );
+                        },
+                      );
+
+                      if (targetMessage) {
+                        const targetMessageId = String(
+                          targetMessage.id ?? "",
+                        ).trim();
+                        if (targetMessageId) {
+                          const existingOriginal =
+                            String(
+                              targetMessage.originalContent ?? "",
+                            ).trim() || String(targetMessage.content ?? "");
+                          updateLocalNostrMessage(targetMessageId, {
+                            content,
+                            status: "sent",
+                            wrapId,
+                            pubkey: effectivePubkey,
+                            ...(tagClientId ? { clientId: tagClientId } : {}),
+                            ...(rumorId ? { rumorId } : {}),
+                            editedAtSec: createdAtSec,
+                            editedFromId,
+                            isEdited: true,
+                            originalContent: existingOriginal || null,
+                          });
+                          insertedMessageId = targetMessageId;
+                        }
+                      }
+                    }
+
+                    if (!insertedMessageId) {
+                      const existingMessage =
+                        nostrMessagesLatestRef.current.find((message) => {
+                          const matchesContactId =
+                            String(message.contactId ?? "") ===
+                            String(contactId);
+                          if (
+                            !matchesContactId &&
+                            !matchesStoredIncomingPeer(message)
+                          ) {
+                            return false;
+                          }
+                          if (
+                            String(message.direction ?? "") !== messageDirection
+                          ) {
+                            return false;
+                          }
+                          if (
+                            rumorId &&
+                            String(message.rumorId ?? "").trim() === rumorId
+                          ) {
+                            return true;
+                          }
+                          if (tagClientId) {
+                            return (
+                              String(message.clientId ?? "").trim() ===
+                              String(tagClientId).trim()
+                            );
+                          }
+                          return (
+                            String(message.content ?? "").trim() ===
+                            content.trim()
+                          );
+                        });
+
+                      if (existingMessage) {
+                        const existingMessageId = String(
+                          existingMessage.id ?? "",
+                        ).trim();
+                        if (existingMessageId) {
+                          updateLocalNostrMessage(existingMessageId, {
+                            status: "sent",
+                            wrapId,
+                            pubkey: effectivePubkey,
+                            ...(tagClientId ? { clientId: tagClientId } : {}),
+                            ...(rumorId ? { rumorId } : {}),
+                            ...(replyToId ? { replyToId } : {}),
+                            ...(rootMessageId ? { rootMessageId } : {}),
+                            ...(editedFromId ? { editedFromId } : {}),
+                          });
+                          insertedMessageId = existingMessageId;
+                        }
+                      } else {
+                        insertedMessageId = appendLocalNostrMessage({
+                          contactId,
+                          content,
+                          createdAtSec,
+                          direction: messageDirection,
+                          pubkey: effectivePubkey,
+                          rumorId: rumorId || null,
+                          wrapId,
+                          ...(tagClientId ? { clientId: tagClientId } : {}),
+                          ...(replyToId ? { replyToId } : {}),
+                          ...(rootMessageId ? { rootMessageId } : {}),
+                          ...(editedFromId
+                            ? {
+                                editedAtSec: createdAtSec,
+                                editedFromId,
+                                isEdited: true,
+                              }
+                            : {}),
+                        });
+                      }
+
+                      nostrMessageWrapIdsRef.current.add(wrapId);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        setPendingDeleteId(null);
+        navigateTo({ route: "chat", id: contactId });
+        if (insertedMessageId) {
+          triggerChatScrollToBottom(insertedMessageId);
+        }
+        return true;
+      } catch {
+        return openedFromNotificationData;
+      }
+    },
+    [
+      appendLocalNostrMessage,
+      bankPaymentOfferMessages,
+      currentNsec,
+      knownNostrMessageIdentityIndex,
+      nostrFetchRelays,
+      nostrMessagesLatestRef,
+      nostrMessageWrapIdsRef,
+      setPendingDeleteId,
+      triggerChatScrollToBottom,
+      updateLocalNostrMessage,
+      upsertBankPaymentOfferMessage,
+    ],
+  );
+
+  const handleContactIdentifierScanned = React.useCallback(
+    async (identifier: string) => {
+      await addNewContactFromIdentifier(identifier);
+    },
+    [addNewContactFromIdentifier],
+  );
+
+  const handleScannedText = useScannedTextHandler<(typeof contacts)[number]>({
+    appOwnerId: contactsOwnerId,
+    closeScan,
+    contacts,
+    currentNpub,
+    extractCashuTokenFromText,
+    insert,
+    lightningInvoiceAutoPayLimit,
+    onContactIdentifierScanned:
+      route.kind === "contactNew" ? handleContactIdentifierScanned : null,
+    openScannedContactPendingNpubRef,
+    payCashuPaymentRequest,
+    payLightningInvoiceWithCashu,
+    refreshContactFromNostr,
+    requestLightningInvoiceConfirmation: setPendingLightningInvoiceConfirmation,
+    requestLnurlWithdrawConfirmation: setPendingLnurlWithdrawConfirmation,
+    saveCashuFromText,
+    scanAcceptsBankPayment:
+      scanEntryPoint === "send" || route.kind === "manualPay",
+    scanEntryPoint,
+    setStatus,
+    t,
+  });
+
+  React.useEffect(() => {
+    const acceptDeepLinkUrl = (rawUrl: unknown) => {
+      const parsed = parseNativeDeepLinkUrl(rawUrl);
+      if (!parsed) {
+        return;
+      }
+
+      setPendingDeleteId(null);
+      updatePendingDeepLinkText(parsed.text);
+      consumePendingNativeDeepLinkUrl();
+    };
+
+    acceptDeepLinkUrl(consumePendingNativeDeepLinkUrl());
+    void consumePendingIosNativeDeepLinkUrl().then(acceptDeepLinkUrl);
+
+    const onDeepLink: EventListener = (event) => {
+      if (!(event instanceof CustomEvent)) {
+        return;
+      }
+
+      const detail = event.detail;
+      if (typeof detail !== "object" || detail === null) {
+        return;
+      }
+
+      acceptDeepLinkUrl(Reflect.get(detail, "url"));
+    };
+
+    window.addEventListener(NATIVE_DEEP_LINK_EVENT, onDeepLink);
+    return () => window.removeEventListener(NATIVE_DEEP_LINK_EVENT, onDeepLink);
+  }, [setPendingDeleteId, updatePendingDeepLinkText]);
+
+  React.useEffect(() => {
+    const openNotificationRoute = (rawRoute: unknown) => {
+      const routeValue = readNotificationOpenRoute(rawRoute);
+      if (routeValue === "#contacts") {
+        navigateTo({ route: "contacts" });
+        return;
+      }
+      if (routeValue === "#wallet") {
+        navigateTo({ route: "wallet" });
+      }
+    };
+
+    const openNotification = (rawDetail: unknown) => {
+      if (!nostrBootstrapReady) {
+        pendingNotificationOpenDetailsRef.current.push({ value: rawDetail });
+        return;
+      }
+
+      void openNotificationChat(rawDetail).then((opened) => {
+        if (opened) {
+          return;
+        }
+
+        openNotificationRoute(rawDetail);
+      });
+    };
+
+    const pendingNotificationDetail =
+      consumePendingNativeNotificationOpenDetail();
+    const pendingHashNotificationDetail =
+      consumeNotificationOpenDetailFromHash();
+    if (pendingNotificationDetail) {
+      openNotification(pendingNotificationDetail);
+    } else if (pendingHashNotificationDetail) {
+      openNotification(pendingHashNotificationDetail);
+    } else {
+      openNotificationRoute(consumePendingNativeNotificationRoute());
+    }
+
+    if (nostrBootstrapReady) {
+      const queuedDetails = pendingNotificationOpenDetailsRef.current.splice(0);
+      for (const detail of queuedDetails) {
+        openNotification(detail.value);
+      }
+    }
+
+    const onNotificationOpen: EventListener = (event) => {
+      if (!(event instanceof CustomEvent)) {
+        return;
+      }
+
+      const detail = event.detail;
+      if (typeof detail !== "object" || detail === null) {
+        return;
+      }
+
+      openNotification(detail);
+    };
+
+    window.addEventListener(NATIVE_NOTIFICATION_OPEN_EVENT, onNotificationOpen);
+    window.addEventListener(NATIVE_PUSH_ACTION_EVENT, onNotificationOpen);
+    const onServiceWorkerMessage = (event: MessageEvent) => {
+      const data = event.data;
+      if (typeof data !== "object" || data === null) {
+        return;
+      }
+      if (Reflect.get(data, "type") !== "notification-open") {
+        return;
+      }
+
+      openNotification(Reflect.get(data, "detail"));
+    };
+
+    if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
+      navigator.serviceWorker.addEventListener(
+        "message",
+        onServiceWorkerMessage,
+      );
+    }
+
+    return () => {
+      if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
+        navigator.serviceWorker.removeEventListener(
+          "message",
+          onServiceWorkerMessage,
+        );
+      }
+
+      window.removeEventListener(
+        NATIVE_NOTIFICATION_OPEN_EVENT,
+        onNotificationOpen,
+      );
+      window.removeEventListener(NATIVE_PUSH_ACTION_EVENT, onNotificationOpen);
+    };
+  }, [nostrBootstrapReady, openNotificationChat]);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const rawHash = String(window.location.hash ?? "");
+    const token = extractCashuTokenFromTextFromUrl(rawHash);
+    if (!token) {
+      return;
+    }
+
+    setPendingDeleteId(null);
+    updatePendingDeepLinkText(`cashu:${token}`);
+
+    const cleanHash = rawHash.split("?")[0] ?? "#wallet";
+    const nextHash = cleanHash || "#wallet";
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${window.location.search}${nextHash}`,
+    );
+  }, [setPendingDeleteId, updatePendingDeepLinkText]);
+
+  React.useEffect(() => {
+    if (!pendingDeepLinkText) {
+      return;
+    }
+
+    if (!currentNsec || !cashuOwnerId) {
+      return;
+    }
+
+    updatePendingDeepLinkText(null);
+    void handleScannedText(pendingDeepLinkText).catch(() => {
+      updatePendingDeepLinkText(pendingDeepLinkText);
+    });
+  }, [
+    cashuOwnerId,
+    currentNsec,
+    handleScannedText,
+    pendingDeepLinkText,
+    updatePendingDeepLinkText,
+  ]);
+
+  const pasteScanValue = React.useCallback(async () => {
+    let text = "";
+
+    if (navigator.clipboard?.readText) {
+      try {
+        text = await navigator.clipboard.readText();
+      } catch {
+        if (
+          typeof window !== "undefined" &&
+          typeof window.prompt === "function"
+        ) {
+          text = String(window.prompt(t("scanPastePrompt")) ?? "");
+        } else {
+          pushToast(t("pasteNotAvailable"));
+          return;
+        }
+      }
+    } else if (
+      typeof window !== "undefined" &&
+      typeof window.prompt === "function"
+    ) {
+      text = String(window.prompt(t("scanPastePrompt")) ?? "");
+    } else {
+      pushToast(t("pasteNotAvailable"));
+      return;
+    }
+
+    const raw = String(text ?? "").trim();
+    if (!raw) {
+      pushToast(t("pasteEmpty"));
+      return;
+    }
+
+    await handleScannedText(raw);
+  }, [handleScannedText, pushToast, t]);
+
+  const onScanImageSelected = React.useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const input = event.currentTarget;
+      const file = input.files?.[0] ?? null;
+      input.value = "";
+
+      if (!file) {
+        return;
+      }
+
+      const loadImage = async (imageFile: File): Promise<HTMLImageElement> => {
+        const objectUrl = URL.createObjectURL(imageFile);
+
+        try {
+          return await new Promise<HTMLImageElement>((resolve, reject) => {
+            const image = new Image();
+            image.onload = () => resolve(image);
+            image.onerror = () => reject(new Error("image-load-failed"));
+            image.src = objectUrl;
+          });
+        } finally {
+          URL.revokeObjectURL(objectUrl);
+        }
+      };
+
+      try {
+        const image = await loadImage(file);
+        const detectorCtor = window.BarcodeDetector;
+
+        if (detectorCtor) {
+          const detector = new detectorCtor({ formats: ["qr_code"] });
+          const detectorValue = String(
+            (await detector.detect(image))?.[0]?.rawValue ?? "",
+          ).trim();
+
+          if (detectorValue) {
+            await handleScannedText(detectorValue);
+            return;
+          }
+        }
+
+        const width = image.naturalWidth || image.width;
+        const height = image.naturalHeight || image.height;
+        if (width <= 0 || height <= 0) {
+          pushToast(t("scanImageUnsupported"));
+          return;
+        }
+
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+
+        const ctx = canvas.getContext("2d", { willReadFrequently: true });
+        if (!ctx) {
+          pushToast(t("scanImageUnsupported"));
+          return;
+        }
+
+        ctx.drawImage(image, 0, 0, width, height);
+        const imageData = ctx.getImageData(0, 0, width, height);
+        const jsQr = (await import("jsqr")).default;
+        const qrValue = String(
+          jsQr(imageData.data, width, height)?.data ?? "",
+        ).trim();
+
+        if (!qrValue) {
+          pushToast(t("scanImageUnsupported"));
+          return;
+        }
+
+        await handleScannedText(qrValue);
+      } catch {
+        pushToast(t("scanImageUnsupported"));
+      }
+    },
+    [handleScannedText, pushToast, t],
+  );
+
+  const onSubmitManualPayText = React.useCallback(
+    async (text: string) => {
+      await handleScannedText(text);
+    },
+    [handleScannedText],
+  );
+
+  useScannedTextHandlerRefBridge({
+    handleScannedText,
+    scannedTextHandlerRef,
+  });
+
+  return {
+    cancelPendingNfcWrite,
+    canWriteNfc,
+    closeScan,
+    closeShareOptions,
+    contactsGuide,
+    contactsGuideActiveStep,
+    contactsGuideHighlightRect,
+    contactsOnboardingCelebrating,
+    contactsOnboardingTasks,
+    copyShareOptionsText,
+    dismissContactsOnboarding,
+    nfcWritePromptKind,
+    onPickScanImage,
+    onScanImageSelected,
+    onSubmitManualPayText,
+    openIssueTokenFromScan,
+    openManualContactFromScan,
+    openManualPayFromScan,
+    openReceiveScan,
+    openScan,
+    openWalletScan,
+    pasteScanValue,
+    scanAllowsManualContact,
+    scanEntryPoint,
+    scanImageInputRef,
+    scanIsOpen,
+    scanVideoRef,
+    shareCashuTokenText,
+    shareOptionsText,
+    shareOptionsViaEmail,
+    shareOptionsViaSms,
+    shareOptionsViaWhatsApp,
+    showContactsOnboarding,
+    stableContactsGuideNav,
+    startContactsGuide,
+    stopContactsGuide,
+    writeCashuTokenToNfc,
+    writeCurrentNpubToNfc,
+  };
+};

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -11,8 +11,6 @@ import React, { useMemo, useState } from "react";
 import { createSendTokenWithTokensAtMint } from "../cashuSend";
 import { ContactCard } from "../components/ContactCard";
 import {
-  DEFAULT_LIGHTNING_ADDRESS_DOMAIN,
-  deriveDefaultLightningAddress,
   deriveDefaultProfile,
   omitSyntheticContactLightningAddress,
 } from "../derivedProfile";
@@ -123,7 +121,6 @@ import {
 } from "../utils/mint";
 import { normalizeNpubIdentifier } from "../utils/nostrNpub";
 import { parseNpubCashProfileInfo } from "../utils/npubCashInfo";
-import { resolveNpubCashServerBaseUrl } from "../utils/npubCashServer";
 import { setStoredPushContactNames } from "../utils/pushContactNamesStorage";
 import {
   getInitialAllowedDisplayCurrencies,
@@ -132,7 +129,6 @@ import {
   getInitialDisplayCurrency,
   getInitialLightningInvoiceAutoPayLimit,
   getInitialPayWithCashuEnabled,
-  getInitialShowProfileQrOnTiltEnabled,
   safeLocalStorageGet,
   safeLocalStorageGetJson,
   safeLocalStorageRemove,
@@ -148,6 +144,7 @@ import { useRestoreMissingTokens } from "./hooks/cashu/useRestoreMissingTokens";
 import { useSaveCashuFromText } from "./hooks/cashu/useSaveCashuFromText";
 import { useIdentityOwnersComposition } from "./hooks/composition/useIdentityOwnersComposition";
 import { usePaymentMoneyComposition } from "./hooks/composition/usePaymentMoneyComposition";
+import { useProfileComposition } from "./hooks/composition/useProfileComposition";
 import { useProfilePeopleComposition } from "./hooks/composition/useProfilePeopleComposition";
 import { useRoutingViewComposition } from "./hooks/composition/useRoutingViewComposition";
 import { useSystemSettingsComposition } from "./hooks/composition/useSystemSettingsComposition";
@@ -187,10 +184,6 @@ import { useNpubCashMintSelection } from "./hooks/mint/useNpubCashMintSelection"
 import { useContactPayMethod } from "./hooks/payments/useContactPayMethod";
 import { usePayContactWithCashuMessage } from "./hooks/payments/usePayContactWithCashuMessage";
 import { useRouteAmountResetEffects } from "./hooks/payments/useRouteAmountResetEffects";
-import { useProfileEditor } from "./hooks/profile/useProfileEditor";
-import { useProfileMetadataSyncEffect } from "./hooks/profile/useProfileMetadataSyncEffect";
-import { useProfileStatusEditor } from "./hooks/profile/useProfileStatusEditor";
-import { useProfileStatusSyncEffect } from "./hooks/profile/useProfileStatusSyncEffect";
 import { shouldKeepTopupQuoteAfterClaimError } from "./hooks/topup/topupMintClaim";
 import {
   isClaimableMintQuoteState,
@@ -219,7 +212,6 @@ import { useMintDomain } from "./hooks/useMintDomain";
 import { useOwnerScopedStorage } from "./hooks/useOwnerScopedStorage";
 import { usePaidOverlayState } from "./hooks/usePaidOverlayState";
 import { usePaymentsDomain } from "./hooks/usePaymentsDomain";
-import { usePortraitOrientationLock } from "./hooks/usePortraitOrientationLock";
 import { useProfileNpubCashEffects } from "./hooks/useProfileNpubCashEffects";
 import { useRelayDomain } from "./hooks/useRelayDomain";
 import { useScannedTextHandler } from "./hooks/useScannedTextHandler";
@@ -636,8 +628,6 @@ export const useAppShellComposition = () => {
   const [cashuAutoswapEnabled, setCashuAutoswapEnabled] = useState<boolean>(
     () => getInitialCashuAutoswapEnabled(),
   );
-  const [showProfileQrOnTiltEnabled, setShowProfileQrOnTiltEnabled] =
-    useState<boolean>(() => getInitialShowProfileQrOnTiltEnabled());
   const [lightningInvoiceAutoPayLimit, setLightningInvoiceAutoPayLimit] =
     useState<number>(() => getInitialLightningInvoiceAutoPayLimit());
   const [
@@ -1229,26 +1219,7 @@ export const useAppShellComposition = () => {
     [],
   );
 
-  const [myProfileName, setMyProfileName] = useState<string | null>(null);
-  const [myProfilePicture, setMyProfilePicture] = useState<string | null>(null);
-  const [myProfileQr, setMyProfileQr] = useState<string | null>(null);
-  const [myProfileLnAddress, setMyProfileLnAddress] = useState<string | null>(
-    null,
-  );
-  const [ownedProfileLightningAddresses, setOwnedProfileLightningAddresses] =
-    useState<string[]>([]);
-  const [
-    ownedProfileLightningAddressesLoading,
-    setOwnedProfileLightningAddressesLoading,
-  ] = useState(true);
-  const [myProfileStatus, setMyProfileStatus] = useState<string | null>(null);
-  const [myProfileMetadata, setMyProfileMetadata] =
-    useState<NostrProfileMetadata | null>(null);
-
   const npubCashClaimInFlightRef = React.useRef(false);
-  const npubCashInfoInFlightRef = React.useRef(false);
-  const npubCashInfoLoadedForNpubRef = React.useRef<string | null>(null);
-  const npubCashInfoLoadedAtMsRef = React.useRef<number>(0);
   const npubCashMintSyncRef = React.useRef<string | null>(null);
 
   const nostrInFlight = React.useRef<Set<string>>(new Set());
@@ -1570,47 +1541,6 @@ export const useAppShellComposition = () => {
       return null;
     }
   }, [currentNpub]);
-
-  useTopupInvoiceQuoteEffects({
-    defaultMintUrl,
-    effectiveMyLightningAddress:
-      myProfileLnAddress ??
-      (currentNpub ? deriveDefaultLightningAddress(currentNpub) : null),
-    routeKind: route.kind,
-    t,
-    topupAmount,
-    topupInvoice,
-    topupInvoiceError,
-    topupInvoiceIsBusy,
-    topupInvoicePaidHandledRef,
-    topupInvoiceQr,
-    topupInvoiceStartBalanceRef,
-    topupMintQuote,
-    topupPaidNavTimerRef,
-    topupRefreshKey: myProfileName,
-    topupRecipientNprofile,
-    setTopupAmount,
-    setTopupInvoice,
-    setTopupInvoiceCashuRequest,
-    setTopupInvoiceError,
-    setTopupInvoiceIsBusy,
-    setTopupInvoiceQr,
-    setTopupInvoiceQrPayload,
-    setTopupMintQuote,
-  });
-
-  useAppPreferences({
-    allowedDisplayCurrencies,
-    cashuAutoswapEnabled,
-    displayCurrency,
-    bankPaymentOfferRecipientCount,
-    lang,
-    lightningInvoiceAutoPayLimit,
-    payWithCashuEnabled,
-    showProfileQrOnTiltEnabled,
-  });
-
-  usePortraitOrientationLock(showProfileQrOnTiltEnabled);
 
   useArmedDeleteTimeouts({
     pendingCashuDeleteId,
@@ -2715,39 +2645,26 @@ export const useAppShellComposition = () => {
     amountSat: number;
   }>(null);
 
-  const defaultLightningAddress = useMemo(() => {
-    if (!currentNpub) return null;
-    return deriveDefaultLightningAddress(currentNpub);
-  }, [currentNpub]);
-
-  const derivedProfile = useMemo(() => {
-    if (!currentNpub) return null;
-    return deriveDefaultProfile(currentNpub, lang);
-  }, [currentNpub, lang]);
-
-  const effectiveProfileName = myProfileName ?? derivedProfile?.name ?? null;
-  const effectiveProfilePicture =
-    myProfilePicture ?? derivedProfile?.pictureUrl ?? null;
-
-  const effectiveMyLightningAddress =
-    myProfileLnAddress ?? defaultLightningAddress;
-
-  const npubCashServerBaseUrl = useMemo(() => {
-    return resolveNpubCashServerBaseUrl(effectiveMyLightningAddress);
-  }, [effectiveMyLightningAddress]);
-
-  const profileClaimLightningAddressServerBaseUrl = useMemo(() => {
-    return resolveNpubCashServerBaseUrl(
-      `claim@${DEFAULT_LIGHTNING_ADDRESS_DOMAIN}`,
-    );
-  }, []);
-
   const {
     cycleProfileAvatarControl,
+    derivedProfile,
+    effectiveMyLightningAddress,
+    effectiveProfileName,
+    effectiveProfilePicture,
     isProfileEditing,
+    myProfileName,
+    myProfileQr,
+    myProfileStatus,
+    npubCashInfoInFlightRef,
+    npubCashInfoLoadedAtMsRef,
+    npubCashInfoLoadedForNpubRef,
+    npubCashServerBaseUrl,
     onPickProfilePhoto,
     onProfilePhotoError,
     onProfilePhotoSelected,
+    openProfileQr,
+    ownedProfileLightningAddresses,
+    profileClaimLightningAddressServerBaseUrl,
     profileCustomPictureUrl,
     profileEditInitialRef,
     profileEditLnAddress,
@@ -2757,33 +2674,70 @@ export const useAppShellComposition = () => {
     profileEditsSavable,
     profilePhotoInputRef,
     profileSelectedPictureKind,
+    profileStatusCurrencies,
+    profileStatusIsSaving,
     saveClaimedLightningAddress,
     saveProfileEdits,
+    selectedProfileStatusCurrencies,
     setIsProfileEditing,
+    setMyProfileQr,
+    setOwnedProfileLightningAddresses,
+    setOwnedProfileLightningAddressesLoading,
     setProfileEditLnAddress,
     setProfileEditName,
     setProfileEditStatus,
+    setShowProfileQrOnTiltEnabled,
+    showProfileQrOnTiltEnabled,
     toggleProfileEditing,
+    toggleProfileStatusCurrency,
     unregisteredOwnLightningAddress,
-  } = useProfileEditor({
+  } = useProfileComposition({
     currentNpub,
     currentNsec,
-    defaultLightningAddress,
-    effectiveMyLightningAddress,
-    effectiveProfileName,
-    effectiveProfilePicture,
-    myProfileMetadata,
-    myProfileStatus,
+    lang,
+    nostrBootstrapReady,
     nostrFetchRelays,
-    ownedLightningAddresses: ownedProfileLightningAddresses,
-    ownedLightningAddressesLoading: ownedProfileLightningAddressesLoading,
-    setMyProfileLnAddress,
-    setMyProfileMetadata,
-    setMyProfileName,
-    setMyProfilePicture,
-    setMyProfileStatus,
+    rememberBlobAvatarUrl,
+    route,
     setStatus,
     t,
+  });
+
+  useTopupInvoiceQuoteEffects({
+    defaultMintUrl,
+    effectiveMyLightningAddress,
+    routeKind: route.kind,
+    t,
+    topupAmount,
+    topupInvoice,
+    topupInvoiceError,
+    topupInvoiceIsBusy,
+    topupInvoicePaidHandledRef,
+    topupInvoiceQr,
+    topupInvoiceStartBalanceRef,
+    topupMintQuote,
+    topupPaidNavTimerRef,
+    topupRefreshKey: myProfileName,
+    topupRecipientNprofile,
+    setTopupAmount,
+    setTopupInvoice,
+    setTopupInvoiceCashuRequest,
+    setTopupInvoiceError,
+    setTopupInvoiceIsBusy,
+    setTopupInvoiceQr,
+    setTopupInvoiceQrPayload,
+    setTopupMintQuote,
+  });
+
+  useAppPreferences({
+    allowedDisplayCurrencies,
+    cashuAutoswapEnabled,
+    displayCurrency,
+    bankPaymentOfferRecipientCount,
+    lang,
+    lightningInvoiceAutoPayLimit,
+    payWithCashuEnabled,
+    showProfileQrOnTiltEnabled,
   });
 
   const defaultMintDisplay = useMemo(() => {
@@ -2915,6 +2869,8 @@ export const useAppShellComposition = () => {
     currentNsec,
     makeNip98AuthHeader,
     profileClaimLightningAddressServerBaseUrl,
+    setOwnedProfileLightningAddresses,
+    setOwnedProfileLightningAddressesLoading,
   ]);
 
   React.useEffect(() => {
@@ -2977,39 +2933,6 @@ export const useAppShellComposition = () => {
     touchMintInfo,
   });
 
-  useProfileMetadataSyncEffect({
-    canFetchFromNostr: nostrBootstrapReady,
-    currentNpub,
-    nostrFetchRelays,
-    rememberBlobAvatarUrl,
-    setMyProfileLnAddress,
-    setMyProfileMetadata,
-    setMyProfileName,
-    setMyProfilePicture,
-  });
-
-  useProfileStatusSyncEffect({
-    canFetchFromNostr: nostrBootstrapReady,
-    currentNpub,
-    nostrFetchRelays,
-    setMyProfileStatus,
-  });
-
-  const {
-    profileStatusCurrencies,
-    profileStatusIsSaving,
-    selectedProfileStatusCurrencies,
-    toggleProfileStatusCurrency,
-  } = useProfileStatusEditor({
-    currentNpub,
-    currentNsec,
-    myProfileStatus,
-    nostrFetchRelays,
-    setMyProfileStatus,
-    setStatus,
-    t,
-  });
-
   useProfileNpubCashEffects({
     claimNpubCashOnce,
     claimNpubCashOnceLatestRef,
@@ -3028,16 +2951,6 @@ export const useAppShellComposition = () => {
     setIsProfileEditing,
     setMyProfileQr,
   });
-
-  React.useEffect(() => {
-    if (route.kind !== "profileEdit") {
-      return;
-    }
-
-    if (!isProfileEditing) {
-      toggleProfileEditing();
-    }
-  }, [isProfileEditing, route.kind, toggleProfileEditing]);
 
   // Intentionally no automatic publishing of kind-0 profile metadata.
   // We only publish profile changes when the user does so explicitly.
@@ -8863,10 +8776,6 @@ export const useAppShellComposition = () => {
     updateLocalNostrMessage,
     updateLocalNostrReaction,
   });
-
-  const openProfileQr = React.useCallback(() => {
-    navigateTo({ route: "profile" });
-  }, []);
 
   const handleContactIdentifierScanned = React.useCallback(
     async (identifier: string) => {

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -1,7 +1,5 @@
-import { Share } from "@capacitor/share";
 import * as Evolu from "@evolu/common";
 import { useQuery } from "@evolu/react";
-import { nip19 } from "nostr-tools";
 import React, { useMemo, useState } from "react";
 import { ContactCard } from "../components/ContactCard";
 import {
@@ -12,38 +10,21 @@ import {
   useEvoluLastError,
   useEvoluServersManager,
   wipeEvoluStorage as wipeEvoluStorageImpl,
-  type CashuTokenId,
   type ContactId,
 } from "../evolu";
-import { navigateTo, useRouting } from "../hooks/useRouting";
+import { useRouting } from "../hooks/useRouting";
 import { useToasts } from "../hooks/useToasts";
 import { getInitialLang, translations, type Lang } from "../i18n";
-import { NOSTR_RELAYS } from "../nostrProfile";
 import { writeClipboardText } from "../platform/clipboard";
-import {
-  cancelNativeNfcWrite,
-  consumePendingIosNativeDeepLinkUrl,
-  consumePendingNativeDeepLinkUrl,
-  consumePendingNativeNotificationOpenDetail,
-  consumePendingNativeNotificationRoute,
-  NATIVE_DEEP_LINK_EVENT,
-  NATIVE_NOTIFICATION_OPEN_EVENT,
-  NATIVE_PUSH_ACTION_EVENT,
-  startNativeNfcWrite,
-  supportsNativeNfcWrite,
-} from "../platform/nativeBridge";
 import {
   triggerPasswordManagerSeedSave,
   type PasswordManagerSaveResult,
 } from "../platform/passwordManager";
-import { isNativePlatform } from "../platform/runtime";
 import {
   CONTACTS_ONBOARDING_HAS_BACKUPED_KEYS_STORAGE_KEY,
   FEEDBACK_CONTACT_NPUB,
   LOCAL_MINT_INFO_STORAGE_KEY_PREFIX,
-  PENDING_DEEP_LINK_TEXT_STORAGE_KEY,
 } from "../utils/constants";
-import { buildCashuDeepLink, parseNativeDeepLinkUrl } from "../utils/deepLinks";
 import {
   applyAmountInputKey,
   formatDisplayAmountParts,
@@ -64,7 +45,6 @@ import {
   getInitialAllowedDisplayCurrencies,
   getInitialDisplayCurrency,
   safeLocalStorageGet,
-  safeLocalStorageRemove,
   safeLocalStorageSet,
   safeLocalStorageSetJson,
 } from "../utils/storage";
@@ -78,78 +58,37 @@ import { usePaymentMoneyComposition } from "./hooks/composition/usePaymentMoneyC
 import { useProfileComposition } from "./hooks/composition/useProfileComposition";
 import { useProfilePeopleComposition } from "./hooks/composition/useProfilePeopleComposition";
 import { useRoutingViewComposition } from "./hooks/composition/useRoutingViewComposition";
+import { useScanNativeComposition } from "./hooks/composition/useScanNativeComposition";
 import { useSystemSettingsComposition } from "./hooks/composition/useSystemSettingsComposition";
-import { useContactsOnboardingProgress } from "./hooks/guide/useContactsOnboardingProgress";
 import { useMainMenuState } from "./hooks/layout/useMainMenuState";
 import { useMainSwipeNavigation } from "./hooks/layout/useMainSwipeNavigation";
-import {
-  extractClientTag,
-  extractEditedFromTag,
-  extractReplyContextFromTags,
-  isInvalidInnerRumorPubkey,
-  isNestedEncryptedNip44PayloadForAnyPubkey,
-} from "./hooks/messages/chatNostrProtocol";
-import {
-  buildUnknownContactId,
-  isUnknownContactId,
-  normalizePubkeyHex,
-} from "./hooks/messages/contactIdentity";
-import { hasKnownNostrMessageIdentity } from "./hooks/messages/messageHelpers";
+import { isUnknownContactId } from "./hooks/messages/contactIdentity";
 import { useChatMessageEffects } from "./hooks/messages/useChatMessageEffects";
 import { useAppDataTransfer } from "./hooks/useAppDataTransfer";
 import { useAppPreferences } from "./hooks/useAppPreferences";
 import { useArmedDeleteTimeouts } from "./hooks/useArmedDeleteTimeouts";
 import { useFiatRates } from "./hooks/useFiatRates";
-import { useGuideScannerDomain } from "./hooks/useGuideScannerDomain";
 import { useMainSwipePageEffects } from "./hooks/useMainSwipePageEffects";
 import { useOwnerScopedStorage } from "./hooks/useOwnerScopedStorage";
-import { useScannedTextHandler } from "./hooks/useScannedTextHandler";
-import { useScannedTextHandlerRefBridge } from "./hooks/useScannedTextHandlerRefBridge";
 import { useStatusToasts } from "./hooks/useStatusToasts";
 import { useStoragePersistRequestEffect } from "./hooks/useStoragePersistRequestEffect";
-import {
-  getLinkyBankPaymentOfferInfo,
-  isLinkyBankPaymentOfferEvent,
-  setLinkyBankPaymentOfferMinimized,
-} from "./lib/bankPaymentOffer";
-import {
-  CASHU_TOKEN_STATE_EXTERNALIZED,
-  isCashuTokenAcceptedState,
-} from "./lib/cashuTokenState";
 import {
   buildIdentityChangeMessageContent,
   buildIdentityChangeMessageWrapId,
 } from "./lib/identityChangeMessage";
 import {
-  consumeNotificationOpenDetailFromHash,
-  readNotificationOpenRoute,
-  readNotificationOpenTarget,
-} from "./lib/notificationOpenTarget";
-import { getSharedAppNostrPool } from "./lib/nostrPool";
-import {
   buildDismissedOnboardingTutorialOwnerMetaPayload,
   hasDismissedOnboardingTutorialOwnerMetaRow,
   ONBOARDING_TUTORIAL_OWNER_META_SCOPE,
 } from "./lib/onboardingTutorialSync";
-import {
-  parsePrivateImageMessage,
-  privateImageMessageFromEvent,
-} from "./lib/privateImageMessage";
-import {
-  getLinkyBankPaymentOfferPaymentNoticeOfferId,
-  isLinkyBankPaymentOfferPaymentNoticeEvent,
-} from "./lib/pushWrappedEvent";
+import { parsePrivateImageMessage } from "./lib/privateImageMessage";
 import { showPwaNotification } from "./lib/pwaNotifications";
-import {
-  extractCashuTokenFromText,
-  extractCashuTokenFromText as extractCashuTokenFromTextFromUrl,
-} from "./lib/tokenText";
 import {
   buildTopbar,
   buildTopbarRight,
   buildTopbarTitle,
 } from "./lib/topbarConfig";
-import type { ContactRowLike, LocalNostrMessage } from "./types/appTypes";
+import type { ContactRowLike } from "./types/appTypes";
 import {
   useContactsMessagingComposition,
   type DisplayContact,
@@ -159,10 +98,6 @@ type TranslationKey = keyof (typeof translations)["cs"];
 
 const hasTranslationKey = (key: string): key is TranslationKey =>
   Object.prototype.hasOwnProperty.call(translations.cs, key);
-
-interface QueuedNotificationOpenDetail {
-  value: unknown;
-}
 
 export const useAppShellComposition = () => {
   const { insert, update, upsert } = useEvolu();
@@ -303,10 +238,6 @@ export const useAppShellComposition = () => {
     getInitialDisplayCurrency(),
   );
 
-  const pendingNotificationOpenDetailsRef = React.useRef<
-    QueuedNotificationOpenDetail[]
-  >([]);
-
   React.useEffect(() => {
     if (allowedDisplayCurrencies.includes(displayCurrency)) return;
     setDisplayCurrency(allowedDisplayCurrencies[0] ?? "sat");
@@ -434,8 +365,6 @@ export const useAppShellComposition = () => {
       setEvoluWipeStorageIsBusy(false);
     }
   }, [evoluWipeStorageIsBusy, lang, pushToast]);
-
-  const [shareOptionsText, setShareOptionsText] = useState<string | null>(null);
 
   const [contactPaymentIntent, setContactPaymentIntent] = useState<
     "pay" | "request"
@@ -744,31 +673,6 @@ export const useAppShellComposition = () => {
     lastMessageByContactId,
   ]);
 
-  const [pendingDeepLinkText, setPendingDeepLinkText] = React.useState<
-    string | null
-  >(() => {
-    const stored = String(
-      safeLocalStorageGet(PENDING_DEEP_LINK_TEXT_STORAGE_KEY) ?? "",
-    ).trim();
-    return stored || null;
-  });
-
-  const updatePendingDeepLinkText = React.useCallback(
-    (value: string | null) => {
-      const normalized = String(value ?? "").trim();
-
-      if (!normalized) {
-        safeLocalStorageRemove(PENDING_DEEP_LINK_TEXT_STORAGE_KEY);
-        setPendingDeepLinkText(null);
-        return;
-      }
-
-      safeLocalStorageSet(PENDING_DEEP_LINK_TEXT_STORAGE_KEY, normalized);
-      setPendingDeepLinkText(normalized);
-    },
-    [],
-  );
-
   const {
     cycleProfileAvatarControl,
     derivedProfile,
@@ -1070,333 +974,89 @@ export const useAppShellComposition = () => {
       route,
     });
 
-  const scannedTextHandlerRef = React.useRef<
-    (rawValue: string) => Promise<void>
-  >(async () => {});
-
   const {
+    cancelPendingNfcWrite,
+    canWriteNfc,
     closeScan,
+    closeShareOptions,
     contactsGuide,
     contactsGuideActiveStep,
     contactsGuideHighlightRect,
-    contactsGuideNav,
-    openScan,
-    openReceiveScan,
-    openWalletScan,
-    scanAllowsManualContact,
-    scanEntryPoint,
-    scanIsOpen,
-    scanVideoRef,
-    startContactsGuide,
-    stopContactsGuide,
-  } = useGuideScannerDomain({
-    cashuBalance,
-    contacts,
-    contactsOnboardingHasBackedUpKeys,
-    contactsOnboardingHasPaid,
-    contactsOnboardingHasSentMessage,
-    openNewContactPage,
-    onScannedText: (rawValue: string) =>
-      scannedTextHandlerRef.current(rawValue),
-    pushToast,
-    route,
-    t,
-  });
-  const contactsGuideNavRef = React.useRef(contactsGuideNav);
-  React.useLayoutEffect(() => {
-    contactsGuideNavRef.current = contactsGuideNav;
-  }, [contactsGuideNav]);
-  const stableContactsGuideNav = React.useMemo(
-    () => ({
-      back: () => {
-        contactsGuideNavRef.current.back();
-      },
-      next: () => {
-        contactsGuideNavRef.current.next();
-      },
-    }),
-    [],
-  );
-
-  const openManualContactFromScan = React.useCallback(() => {
-    closeScan();
-    if (route.kind === "contactNew") return;
-    openNewContactPage();
-  }, [closeScan, openNewContactPage, route.kind]);
-
-  const scanImageInputRef = React.useRef<HTMLInputElement | null>(null);
-
-  const openIssueTokenFromScan = React.useCallback(() => {
-    closeScan();
-    if (route.kind === "cashuTokenEmit") return;
-    navigateTo({ route: "cashuTokenEmit" });
-  }, [closeScan, route.kind]);
-
-  const openManualPayFromScan = React.useCallback(() => {
-    closeScan();
-    if (route.kind === "manualPay") return;
-    navigateTo({ route: "manualPay" });
-  }, [closeScan, route.kind]);
-
-  const onPickScanImage = React.useCallback(() => {
-    scanImageInputRef.current?.click();
-  }, []);
-
-  const {
     contactsOnboardingCelebrating,
     contactsOnboardingTasks,
+    copyShareOptionsText,
     dismissContactsOnboarding,
+    nfcWritePromptKind,
+    onPickScanImage,
+    onScanImageSelected,
+    onSubmitManualPayText,
+    openIssueTokenFromScan,
+    openManualContactFromScan,
+    openManualPayFromScan,
+    openReceiveScan,
+    openScan,
+    openWalletScan,
+    pasteScanValue,
+    scanAllowsManualContact,
+    scanEntryPoint,
+    scanImageInputRef,
+    scanIsOpen,
+    scanVideoRef,
+    shareCashuTokenText,
+    shareOptionsText,
+    shareOptionsViaEmail,
+    shareOptionsViaSms,
+    shareOptionsViaWhatsApp,
     showContactsOnboarding,
-  } = useContactsOnboardingProgress({
+    stableContactsGuideNav,
+    startContactsGuide,
+    stopContactsGuide,
+    writeCashuTokenToNfc,
+    writeCurrentNpubToNfc,
+  } = useScanNativeComposition({
+    addNewContactFromIdentifier,
+    appendLocalNostrMessage,
+    bankPaymentOfferMessages,
     cashuBalance,
-    contactsCount: contacts.length,
+    cashuOwnerId,
+    cashuTokensAllFiltered,
+    contacts,
+    contactsLatestRef,
     contactsOnboardingDismissedSynced,
     contactsOnboardingHasBackedUpKeys,
     contactsOnboardingHasPaid,
     contactsOnboardingHasSentMessage,
+    contactsOwnerId,
+    copyText,
+    currentNpub,
+    currentNsec,
+    insert,
+    knownNostrMessageIdentityIndex,
+    lightningInvoiceAutoPayLimit,
+    markCashuTokenIssued,
+    nostrBootstrapReady,
+    nostrFetchRelays,
+    nostrMessagesLatestRef,
+    nostrMessageWrapIdsRef,
+    openNewContactPage,
+    openScannedContactPendingNpubRef,
+    payCashuPaymentRequest,
+    payLightningInvoiceWithCashu,
     persistContactsOnboardingDismissed,
-    routeKind: route.kind,
-    stopContactsGuide,
+    pushToast,
+    refreshContactFromNostr,
+    route,
+    saveCashuFromText,
+    setPendingDeleteId,
+    setPendingLightningInvoiceConfirmation,
+    setPendingLnurlWithdrawConfirmation,
+    setStatus,
     t,
+    triggerChatScrollToBottom,
+    update,
+    updateLocalNostrMessage,
+    upsertBankPaymentOfferMessage,
   });
-
-  const closeShareOptions = React.useCallback(() => {
-    setShareOptionsText(null);
-  }, []);
-
-  const openShareOptionsUrl = React.useCallback((url: string) => {
-    if (typeof window === "undefined") return;
-    window.open(url, "_blank", "noopener,noreferrer");
-    setShareOptionsText(null);
-  }, []);
-
-  const copyShareOptionsText = React.useCallback(async () => {
-    const text = String(shareOptionsText ?? "").trim();
-    if (!text) return;
-    await copyText(text);
-    setShareOptionsText(null);
-  }, [copyText, shareOptionsText]);
-
-  const shareOptionsViaEmail = React.useCallback(() => {
-    const text = String(shareOptionsText ?? "").trim();
-    if (!text) return;
-    openShareOptionsUrl(`mailto:?body=${encodeURIComponent(text)}`);
-  }, [openShareOptionsUrl, shareOptionsText]);
-
-  const shareOptionsViaSms = React.useCallback(() => {
-    const text = String(shareOptionsText ?? "").trim();
-    if (!text) return;
-    openShareOptionsUrl(`sms:?body=${encodeURIComponent(text)}`);
-  }, [openShareOptionsUrl, shareOptionsText]);
-
-  const shareOptionsViaWhatsApp = React.useCallback(() => {
-    const text = String(shareOptionsText ?? "").trim();
-    if (!text) return;
-    openShareOptionsUrl(`https://wa.me/?text=${encodeURIComponent(text)}`);
-  }, [openShareOptionsUrl, shareOptionsText]);
-
-  const shareText = React.useCallback(
-    async (value: string) => {
-      const text = String(value ?? "").trim();
-      if (!text) {
-        pushToast(t("errorPrefix"));
-        return;
-      }
-
-      if (isNativePlatform()) {
-        try {
-          await Share.share({ text });
-          return;
-        } catch (error) {
-          const errorMessage =
-            typeof error === "object" &&
-            error !== null &&
-            "message" in error &&
-            typeof error.message === "string"
-              ? error.message
-              : "";
-          if (
-            /cancel/i.test(errorMessage) ||
-            /abort/i.test(errorMessage) ||
-            /dismiss/i.test(errorMessage)
-          ) {
-            return;
-          }
-          pushToast(t("shareFailed"));
-          return;
-        }
-      }
-
-      if (typeof navigator.share === "function") {
-        try {
-          await navigator.share({ text });
-          return;
-        } catch (error) {
-          const errorName =
-            typeof error === "object" &&
-            error !== null &&
-            "name" in error &&
-            typeof error.name === "string"
-              ? error.name
-              : "";
-          if (errorName === "AbortError") return;
-          pushToast(t("shareFailed"));
-          return;
-        }
-      }
-
-      pushToast(t("shareUnavailable"));
-    },
-    [pushToast, t],
-  );
-
-  const canWriteNfc = supportsNativeNfcWrite();
-  const [nfcWritePromptKind, setNfcWritePromptKind] = React.useState<
-    "profile" | "token" | null
-  >(null);
-  const nfcWriteCancelledByUserRef = React.useRef(false);
-
-  const cancelPendingNfcWrite = React.useCallback(() => {
-    nfcWriteCancelledByUserRef.current = true;
-    setNfcWritePromptKind(null);
-    cancelNativeNfcWrite();
-  }, []);
-
-  const writeNfcUriWithToast = React.useCallback(
-    async (
-      url: string,
-      successKey: "nfcWriteProfileSuccess" | "nfcWriteTokenSuccess",
-      promptKind: "profile" | "token",
-    ): Promise<boolean> => {
-      nfcWriteCancelledByUserRef.current = false;
-
-      const result = await startNativeNfcWrite(url, (progress) => {
-        if (progress.status === "armed" && progress.prompt === "web") {
-          setNfcWritePromptKind(promptKind);
-        }
-      });
-
-      setNfcWritePromptKind(null);
-
-      if (result === null || result.status === "unsupported") {
-        pushToast(t("nfcWriteUnsupported"));
-        return false;
-      }
-
-      if (result.status === "success") {
-        pushToast(t(successKey));
-        return true;
-      }
-
-      if (result.status === "disabled") {
-        pushToast(t("nfcWriteDisabled"));
-        return false;
-      }
-
-      if (result.status === "busy") {
-        pushToast(t("nfcWriteBusy"));
-        return false;
-      }
-
-      if (result.status === "cancelled") {
-        if (nfcWriteCancelledByUserRef.current) {
-          nfcWriteCancelledByUserRef.current = false;
-          return false;
-        }
-
-        pushToast(t("nfcWriteCancelled"));
-        return false;
-      }
-
-      nfcWriteCancelledByUserRef.current = false;
-
-      const message = String(result.message ?? "").trim();
-      pushToast(
-        message ? `${t("nfcWriteFailed")}: ${message}` : t("nfcWriteFailed"),
-      );
-
-      return false;
-    },
-    [pushToast, t],
-  );
-
-  const writeCashuTokenToNfc = React.useCallback(
-    async (id: CashuTokenId, tokenText: string) => {
-      const trimmed = String(tokenText ?? "").trim();
-      const deepLink = buildCashuDeepLink(trimmed);
-      if (!deepLink) {
-        pushToast(t("cashuInvalid"));
-        return;
-      }
-
-      const wrote = await writeNfcUriWithToast(
-        deepLink,
-        "nfcWriteTokenSuccess",
-        "token",
-      );
-
-      if (!wrote) return;
-
-      const payload = {
-        id,
-        state:
-          CASHU_TOKEN_STATE_EXTERNALIZED as typeof Evolu.NonEmptyString100.Type,
-        error: null,
-      };
-
-      const result = cashuOwnerId
-        ? update("cashuToken", payload, { ownerId: cashuOwnerId })
-        : update("cashuToken", payload);
-
-      if (!result.ok) {
-        setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
-      }
-    },
-    [cashuOwnerId, pushToast, setStatus, t, update, writeNfcUriWithToast],
-  );
-
-  const shareCashuTokenText = React.useCallback(
-    async (id: CashuTokenId, text: string) => {
-      const trimmed = String(text ?? "").trim();
-      if (!trimmed) {
-        pushToast(t("cashuInvalid"));
-        return;
-      }
-
-      const row = cashuTokensAllFiltered.find(
-        (candidate) => candidate.id === id && !candidate.isDeleted,
-      );
-      if (!row) {
-        pushToast(t("cashuInvalid"));
-        return;
-      }
-
-      if (isNativePlatform() || typeof navigator.share === "function") {
-        await shareText(trimmed);
-      } else {
-        setShareOptionsText(trimmed);
-      }
-
-      if (isCashuTokenAcceptedState(row.state)) {
-        await markCashuTokenIssued(id);
-      }
-    },
-    [cashuTokensAllFiltered, markCashuTokenIssued, pushToast, shareText, t],
-  );
-
-  const writeCurrentNpubToNfc = React.useCallback(async () => {
-    const npub = normalizeNpubIdentifier(currentNpub);
-    if (!npub) {
-      pushToast(t("profileMissingNpub"));
-      return;
-    }
-
-    await writeNfcUriWithToast(
-      `nostr://${npub}`,
-      "nfcWriteProfileSuccess",
-      "profile",
-    );
-  }, [currentNpub, pushToast, t, writeNfcUriWithToast]);
 
   const handleSelectContact = React.useCallback(
     (contact: DisplayContact) => {
@@ -1584,796 +1244,6 @@ export const useAppShellComposition = () => {
         : null,
     [route.kind, selectedChatContact, selectedContact?.id],
   );
-
-  const openNotificationChat = React.useCallback(
-    async (rawDetail: unknown): Promise<boolean> => {
-      const target = readNotificationOpenTarget(rawDetail);
-      if (!target || !currentNsec) {
-        return false;
-      }
-
-      let openedFromNotificationData = false;
-      try {
-        const decoded = nip19.decode(currentNsec);
-        if (decoded.type !== "nsec" || !(decoded.data instanceof Uint8Array)) {
-          return false;
-        }
-
-        const { getPublicKey } = await import("nostr-tools");
-        const { unwrapEvent } = await import("nostr-tools/nip17");
-
-        const privBytes = decoded.data;
-        const myPubHex = getPublicKey(privBytes);
-        if (target.recipientPubkey !== myPubHex) {
-          return false;
-        }
-
-        const findKnownContact = (peerPubkey: string) =>
-          contactsLatestRef.current.find((contact) => {
-            const normalizedNpub = normalizeNpubIdentifier(contact.npub);
-            if (!normalizedNpub) {
-              return false;
-            }
-
-            try {
-              const decodedContact = nip19.decode(normalizedNpub);
-              return (
-                decodedContact.type === "npub" &&
-                typeof decodedContact.data === "string" &&
-                normalizePubkeyHex(decodedContact.data) === peerPubkey
-              );
-            } catch {
-              return false;
-            }
-          }) ?? null;
-
-        const openKnownNotificationContact = (peerPubkey: string): boolean => {
-          const knownContact = findKnownContact(peerPubkey);
-          const knownContactId = String(knownContact?.id ?? "").trim();
-          if (!knownContactId) {
-            return false;
-          }
-
-          setPendingDeleteId(null);
-          navigateTo({ route: "chat", id: knownContactId });
-          return true;
-        };
-
-        openedFromNotificationData = target.senderPubkey
-          ? openKnownNotificationContact(target.senderPubkey)
-          : false;
-
-        const relays = Array.from(
-          new Set([...target.relayHints, ...nostrFetchRelays, ...NOSTR_RELAYS]),
-        );
-        const pool = await getSharedAppNostrPool();
-        const wraps = await pool.querySync(
-          relays,
-          {
-            ids: [target.outerEventId],
-            kinds: [1059],
-            "#p": [myPubHex],
-            limit: 1,
-          },
-          { maxWait: 2500 },
-        );
-        const wrap = wraps[0] ?? null;
-        if (!wrap) {
-          return (
-            openedFromNotificationData ||
-            (target.senderPubkey
-              ? openKnownNotificationContact(target.senderPubkey)
-              : false)
-          );
-        }
-
-        const wrapId = String(wrap.id ?? "").trim();
-        if (!wrapId) {
-          return openedFromNotificationData;
-        }
-
-        const inner = unwrapEvent(wrap, privBytes);
-        if (!inner) {
-          return openedFromNotificationData;
-        }
-
-        const senderPub = normalizePubkeyHex(inner.pubkey);
-        const tags = Array.isArray(inner.tags) ? inner.tags : [];
-        const pTags = tags
-          .filter((tag) => Array.isArray(tag) && tag[0] === "p")
-          .map((tag) => normalizePubkeyHex(tag[1]))
-          .filter((pubkey): pubkey is string => Boolean(pubkey));
-
-        const peerPubkey =
-          senderPub && senderPub !== myPubHex
-            ? senderPub
-            : (pTags.find((pubkey) => pubkey !== myPubHex) ?? null);
-        if (!peerPubkey) {
-          return openedFromNotificationData;
-        }
-
-        const knownContact = findKnownContact(peerPubkey);
-
-        const contactId = knownContact
-          ? String(knownContact.id ?? "").trim()
-          : String(buildUnknownContactId(peerPubkey) ?? "").trim();
-        if (!contactId) {
-          return false;
-        }
-
-        let insertedMessageId: string | null = null;
-
-        if (isLinkyBankPaymentOfferPaymentNoticeEvent(inner)) {
-          const taggedOfferId =
-            getLinkyBankPaymentOfferPaymentNoticeOfferId(inner);
-          const matchingOffer = taggedOfferId
-            ? null
-            : bankPaymentOfferMessages.reduce<{
-                createdAtSec: number;
-                offerId: string;
-              } | null>((latest, message) => {
-                if (String(message.contactId ?? "").trim() !== contactId) {
-                  return latest;
-                }
-
-                const info = getLinkyBankPaymentOfferInfo(
-                  String(message.content ?? ""),
-                );
-                if (!info) return latest;
-
-                const createdAtSec = Number(message.createdAtSec ?? 0);
-                if (latest && latest.createdAtSec >= createdAtSec) {
-                  return latest;
-                }
-                return { createdAtSec, offerId: info.offerId };
-              }, null);
-          const offerId =
-            taggedOfferId ?? matchingOffer?.offerId ?? `expired:${wrapId}`;
-
-          if (taggedOfferId || matchingOffer) {
-            setLinkyBankPaymentOfferMinimized(contactId, offerId, false);
-          }
-          setPendingDeleteId(null);
-          navigateTo({
-            route: "bankPaymentOffer",
-            chatId: contactId,
-            offerId,
-          });
-          return true;
-        }
-
-        if (isLinkyBankPaymentOfferEvent(inner)) {
-          const content = String(inner.content ?? "");
-          const offerInfo = getLinkyBankPaymentOfferInfo(content);
-          if (!offerInfo || !pTags.includes(myPubHex)) {
-            return openedFromNotificationData;
-          }
-
-          const offererPubkey =
-            String(offerInfo.offererPublicKey ?? "").trim() ||
-            senderPub ||
-            peerPubkey;
-          const isOutgoing = offererPubkey === myPubHex;
-          const tagClientId = extractClientTag(tags);
-          const createdAtSecRaw = Number(inner.created_at ?? 0);
-          const createdAtSec =
-            Number.isFinite(createdAtSecRaw) && createdAtSecRaw > 0
-              ? Math.trunc(createdAtSecRaw)
-              : Math.floor(Date.now() / 1_000);
-          const offerMessage: LocalNostrMessage = {
-            contactId,
-            content,
-            createdAtSec,
-            direction: isOutgoing ? "out" : "in",
-            id: `bank-payment-offer:${wrapId}`,
-            localOnly: true,
-            pubkey: isOutgoing ? myPubHex : offererPubkey,
-            rumorId: null,
-            status: "sent",
-            wrapId,
-          };
-          if (tagClientId) {
-            offerMessage.clientId = tagClientId;
-          }
-          upsertBankPaymentOfferMessage(offerMessage);
-          setLinkyBankPaymentOfferMinimized(
-            contactId,
-            offerInfo.offerId,
-            false,
-          );
-          setPendingDeleteId(null);
-          navigateTo({
-            route: "bankPaymentOffer",
-            chatId: contactId,
-            offerId: offerInfo.offerId,
-          });
-          return true;
-        }
-
-        if (inner.kind === 14 || inner.kind === 15) {
-          const existingByWrap = nostrMessagesLatestRef.current.find(
-            (message) => String(message.wrapId ?? "").trim() === wrapId,
-          );
-          if (existingByWrap) {
-            insertedMessageId = String(existingByWrap.id ?? "").trim() || null;
-          } else if (
-            !hasKnownNostrMessageIdentity(knownNostrMessageIdentityIndex, {
-              wrapId,
-            }) &&
-            !isInvalidInnerRumorPubkey(senderPub, wrap.pubkey)
-          ) {
-            const content =
-              inner.kind === 15
-                ? (privateImageMessageFromEvent(inner) ?? "")
-                : String(inner.content ?? "");
-
-            if (content.trim()) {
-              const taggedPeerPub =
-                pTags.find((pubkey) => pubkey !== myPubHex) ?? "";
-              const nestedEncryptedPayload =
-                inner.kind === 14 &&
-                isNestedEncryptedNip44PayloadForAnyPubkey(
-                  content,
-                  [senderPub, taggedPeerPub, wrap.pubkey],
-                  privBytes,
-                );
-
-              if (!nestedEncryptedPayload) {
-                const tagClientId = extractClientTag(tags);
-                const rumorId = inner.id ? String(inner.id).trim() : "";
-                const matchedOutgoingMessage =
-                  senderPub === myPubHex
-                    ? null
-                    : (nostrMessagesLatestRef.current.find((message) => {
-                        if (String(message.direction ?? "").trim() !== "out") {
-                          return false;
-                        }
-                        if (
-                          tagClientId &&
-                          String(message.clientId ?? "").trim() ===
-                            String(tagClientId).trim()
-                        ) {
-                          return true;
-                        }
-                        return (
-                          rumorId &&
-                          String(message.rumorId ?? "").trim() === rumorId
-                        );
-                      }) ?? null);
-
-                const addressesMe = pTags.includes(myPubHex);
-                const isOutgoing =
-                  senderPub === myPubHex ||
-                  (addressesMe && Boolean(matchedOutgoingMessage));
-
-                if (addressesMe || isOutgoing) {
-                  const messageDirection = isOutgoing ? "out" : "in";
-                  const { replyToId, rootMessageId } =
-                    extractReplyContextFromTags(tags);
-                  const editedFromId = extractEditedFromTag(tags);
-                  const effectivePubkey = isOutgoing ? myPubHex : peerPubkey;
-                  const normalizedIncomingPeerPubkey = isOutgoing
-                    ? null
-                    : normalizePubkeyHex(effectivePubkey);
-                  const createdAtSecRaw = Number(inner.created_at ?? 0);
-                  const createdAtSec =
-                    Number.isFinite(createdAtSecRaw) && createdAtSecRaw > 0
-                      ? Math.trunc(createdAtSecRaw)
-                      : Math.ceil(Date.now() / 1e3);
-
-                  const matchesStoredIncomingPeer = (
-                    message: LocalNostrMessage,
-                  ): boolean => {
-                    if (isOutgoing || !normalizedIncomingPeerPubkey) {
-                      return false;
-                    }
-
-                    return (
-                      normalizePubkeyHex(message.pubkey) ===
-                      normalizedIncomingPeerPubkey
-                    );
-                  };
-
-                  if (
-                    !hasKnownNostrMessageIdentity(
-                      knownNostrMessageIdentityIndex,
-                      {
-                        contactId,
-                        direction: messageDirection,
-                        ...(tagClientId ? { clientId: tagClientId } : {}),
-                        ...(rumorId ? { rumorId } : {}),
-                        wrapId,
-                      },
-                    )
-                  ) {
-                    if (editedFromId) {
-                      const targetMessage = nostrMessagesLatestRef.current.find(
-                        (message) => {
-                          const matchesContactId =
-                            String(message.contactId ?? "") ===
-                            String(contactId);
-                          if (
-                            !matchesContactId &&
-                            !matchesStoredIncomingPeer(message)
-                          ) {
-                            return false;
-                          }
-                          if (
-                            String(message.direction ?? "") !== messageDirection
-                          ) {
-                            return false;
-                          }
-                          return (
-                            String(message.rumorId ?? "").trim() ===
-                              editedFromId ||
-                            String(message.editedFromId ?? "").trim() ===
-                              editedFromId
-                          );
-                        },
-                      );
-
-                      if (targetMessage) {
-                        const targetMessageId = String(
-                          targetMessage.id ?? "",
-                        ).trim();
-                        if (targetMessageId) {
-                          const existingOriginal =
-                            String(
-                              targetMessage.originalContent ?? "",
-                            ).trim() || String(targetMessage.content ?? "");
-                          updateLocalNostrMessage(targetMessageId, {
-                            content,
-                            status: "sent",
-                            wrapId,
-                            pubkey: effectivePubkey,
-                            ...(tagClientId ? { clientId: tagClientId } : {}),
-                            ...(rumorId ? { rumorId } : {}),
-                            editedAtSec: createdAtSec,
-                            editedFromId,
-                            isEdited: true,
-                            originalContent: existingOriginal || null,
-                          });
-                          insertedMessageId = targetMessageId;
-                        }
-                      }
-                    }
-
-                    if (!insertedMessageId) {
-                      const existingMessage =
-                        nostrMessagesLatestRef.current.find((message) => {
-                          const matchesContactId =
-                            String(message.contactId ?? "") ===
-                            String(contactId);
-                          if (
-                            !matchesContactId &&
-                            !matchesStoredIncomingPeer(message)
-                          ) {
-                            return false;
-                          }
-                          if (
-                            String(message.direction ?? "") !== messageDirection
-                          ) {
-                            return false;
-                          }
-                          if (
-                            rumorId &&
-                            String(message.rumorId ?? "").trim() === rumorId
-                          ) {
-                            return true;
-                          }
-                          if (tagClientId) {
-                            return (
-                              String(message.clientId ?? "").trim() ===
-                              String(tagClientId).trim()
-                            );
-                          }
-                          return (
-                            String(message.content ?? "").trim() ===
-                            content.trim()
-                          );
-                        });
-
-                      if (existingMessage) {
-                        const existingMessageId = String(
-                          existingMessage.id ?? "",
-                        ).trim();
-                        if (existingMessageId) {
-                          updateLocalNostrMessage(existingMessageId, {
-                            status: "sent",
-                            wrapId,
-                            pubkey: effectivePubkey,
-                            ...(tagClientId ? { clientId: tagClientId } : {}),
-                            ...(rumorId ? { rumorId } : {}),
-                            ...(replyToId ? { replyToId } : {}),
-                            ...(rootMessageId ? { rootMessageId } : {}),
-                            ...(editedFromId ? { editedFromId } : {}),
-                          });
-                          insertedMessageId = existingMessageId;
-                        }
-                      } else {
-                        insertedMessageId = appendLocalNostrMessage({
-                          contactId,
-                          content,
-                          createdAtSec,
-                          direction: messageDirection,
-                          pubkey: effectivePubkey,
-                          rumorId: rumorId || null,
-                          wrapId,
-                          ...(tagClientId ? { clientId: tagClientId } : {}),
-                          ...(replyToId ? { replyToId } : {}),
-                          ...(rootMessageId ? { rootMessageId } : {}),
-                          ...(editedFromId
-                            ? {
-                                editedAtSec: createdAtSec,
-                                editedFromId,
-                                isEdited: true,
-                              }
-                            : {}),
-                        });
-                      }
-
-                      nostrMessageWrapIdsRef.current.add(wrapId);
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        setPendingDeleteId(null);
-        navigateTo({ route: "chat", id: contactId });
-        if (insertedMessageId) {
-          triggerChatScrollToBottom(insertedMessageId);
-        }
-        return true;
-      } catch {
-        return openedFromNotificationData;
-      }
-    },
-    [
-      appendLocalNostrMessage,
-      bankPaymentOfferMessages,
-      currentNsec,
-      knownNostrMessageIdentityIndex,
-      nostrFetchRelays,
-      nostrMessagesLatestRef,
-      nostrMessageWrapIdsRef,
-      setPendingDeleteId,
-      triggerChatScrollToBottom,
-      updateLocalNostrMessage,
-      upsertBankPaymentOfferMessage,
-    ],
-  );
-
-  const handleContactIdentifierScanned = React.useCallback(
-    async (identifier: string) => {
-      await addNewContactFromIdentifier(identifier);
-    },
-    [addNewContactFromIdentifier],
-  );
-
-  const handleScannedText = useScannedTextHandler<(typeof contacts)[number]>({
-    appOwnerId: contactsOwnerId,
-    closeScan,
-    contacts,
-    currentNpub,
-    extractCashuTokenFromText,
-    insert,
-    lightningInvoiceAutoPayLimit,
-    onContactIdentifierScanned:
-      route.kind === "contactNew" ? handleContactIdentifierScanned : null,
-    openScannedContactPendingNpubRef,
-    payCashuPaymentRequest,
-    payLightningInvoiceWithCashu,
-    refreshContactFromNostr,
-    requestLightningInvoiceConfirmation: setPendingLightningInvoiceConfirmation,
-    requestLnurlWithdrawConfirmation: setPendingLnurlWithdrawConfirmation,
-    saveCashuFromText,
-    scanAcceptsBankPayment:
-      scanEntryPoint === "send" || route.kind === "manualPay",
-    scanEntryPoint,
-    setStatus,
-    t,
-  });
-
-  React.useEffect(() => {
-    const acceptDeepLinkUrl = (rawUrl: unknown) => {
-      const parsed = parseNativeDeepLinkUrl(rawUrl);
-      if (!parsed) {
-        return;
-      }
-
-      setPendingDeleteId(null);
-      updatePendingDeepLinkText(parsed.text);
-      consumePendingNativeDeepLinkUrl();
-    };
-
-    acceptDeepLinkUrl(consumePendingNativeDeepLinkUrl());
-    void consumePendingIosNativeDeepLinkUrl().then(acceptDeepLinkUrl);
-
-    const onDeepLink: EventListener = (event) => {
-      if (!(event instanceof CustomEvent)) {
-        return;
-      }
-
-      const detail = event.detail;
-      if (typeof detail !== "object" || detail === null) {
-        return;
-      }
-
-      acceptDeepLinkUrl(Reflect.get(detail, "url"));
-    };
-
-    window.addEventListener(NATIVE_DEEP_LINK_EVENT, onDeepLink);
-    return () => window.removeEventListener(NATIVE_DEEP_LINK_EVENT, onDeepLink);
-  }, [setPendingDeleteId, updatePendingDeepLinkText]);
-
-  React.useEffect(() => {
-    const openNotificationRoute = (rawRoute: unknown) => {
-      const routeValue = readNotificationOpenRoute(rawRoute);
-      if (routeValue === "#contacts") {
-        navigateTo({ route: "contacts" });
-        return;
-      }
-      if (routeValue === "#wallet") {
-        navigateTo({ route: "wallet" });
-      }
-    };
-
-    const openNotification = (rawDetail: unknown) => {
-      if (!nostrBootstrapReady) {
-        pendingNotificationOpenDetailsRef.current.push({ value: rawDetail });
-        return;
-      }
-
-      void openNotificationChat(rawDetail).then((opened) => {
-        if (opened) {
-          return;
-        }
-
-        openNotificationRoute(rawDetail);
-      });
-    };
-
-    const pendingNotificationDetail =
-      consumePendingNativeNotificationOpenDetail();
-    const pendingHashNotificationDetail =
-      consumeNotificationOpenDetailFromHash();
-    if (pendingNotificationDetail) {
-      openNotification(pendingNotificationDetail);
-    } else if (pendingHashNotificationDetail) {
-      openNotification(pendingHashNotificationDetail);
-    } else {
-      openNotificationRoute(consumePendingNativeNotificationRoute());
-    }
-
-    if (nostrBootstrapReady) {
-      const queuedDetails = pendingNotificationOpenDetailsRef.current.splice(0);
-      for (const detail of queuedDetails) {
-        openNotification(detail.value);
-      }
-    }
-
-    const onNotificationOpen: EventListener = (event) => {
-      if (!(event instanceof CustomEvent)) {
-        return;
-      }
-
-      const detail = event.detail;
-      if (typeof detail !== "object" || detail === null) {
-        return;
-      }
-
-      openNotification(detail);
-    };
-
-    window.addEventListener(NATIVE_NOTIFICATION_OPEN_EVENT, onNotificationOpen);
-    window.addEventListener(NATIVE_PUSH_ACTION_EVENT, onNotificationOpen);
-    const onServiceWorkerMessage = (event: MessageEvent) => {
-      const data = event.data;
-      if (typeof data !== "object" || data === null) {
-        return;
-      }
-      if (Reflect.get(data, "type") !== "notification-open") {
-        return;
-      }
-
-      openNotification(Reflect.get(data, "detail"));
-    };
-
-    if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
-      navigator.serviceWorker.addEventListener(
-        "message",
-        onServiceWorkerMessage,
-      );
-    }
-
-    return () => {
-      if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
-        navigator.serviceWorker.removeEventListener(
-          "message",
-          onServiceWorkerMessage,
-        );
-      }
-
-      window.removeEventListener(
-        NATIVE_NOTIFICATION_OPEN_EVENT,
-        onNotificationOpen,
-      );
-      window.removeEventListener(NATIVE_PUSH_ACTION_EVENT, onNotificationOpen);
-    };
-  }, [nostrBootstrapReady, openNotificationChat]);
-
-  React.useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    const rawHash = String(window.location.hash ?? "");
-    const token = extractCashuTokenFromTextFromUrl(rawHash);
-    if (!token) {
-      return;
-    }
-
-    setPendingDeleteId(null);
-    updatePendingDeepLinkText(`cashu:${token}`);
-
-    const cleanHash = rawHash.split("?")[0] ?? "#wallet";
-    const nextHash = cleanHash || "#wallet";
-    window.history.replaceState(
-      null,
-      "",
-      `${window.location.pathname}${window.location.search}${nextHash}`,
-    );
-  }, [setPendingDeleteId, updatePendingDeepLinkText]);
-
-  React.useEffect(() => {
-    if (!pendingDeepLinkText) {
-      return;
-    }
-
-    if (!currentNsec || !cashuOwnerId) {
-      return;
-    }
-
-    updatePendingDeepLinkText(null);
-    void handleScannedText(pendingDeepLinkText).catch(() => {
-      updatePendingDeepLinkText(pendingDeepLinkText);
-    });
-  }, [
-    cashuOwnerId,
-    currentNsec,
-    handleScannedText,
-    pendingDeepLinkText,
-    updatePendingDeepLinkText,
-  ]);
-
-  const pasteScanValue = React.useCallback(async () => {
-    let text = "";
-
-    if (navigator.clipboard?.readText) {
-      try {
-        text = await navigator.clipboard.readText();
-      } catch {
-        if (
-          typeof window !== "undefined" &&
-          typeof window.prompt === "function"
-        ) {
-          text = String(window.prompt(t("scanPastePrompt")) ?? "");
-        } else {
-          pushToast(t("pasteNotAvailable"));
-          return;
-        }
-      }
-    } else if (
-      typeof window !== "undefined" &&
-      typeof window.prompt === "function"
-    ) {
-      text = String(window.prompt(t("scanPastePrompt")) ?? "");
-    } else {
-      pushToast(t("pasteNotAvailable"));
-      return;
-    }
-
-    const raw = String(text ?? "").trim();
-    if (!raw) {
-      pushToast(t("pasteEmpty"));
-      return;
-    }
-
-    await handleScannedText(raw);
-  }, [handleScannedText, pushToast, t]);
-
-  const onScanImageSelected = React.useCallback(
-    async (event: React.ChangeEvent<HTMLInputElement>) => {
-      const input = event.currentTarget;
-      const file = input.files?.[0] ?? null;
-      input.value = "";
-
-      if (!file) {
-        return;
-      }
-
-      const loadImage = async (imageFile: File): Promise<HTMLImageElement> => {
-        const objectUrl = URL.createObjectURL(imageFile);
-
-        try {
-          return await new Promise<HTMLImageElement>((resolve, reject) => {
-            const image = new Image();
-            image.onload = () => resolve(image);
-            image.onerror = () => reject(new Error("image-load-failed"));
-            image.src = objectUrl;
-          });
-        } finally {
-          URL.revokeObjectURL(objectUrl);
-        }
-      };
-
-      try {
-        const image = await loadImage(file);
-        const detectorCtor = window.BarcodeDetector;
-
-        if (detectorCtor) {
-          const detector = new detectorCtor({ formats: ["qr_code"] });
-          const detectorValue = String(
-            (await detector.detect(image))?.[0]?.rawValue ?? "",
-          ).trim();
-
-          if (detectorValue) {
-            await handleScannedText(detectorValue);
-            return;
-          }
-        }
-
-        const width = image.naturalWidth || image.width;
-        const height = image.naturalHeight || image.height;
-        if (width <= 0 || height <= 0) {
-          pushToast(t("scanImageUnsupported"));
-          return;
-        }
-
-        const canvas = document.createElement("canvas");
-        canvas.width = width;
-        canvas.height = height;
-
-        const ctx = canvas.getContext("2d", { willReadFrequently: true });
-        if (!ctx) {
-          pushToast(t("scanImageUnsupported"));
-          return;
-        }
-
-        ctx.drawImage(image, 0, 0, width, height);
-        const imageData = ctx.getImageData(0, 0, width, height);
-        const jsQr = (await import("jsqr")).default;
-        const qrValue = String(
-          jsQr(imageData.data, width, height)?.data ?? "",
-        ).trim();
-
-        if (!qrValue) {
-          pushToast(t("scanImageUnsupported"));
-          return;
-        }
-
-        await handleScannedText(qrValue);
-      } catch {
-        pushToast(t("scanImageUnsupported"));
-      }
-    },
-    [handleScannedText, pushToast, t],
-  );
-
-  const onSubmitManualPayText = React.useCallback(
-    async (text: string) => {
-      await handleScannedText(text);
-    },
-    [handleScannedText],
-  );
-
-  useScannedTextHandlerRefBridge({
-    handleScannedText,
-    scannedTextHandlerRef,
-  });
 
   useChatMessageEffects({
     autoAcceptedChatMessageIdsRef,

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -2,18 +2,11 @@ import { Share } from "@capacitor/share";
 import type { Proof } from "@cashu/cashu-ts";
 import * as Evolu from "@evolu/common";
 import { useQuery } from "@evolu/react";
-import {
-  nip19,
-  type Event as NostrToolsEvent,
-  type UnsignedEvent,
-} from "nostr-tools";
+import { nip19, type UnsignedEvent } from "nostr-tools";
 import React, { useMemo, useState } from "react";
 import { createSendTokenWithTokensAtMint } from "../cashuSend";
 import { ContactCard } from "../components/ContactCard";
-import {
-  deriveDefaultProfile,
-  omitSyntheticContactLightningAddress,
-} from "../derivedProfile";
+import { deriveDefaultProfile } from "../derivedProfile";
 import {
   evolu,
   normalizeEvoluServerUrl,
@@ -33,27 +26,7 @@ import {
   redeemLnurlWithdraw,
   type LnurlWithdrawPreview,
 } from "../lnurlPay";
-import {
-  cacheProfileAvatarFromUrl,
-  deleteCachedProfileAvatar,
-  fetchNostrProfileMetadata,
-  fetchNostrProfilePicture,
-  getNostrProfilePictureUrl,
-  isCachedProfilePictureStale,
-  loadCachedProfileAvatarObjectUrl,
-  loadCachedProfileMetadata,
-  loadCachedProfilePicture,
-  NOSTR_RELAYS,
-  saveCachedProfileMetadata,
-  saveCachedProfilePicture,
-  type NostrProfileMetadata,
-} from "../nostrProfile";
-import {
-  buildStatusFilterValue,
-  extractStatusFilterCurrencies,
-  isStatusFilterValue,
-  parseStatusFilterValue,
-} from "../nostrStatus";
+import { NOSTR_RELAYS } from "../nostrProfile";
 import { writeClipboardText } from "../platform/clipboard";
 import {
   cancelNativeNfcWrite,
@@ -81,8 +54,6 @@ import { getCashuLib } from "../utils/cashuLib";
 import { cashuAmountToNumber } from "../utils/cashuProofs";
 import { createLoadedCashuWallet } from "../utils/cashuWallet";
 import {
-  ARCHIVED_CONTACTS_FILTER,
-  BLOCKED_NOSTR_PUBKEYS_STORAGE_KEY,
   CASHU_AUTOSWAP_MIN_SOURCE_SUM,
   CASHU_ONBOARDING_SET_MAIN_MINT_STORAGE_KEY,
   CONTACTS_ONBOARDING_HAS_BACKUPED_KEYS_STORAGE_KEY,
@@ -91,7 +62,6 @@ import {
   LOCAL_MINT_INFO_STORAGE_KEY_PREFIX,
   LOCAL_PENDING_TOPUP_QUOTE_STORAGE_KEY_PREFIX,
   MAX_CONTACTS_PER_OWNER,
-  NO_GROUP_FILTER,
   PENDING_DEEP_LINK_TEXT_STORAGE_KEY,
   WALLET_WARNING_BALANCE_THRESHOLD_SAT,
   WALLET_WARNING_DISMISSED_STORAGE_KEY,
@@ -106,7 +76,6 @@ import {
   normalizeAllowedDisplayCurrencies,
   type DisplayCurrency,
 } from "../utils/displayAmounts";
-import { formatShortNpub, getBestNostrName } from "../utils/formatting";
 import {
   getLightningInvoicePreview,
   type LightningInvoicePreview,
@@ -121,16 +90,13 @@ import {
 } from "../utils/mint";
 import { normalizeNpubIdentifier } from "../utils/nostrNpub";
 import { parseNpubCashProfileInfo } from "../utils/npubCashInfo";
-import { setStoredPushContactNames } from "../utils/pushContactNamesStorage";
 import {
   getInitialAllowedDisplayCurrencies,
-  getInitialBankPaymentOfferRecipientCount,
   getInitialCashuAutoswapEnabled,
   getInitialDisplayCurrency,
   getInitialLightningInvoiceAutoPayLimit,
   getInitialPayWithCashuEnabled,
   safeLocalStorageGet,
-  safeLocalStorageGetJson,
   safeLocalStorageRemove,
   safeLocalStorageSet,
   safeLocalStorageSetJson,
@@ -148,8 +114,6 @@ import { useProfileComposition } from "./hooks/composition/useProfileComposition
 import { useProfilePeopleComposition } from "./hooks/composition/useProfilePeopleComposition";
 import { useRoutingViewComposition } from "./hooks/composition/useRoutingViewComposition";
 import { useSystemSettingsComposition } from "./hooks/composition/useSystemSettingsComposition";
-import { useContactEditor } from "./hooks/contacts/useContactEditor";
-import { useVisibleContacts } from "./hooks/contacts/useVisibleContacts";
 import { useContactsOnboardingProgress } from "./hooks/guide/useContactsOnboardingProgress";
 import { useMainMenuState } from "./hooks/layout/useMainMenuState";
 import { useMainSwipeNavigation } from "./hooks/layout/useMainSwipeNavigation";
@@ -164,22 +128,9 @@ import {
   buildUnknownContactId,
   isUnknownContactId,
   normalizePubkeyHex,
-  readUnknownContactIdPubkey,
 } from "./hooks/messages/contactIdentity";
 import { hasKnownNostrMessageIdentity } from "./hooks/messages/messageHelpers";
 import { useChatMessageEffects } from "./hooks/messages/useChatMessageEffects";
-import { useChatNostrSyncEffect } from "./hooks/messages/useChatNostrSyncEffect";
-import {
-  useEditChatMessage,
-  type EditChatContext,
-} from "./hooks/messages/useEditChatMessage";
-import { useInboxNotificationsSync } from "./hooks/messages/useInboxNotificationsSync";
-import { useNostrPendingFlush } from "./hooks/messages/useNostrPendingFlush";
-import {
-  useSendChatMessage,
-  type ReplyContext,
-} from "./hooks/messages/useSendChatMessage";
-import { useSendReaction } from "./hooks/messages/useSendReaction";
 import { useNpubCashMintSelection } from "./hooks/mint/useNpubCashMintSelection";
 import { useContactPayMethod } from "./hooks/payments/useContactPayMethod";
 import { usePayContactWithCashuMessage } from "./hooks/payments/usePayContactWithCashuMessage";
@@ -199,26 +150,19 @@ import { useAppDataTransfer } from "./hooks/useAppDataTransfer";
 import { useAppPreferences } from "./hooks/useAppPreferences";
 import { useArmedDeleteTimeouts } from "./hooks/useArmedDeleteTimeouts";
 import { useCashuDomain } from "./hooks/useCashuDomain";
-import { useContactsDomain } from "./hooks/useContactsDomain";
-import { useContactsNostrPrefetchEffects } from "./hooks/useContactsNostrPrefetchEffects";
-import { useEvoluNostrBootstrapReady } from "./hooks/useEvoluNostrBootstrapReady";
-import { useFeedbackContact } from "./hooks/useFeedbackContact";
 import { useFiatRates } from "./hooks/useFiatRates";
 import { useGuideScannerDomain } from "./hooks/useGuideScannerDomain";
 import { useLightningPaymentsDomain } from "./hooks/useLightningPaymentsDomain";
 import { useMainSwipePageEffects } from "./hooks/useMainSwipePageEffects";
-import { useMessagesDomain } from "./hooks/useMessagesDomain";
 import { useMintDomain } from "./hooks/useMintDomain";
 import { useOwnerScopedStorage } from "./hooks/useOwnerScopedStorage";
 import { usePaidOverlayState } from "./hooks/usePaidOverlayState";
 import { usePaymentsDomain } from "./hooks/usePaymentsDomain";
 import { useProfileNpubCashEffects } from "./hooks/useProfileNpubCashEffects";
-import { useRelayDomain } from "./hooks/useRelayDomain";
 import { useScannedTextHandler } from "./hooks/useScannedTextHandler";
 import { useScannedTextHandlerRefBridge } from "./hooks/useScannedTextHandlerRefBridge";
 import { useStatusToasts } from "./hooks/useStatusToasts";
 import { useStoragePersistRequestEffect } from "./hooks/useStoragePersistRequestEffect";
-import { findUniqueContactByLightningAddress } from "./lib/contactIdentity";
 import {
   appendPendingAutoswapClaim,
   claimAutoswapPendingEntry,
@@ -226,21 +170,10 @@ import {
   readPendingAutoswapClaims,
   type AutoswapPendingClaim,
 } from "./lib/autoswapClaim";
-import { resolveContactRowOwnerLane } from "./lib/contactOwnerLane";
 import {
-  createLinkyBankPaymentOfferEvent,
   getLinkyBankPaymentOfferInfo,
-  getLinkyBankPaymentOfferStatusRank,
   isLinkyBankPaymentOfferEvent,
-  isLinkyBankPaymentOfferTerminalStatus,
-  LINKY_BANK_PAYMENT_OFFER_DEFAULT_RECIPIENT_COUNT,
-  LINKY_BANK_PAYMENT_OFFER_MAX_RECIPIENT_COUNT,
-  LINKY_BANK_PAYMENT_OFFER_MIN_RECIPIENT_COUNT,
-  LINKY_BANK_PAYMENT_OFFER_PHASE_TTL_SEC,
-  LINKY_BANK_PAYMENT_OFFER_RECIPIENT_STATUS_CURRENCY,
   setLinkyBankPaymentOfferMinimized,
-  shouldPushLinkyBankPaymentOfferStatus,
-  type LinkyBankPaymentOfferStatus,
 } from "./lib/bankPaymentOffer";
 import { resolveCashuRowStoredOwnerLane } from "./lib/cashuOwnerLane";
 import { isCashuRowCandidateBetter } from "./lib/cashuRowPreference";
@@ -263,17 +196,12 @@ import {
   readNotificationOpenRoute,
   readNotificationOpenTarget,
 } from "./lib/notificationOpenTarget";
-import type { AppNostrPool } from "./lib/nostrPool";
 import { getSharedAppNostrPool } from "./lib/nostrPool";
 import {
   buildDismissedOnboardingTutorialOwnerMetaPayload,
   hasDismissedOnboardingTutorialOwnerMetaRow,
   ONBOARDING_TUTORIAL_OWNER_META_SCOPE,
 } from "./lib/onboardingTutorialSync";
-import {
-  publishSingleWrappedWithRetry as publishSingleWrappedWithRetryBase,
-  publishWrappedWithRetry as publishWrappedWithRetryBase,
-} from "./lib/nostrPublishRetry";
 import {
   buildPaymentAmountAttempts,
   buildPaymentFailureAmountAttempts,
@@ -290,14 +218,12 @@ import {
 } from "./lib/paymentMintSelection";
 import {
   buildCashuPaymentRequestMessage,
-  buildLinkyPaymentRequestDeclineMessage,
   parseCashuPaymentRequestMessage,
   type CashuPaymentRequestMessageInfo,
 } from "./lib/paymentRequestMessage";
 import {
   parsePrivateImageMessage,
   privateImageMessageFromEvent,
-  privateImagePreviewText,
 } from "./lib/privateImageMessage";
 import {
   getLinkyBankPaymentOfferPaymentNoticeOfferId,
@@ -335,23 +261,17 @@ import type {
   ContactRowLike,
   LocalNostrMessage,
   PaymentLogData,
-  PublishWrappedResult,
 } from "./types/appTypes";
-
-const inMemoryNostrPictureCache = new Map<string, string | null>();
-const INLINE_NPUB_PATTERN =
-  /(?:nostr:)?npub1[023456789acdefghjklmnpqrstuvwxyz]+(?:@npub\.cash)?/gi;
+import {
+  useContactsMessagingComposition,
+  type DisplayContact,
+} from "./hooks/composition/useContactsMessagingComposition";
 
 type TranslationKey = keyof (typeof translations)["cs"];
 type LoadedCashuWallet = Awaited<ReturnType<typeof createLoadedCashuWallet>>;
 
 const hasTranslationKey = (key: string): key is TranslationKey =>
   Object.prototype.hasOwnProperty.call(translations.cs, key);
-
-const readObjectField = (value: unknown, field: string): unknown => {
-  if (typeof value !== "object" || value === null) return undefined;
-  return Reflect.get(value, field);
-};
 
 type CashuProofPayload = Record<string, unknown> & {
   C: string;
@@ -378,23 +298,6 @@ const normalizeCashuProofPayload = (
   };
 };
 
-const extractMentionedNpubs = (content: string): string[] => {
-  const matches = String(content ?? "").match(INLINE_NPUB_PATTERN);
-  if (!matches) return [];
-
-  const seen = new Set<string>();
-  const npubs: string[] = [];
-
-  for (const match of matches) {
-    const npub = normalizeNpubIdentifier(match);
-    if (!npub || seen.has(npub)) continue;
-    seen.add(npub);
-    npubs.push(npub);
-  }
-
-  return npubs;
-};
-
 const logPayStep = (step: string, data?: PaymentLogData): void => {
   try {
     console.log("[linky][pay]", step, data ?? {});
@@ -403,50 +306,9 @@ const logPayStep = (step: string, data?: PaymentLogData): void => {
   }
 };
 
-const clampBankPaymentOfferRecipientCount = (value: number): number => {
-  if (!Number.isFinite(value)) {
-    return LINKY_BANK_PAYMENT_OFFER_DEFAULT_RECIPIENT_COUNT;
-  }
-
-  return Math.min(
-    LINKY_BANK_PAYMENT_OFFER_MAX_RECIPIENT_COUNT,
-    Math.max(LINKY_BANK_PAYMENT_OFFER_MIN_RECIPIENT_COUNT, Math.round(value)),
-  );
-};
-
-interface UnknownChatContact extends ContactRowLike {
-  id: string;
-  isUnknownContact: true;
-  unknownPubkeyHex: string | null;
-}
-
-type DisplayContact = ContactRowLike & {
-  isUnknownContact?: boolean;
-  unknownPubkeyHex?: string | null;
-};
-
-interface ChatSelectedContact {
-  groupName?: string | null;
-  id: string;
-  isUnknownContact?: boolean;
-  lnAddress?: string | null;
-  name?: string | null;
-  npub?: string | null;
-  unknownPubkeyHex?: string | null;
-}
-
 interface QueuedNotificationOpenDetail {
   value: unknown;
 }
-
-const encodeUnknownNpub = (pubkeyHex: string | null): string | null => {
-  if (!pubkeyHex) return null;
-  try {
-    return nip19.npubEncode(pubkeyHex);
-  } catch {
-    return null;
-  }
-};
 
 export const useAppShellComposition = () => {
   const { insert, update, upsert } = useEvolu();
@@ -577,11 +439,6 @@ export const useAppShellComposition = () => {
 
   const topupInvoiceStartBalanceRef = React.useRef<number | null>(null);
   const topupInvoicePaidHandledRef = React.useRef(false);
-  const [pendingDeleteId, setPendingDeleteId] = useState<ContactId | null>(
-    null,
-  );
-  const [recentlyAddedContactId, setRecentlyAddedContactId] =
-    useState<ContactId | null>(null);
   const [pendingCashuDeleteId, setPendingCashuDeleteId] =
     useState<CashuTokenId | null>(null);
   const [pendingMintDeleteUrl, setPendingMintDeleteUrl] = useState<
@@ -594,28 +451,6 @@ export const useAppShellComposition = () => {
   const contactsPullDistanceRef = React.useRef(0);
   const mainSwipeRef = React.useRef<HTMLDivElement | null>(null);
   const mainSwipeScrollTimerRef = React.useRef<number | null>(null);
-
-  const [contactsOnboardingHasPaid, setContactsOnboardingHasPaid] =
-    useState<boolean>(
-      () =>
-        safeLocalStorageGet(CONTACTS_ONBOARDING_HAS_PAID_STORAGE_KEY) === "1",
-    );
-
-  const [
-    contactsOnboardingHasBackedUpKeys,
-    setContactsOnboardingHasBackedUpKeys,
-  ] = useState<boolean>(
-    () =>
-      safeLocalStorageGet(CONTACTS_ONBOARDING_HAS_BACKUPED_KEYS_STORAGE_KEY) ===
-      "1",
-  );
-
-  // Ephemeral per-contact activity indicator.
-  // When a message/payment arrives, we show a dot and temporarily bump the
-  // contact to the top until the user opens it.
-  const [contactAttentionById, setContactAttentionById] = useState<
-    Record<string, number>
-  >(() => ({}));
   const [allowedDisplayCurrencies, setAllowedDisplayCurrencies] = useState<
     DisplayCurrency[]
   >(() => getInitialAllowedDisplayCurrencies());
@@ -630,24 +465,6 @@ export const useAppShellComposition = () => {
   );
   const [lightningInvoiceAutoPayLimit, setLightningInvoiceAutoPayLimit] =
     useState<number>(() => getInitialLightningInvoiceAutoPayLimit());
-  const [
-    bankPaymentOfferRecipientCount,
-    setBankPaymentOfferRecipientCountState,
-  ] = useState<number>(() =>
-    clampBankPaymentOfferRecipientCount(
-      getInitialBankPaymentOfferRecipientCount(
-        LINKY_BANK_PAYMENT_OFFER_DEFAULT_RECIPIENT_COUNT,
-      ),
-    ),
-  );
-  const setBankPaymentOfferRecipientCount = React.useCallback(
-    (value: number) => {
-      setBankPaymentOfferRecipientCountState(
-        clampBankPaymentOfferRecipientCount(value),
-      );
-    },
-    [],
-  );
 
   const pendingNotificationOpenDetailsRef = React.useRef<
     QueuedNotificationOpenDetail[]
@@ -719,37 +536,8 @@ export const useAppShellComposition = () => {
     [displayCurrency, fiatRates, lang],
   );
 
-  const [chatOwnPubkeyHex, setChatOwnPubkeyHex] = useState<string | null>(null);
-
   const evoluLastError = useEvoluLastError({ logToConsole: true });
   const evoluHasError = Boolean(evoluLastError);
-
-  React.useEffect(() => {
-    if (!currentNsec) {
-      setChatOwnPubkeyHex(null);
-      return;
-    }
-
-    let cancelled = false;
-    void import("nostr-tools")
-      .then(({ getPublicKey, nip19 }) => {
-        const decoded = nip19.decode(currentNsec);
-        if (decoded.type !== "nsec" || !(decoded.data instanceof Uint8Array)) {
-          if (!cancelled) setChatOwnPubkeyHex(null);
-          return;
-        }
-        if (!cancelled) {
-          setChatOwnPubkeyHex(getPublicKey(decoded.data));
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setChatOwnPubkeyHex(null);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [currentNsec]);
 
   React.useEffect(() => {
     if (!evoluLastError) return;
@@ -856,66 +644,6 @@ export const useAppShellComposition = () => {
     }
   }, [evoluWipeStorageIsBusy, lang, pushToast]);
 
-  const [nostrPictureByNpub, setNostrPictureByNpub] = useState<
-    Record<string, string | null>
-  >(() => Object.fromEntries(inMemoryNostrPictureCache.entries()));
-  const [nostrStatusByNpub, setNostrStatusByNpub] = useState<
-    Record<string, string | null>
-  >({});
-
-  const avatarObjectUrlsByNpubRef = React.useRef<Map<string, string>>(
-    new Map(),
-  );
-
-  React.useEffect(() => {
-    const objectUrls = avatarObjectUrlsByNpubRef.current;
-    return () => {
-      for (const url of objectUrls.values()) {
-        if (!url.startsWith("blob:")) continue;
-        try {
-          URL.revokeObjectURL(url);
-        } catch {
-          // ignore
-        }
-      }
-      objectUrls.clear();
-      inMemoryNostrPictureCache.clear();
-    };
-  }, [currentNsec]);
-
-  const rememberBlobAvatarUrl = React.useCallback(
-    (npub: string, url: string | null): string | null => {
-      const key = String(npub ?? "").trim();
-      if (!key) return url;
-
-      const existing = avatarObjectUrlsByNpubRef.current.get(key);
-
-      if (url && url.startsWith("blob:")) {
-        if (existing && existing !== url) {
-          try {
-            URL.revokeObjectURL(existing);
-          } catch {
-            // ignore
-          }
-        }
-        avatarObjectUrlsByNpubRef.current.set(key, url);
-        return url;
-      }
-
-      if (existing && existing.startsWith("blob:")) {
-        try {
-          URL.revokeObjectURL(existing);
-        } catch {
-          // ignore
-        }
-      }
-
-      avatarObjectUrlsByNpubRef.current.delete(key);
-      return url;
-    },
-    [],
-  );
-
   const [cashuDraft, setCashuDraft] = useState("");
   const cashuDraftRef = React.useRef<HTMLTextAreaElement | null>(null);
   const [cashuEmitAmount, setCashuEmitAmount] = useState("");
@@ -995,42 +723,8 @@ export const useAppShellComposition = () => {
       JSON.stringify(toPendingTopupQuoteStorage(topupMintQuote)),
     );
   }, [appOwnerId, pendingTopupStorageKey, topupMintQuote]);
-
-  const [chatDraft, setChatDraft] = useState<string>("");
   const [pendingCashuTokenContactPickId, setPendingCashuTokenContactPickId] =
     useState<CashuTokenId | null>(null);
-  const [chatSendIsBusy, setChatSendIsBusy] = useState(false);
-  const [replyContext, setReplyContext] = useState<ReplyContext | null>(null);
-  const replyContextRef = React.useRef<ReplyContext | null>(null);
-  const [editContext, setEditContext] = useState<EditChatContext | null>(null);
-  const activeNostrMessagePublishClientIdsRef = React.useRef<Set<string>>(
-    new Set(),
-  );
-  const chatSeenWrapIdsRef = React.useRef<Set<string>>(new Set());
-  const autoAcceptedChatMessageIdsRef = React.useRef<Set<string>>(new Set());
-  const activeChatRouteId = route.kind === "chat" ? String(route.id ?? "") : "";
-
-  React.useEffect(() => {
-    if (route.kind === "chat") return;
-    setReplyContext(null);
-    setEditContext(null);
-  }, [route.kind]);
-
-  React.useEffect(() => {
-    if (!activeChatRouteId) return;
-    setReplyContext(null);
-    setEditContext(null);
-  }, [activeChatRouteId]);
-
-  React.useEffect(() => {
-    replyContextRef.current = replyContext;
-  }, [replyContext]);
-
-  React.useEffect(() => {
-    for (const [npub, url] of Object.entries(nostrPictureByNpub)) {
-      inMemoryNostrPictureCache.set(npub, url ?? null);
-    }
-  }, [nostrPictureByNpub]);
 
   const [
     pendingLightningInvoiceConfirmation,
@@ -1062,173 +756,8 @@ export const useAppShellComposition = () => {
   );
   const [lnurlWithdrawIsBusy, setLnurlWithdrawIsBusy] = useState(false);
 
-  const chatMessagesRef = React.useRef<HTMLDivElement | null>(null);
-  const chatMessageElByIdRef = React.useRef<Map<string, HTMLDivElement>>(
-    new Map(),
-  );
-  const [bankPaymentOfferMessages, setBankPaymentOfferMessages] = useState<
-    LocalNostrMessage[]
-  >([]);
-  const bankPaymentOfferSpdPayloadByOfferIdRef = React.useRef<
-    Map<string, string>
-  >(new Map());
-  const autoSentBankDetailsOfferIdsRef = React.useRef<Set<string>>(new Set());
-  const bankPaymentOfferExpiryInFlightRef = React.useRef(false);
-  const chatDidInitialScrollForContactRef = React.useRef<string | null>(null);
-  const chatForceScrollToBottomRef = React.useRef(false);
-  const chatScrollTargetIdRef = React.useRef<string | null>(null);
-  const chatLastMessageCountRef = React.useRef<Record<string, number>>({});
-
-  const triggerChatScrollToBottom = React.useCallback((messageId?: string) => {
-    chatForceScrollToBottomRef.current = true;
-    if (messageId) chatScrollTargetIdRef.current = messageId;
-
-    const tryScroll = (attempt: number) => {
-      const targetId = chatScrollTargetIdRef.current;
-      if (targetId) {
-        const el = chatMessageElByIdRef.current.get(targetId);
-        if (el) {
-          el.scrollIntoView({ block: "end" });
-          return;
-        }
-      }
-
-      const c = chatMessagesRef.current;
-      if (c) c.scrollTop = c.scrollHeight;
-
-      if (attempt < 6) {
-        requestAnimationFrame(() => tryScroll(attempt + 1));
-      }
-    };
-
-    requestAnimationFrame(() => tryScroll(0));
-  }, []);
-
-  const upsertBankPaymentOfferMessage = React.useCallback(
-    (message: LocalNostrMessage) => {
-      const messageContactId = String(message.contactId ?? "").trim();
-      const messageWrapId = String(message.wrapId ?? "").trim();
-      const messageClientId = String(message.clientId ?? "").trim();
-      const messageId = String(message.id ?? "").trim();
-      const messageOfferId =
-        getLinkyBankPaymentOfferInfo(String(message.content ?? ""))?.offerId ??
-        "";
-      const messageOfferKey =
-        messageOfferId && messageContactId
-          ? `${messageContactId}:${messageOfferId}`
-          : "";
-
-      setBankPaymentOfferMessages((prev) => {
-        const existingOfferMessage = messageOfferKey
-          ? (prev.find((existing) => {
-              const existingContactId = String(existing.contactId ?? "").trim();
-              const existingOfferId = getLinkyBankPaymentOfferInfo(
-                String(existing.content ?? ""),
-              )?.offerId;
-              return (
-                `${existingContactId}:${existingOfferId ?? ""}` ===
-                messageOfferKey
-              );
-            }) ?? null)
-          : null;
-        const next = prev.filter((existing) => {
-          const existingContactId = String(existing.contactId ?? "").trim();
-          const existingOfferId = getLinkyBankPaymentOfferInfo(
-            String(existing.content ?? ""),
-          )?.offerId;
-          if (
-            messageOfferKey &&
-            `${existingContactId}:${existingOfferId ?? ""}` === messageOfferKey
-          ) {
-            return false;
-          }
-
-          const existingWrapId = String(existing.wrapId ?? "").trim();
-          const existingClientId = String(existing.clientId ?? "").trim();
-          const existingId = String(existing.id ?? "").trim();
-
-          if (messageWrapId && existingWrapId === messageWrapId) return false;
-          if (messageClientId && existingClientId === messageClientId) {
-            return false;
-          }
-          if (messageId && existingId === messageId) return false;
-          return true;
-        });
-
-        const mergedMessage = existingOfferMessage
-          ? (() => {
-              const existingInfo = getLinkyBankPaymentOfferInfo(
-                String(existingOfferMessage.content ?? ""),
-              );
-              const messageInfo = getLinkyBankPaymentOfferInfo(
-                String(message.content ?? ""),
-              );
-              const existingCreatedAt =
-                Number(existingOfferMessage.createdAtSec ?? 0) || 0;
-              const messageCreatedAt = Number(message.createdAtSec ?? 0) || 0;
-              const existingUpdatedAt =
-                existingInfo?.statusUpdatedAtSec ?? existingCreatedAt;
-              const messageUpdatedAt =
-                messageInfo?.statusUpdatedAtSec ?? messageCreatedAt;
-              const latest =
-                messageUpdatedAt > existingUpdatedAt
-                  ? message
-                  : messageUpdatedAt < existingUpdatedAt
-                    ? existingOfferMessage
-                    : messageInfo && existingInfo
-                      ? getLinkyBankPaymentOfferStatusRank(
-                          messageInfo.status,
-                        ) >=
-                        getLinkyBankPaymentOfferStatusRank(existingInfo.status)
-                        ? message
-                        : existingOfferMessage
-                      : messageCreatedAt >= existingCreatedAt
-                        ? message
-                        : existingOfferMessage;
-
-              return {
-                ...existingOfferMessage,
-                ...latest,
-                contactId: existingOfferMessage.contactId,
-                createdAtSec:
-                  existingCreatedAt && messageCreatedAt
-                    ? Math.min(existingCreatedAt, messageCreatedAt)
-                    : existingCreatedAt || messageCreatedAt,
-                direction: existingOfferMessage.direction,
-                id: messageOfferKey
-                  ? `bank-payment-offer:${messageOfferKey}`
-                  : latest.id,
-              };
-            })()
-          : messageOfferKey
-            ? {
-                ...message,
-                id: `bank-payment-offer:${messageOfferKey}`,
-              }
-            : message;
-
-        next.push(mergedMessage);
-        next.sort((a, b) => {
-          const createdA = Number(a.createdAtSec ?? 0);
-          const createdB = Number(b.createdAtSec ?? 0);
-          return createdA - createdB;
-        });
-        return next;
-      });
-    },
-    [],
-  );
-
   const npubCashClaimInFlightRef = React.useRef(false);
   const npubCashMintSyncRef = React.useRef<string | null>(null);
-
-  const nostrInFlight = React.useRef<Set<string>>(new Set());
-  const nostrMetadataInFlight = React.useRef<Set<string>>(new Set());
-  const nostrStatusInFlight = React.useRef<Set<string>>(new Set());
-  const pendingUnknownContactAddRef = React.useRef<{
-    sourceContactId: string;
-    targetNpub: string;
-  } | null>(null);
 
   const {
     paidOverlayIsOpen,
@@ -1484,14 +1013,6 @@ export const useAppShellComposition = () => {
     transactionsVisibleOwnerIds,
   ]);
 
-  const visibleMessageOwnerIds = React.useMemo(() => {
-    const ids = [
-      String(appOwnerId ?? "").trim(),
-      ...messagesVisibleOwnerIds.map((ownerId) => String(ownerId ?? "").trim()),
-    ].filter(Boolean);
-    return Array.from(new Set(ids));
-  }, [appOwnerId, messagesVisibleOwnerIds]);
-
   useStoragePersistRequestEffect({ refreshKey: t });
 
   const maybeShowPwaNotification = React.useCallback(
@@ -1504,16 +1025,6 @@ export const useAppShellComposition = () => {
       });
     },
     [t],
-  );
-
-  const contactNameCollator = useMemo(
-    () =>
-      new Intl.Collator(lang, {
-        usage: "sort",
-        numeric: true,
-        sensitivity: "variant",
-      }),
-    [lang],
   );
 
   const contactPayBackToChatRef = React.useRef<ContactId | null>(null);
@@ -1542,6 +1053,206 @@ export const useAppShellComposition = () => {
     }
   }, [currentNpub]);
 
+  useStatusToasts({
+    pushToast,
+    setStatus,
+    status,
+  });
+
+  const cashuTokensAllQuery = useMemo(
+    () =>
+      evolu.createQuery((db) =>
+        db.selectFrom("cashuToken").selectAll().orderBy("createdAt", "desc"),
+      ),
+    [],
+  );
+  const cashuTokensAll = useQuery(cashuTokensAllQuery);
+
+  const copyText = React.useCallback(
+    async (value: string) => {
+      try {
+        const copied = await writeClipboardText(value);
+        if (!copied) {
+          pushToast(t("copyFailed"));
+          return;
+        }
+        pushToast(t("copiedToClipboard"));
+      } catch {
+        pushToast(t("copyFailed"));
+      }
+    },
+    [pushToast, t],
+  );
+
+  const {
+    activeContactsOwnerContactCount,
+    activeGroup,
+    activeNostrMessagePublishClientIdsRef,
+    addNewContactFromIdentifier,
+    addNewContactFromSearchResult,
+    addUnknownContactFromChat,
+    appendLocalNostrMessage,
+    autoAcceptedChatMessageIdsRef,
+    bankPaymentOfferContacts,
+    bankPaymentOfferMessages,
+    bankPaymentOfferRecipientCount,
+    blockArchivedContact,
+    blockUnknownContactFromChat,
+    buildSavedContactName,
+    canAddContact,
+    canSaveNewRelay,
+    chatDidInitialScrollForContactRef,
+    chatDraft,
+    chatForceScrollToBottomRef,
+    chatLastMessageCountRef,
+    chatMessageElByIdRef,
+    chatMessages,
+    chatMessagesRef,
+    chatMessagesWithBankPaymentOffers,
+    chatOwnPubkeyHex,
+    chatScrollTargetIdRef,
+    chatSeenWrapIdsRef,
+    chatSendIsBusy,
+    closeContactDetail,
+    connectedRelayCount,
+    contactAttentionById,
+    contactEditsSavable,
+    contactFilterOptions,
+    contactSuggestions,
+    contacts,
+    contactsLatestRef,
+    contactsOnboardingHasBackedUpKeys,
+    contactsOnboardingHasPaid,
+    contactsOnboardingHasSentMessage,
+    contactsSearch,
+    contactsSearchInputRef,
+    dedupeContacts,
+    dedupeContactsIsBusy,
+    displayContactById,
+    displayContacts,
+    editContext,
+    editingId,
+    enqueuePendingPayment,
+    form,
+    getNpubMessageContactInfo,
+    groupNames,
+    handleSaveContact,
+    isBankPaymentOfferCanceled,
+    isSavingContact,
+    knownNostrMessageIdentityIndex,
+    lastMessageByContactId,
+    mentionContacts,
+    newRelayUrl,
+    nostrBootstrapReady,
+    nostrFetchRelays,
+    nostrMessageWrapIdsRef,
+    nostrMessagesLatestRef,
+    nostrMessagesLocal,
+    nostrMessagesRecent,
+    nostrPictureByNpub,
+    nostrRelayOverallStatus,
+    nostrStatusByNpub,
+    onCancelEdit,
+    onCancelReply,
+    onCopyChatMessage,
+    onDeclineChatPaymentRequest,
+    onEditChatMessage,
+    onReactToChatMessage,
+    onReplyToChatMessage,
+    openContactDetail,
+    openContactPay,
+    openFeedbackContact,
+    openNewContactPage,
+    openNpubMessageContact,
+    openScannedContactPendingNpubRef,
+    pendingDeleteId,
+    pendingPayments,
+    pendingRelayDeleteUrl,
+    publishSingleWrappedWithRetry,
+    publishWrappedWithRetry,
+    reactionsByMessageId,
+    refreshContactFromNostr,
+    relayStatusByUrl,
+    relayUrls,
+    rememberBlobAvatarUrl,
+    removePendingPayment,
+    replyContext,
+    requestBankPaymentOffer,
+    requestDeleteCurrentContact,
+    requestDeleteSelectedRelay,
+    resetEditedContactFieldFromNostr,
+    respondToBankPaymentOfferWithGroupState,
+    restoreArchivedContact,
+    saveNewRelay,
+    searchNewContact,
+    selectedChatContact,
+    selectedContact,
+    selectedRelayUrl,
+    sendChatImage,
+    sendChatMessage,
+    sendChatOrEditMessage,
+    setActiveGroup,
+    setBankPaymentOfferRecipientCount,
+    setChatDraft,
+    setContactNewPrefill,
+    setContactsOnboardingHasBackedUpKeys,
+    setContactsOnboardingHasPaid,
+    setContactsSearch,
+    setForm,
+    setNewRelayUrl,
+    setPendingDeleteId,
+    statusFilterCurrencies,
+    triggerChatScrollToBottom,
+    ungroupedCount,
+    unknownNameByNpub,
+    updateLocalNostrMessage,
+    upsertBankPaymentOfferMessage,
+    visibleContacts,
+  } = useContactsMessagingComposition({
+    activeSyncedNostrIdentity,
+    appOwnerId,
+    appOwnerIdRef,
+    cashuOwnerId,
+    cashuTokensAll,
+    contactPayBackToChatRef,
+    contactsOwnerId,
+    contactsOwnerNewContactsCount,
+    contactsVisibleOwnerIds,
+    copyText,
+    currentNpub,
+    currentNsec,
+    formatDisplayedAmountText,
+    historicalOwnerSetsReady,
+    identityOwnerId,
+    insert,
+    isSeedLogin,
+    lang,
+    legacyIdentitiesOwnerId,
+    legacyMessagesIdentityOwnerId,
+    logPayStep,
+    maybeShowPwaNotification,
+    messagesOwnerId,
+    messagesOwnerIdRef,
+    messagesVisibleOwnerIds,
+    metaOwnerId,
+    nostrIdentityRows,
+    pushToast,
+    recordContactsOwnerWrite,
+    recordMessagesOwnerWrite,
+    recordTransactionsOwnerWrite,
+    route,
+    setContactPaymentIntent,
+    setPayAmount,
+    setStatus,
+    syncedNostrIdentityMatchesLocal,
+    syncedNostrIdentityResolution,
+    t,
+    transactionsBootstrapSnapshot,
+    transactionsOwnerId,
+    update,
+    upsert,
+  });
+
   useArmedDeleteTimeouts({
     pendingCashuDeleteId,
     pendingDeleteId,
@@ -1552,88 +1263,6 @@ export const useAppShellComposition = () => {
     setPendingEvoluServerDeleteUrl,
     setPendingMintDeleteUrl,
   });
-
-  useStatusToasts({
-    pushToast,
-    setStatus,
-    status,
-  });
-
-  const reassignContactMessagesRef = React.useRef<
-    (fromContactId: string, toContactId: string) => number
-  >(() => 0);
-  const reassignContactMessages = React.useCallback(
-    (fromContactId: string, toContactId: string) =>
-      reassignContactMessagesRef.current(fromContactId, toContactId),
-    [],
-  );
-
-  const {
-    activeGroup,
-    contacts,
-    contactsSearch,
-    contactsSearchInputRef,
-    contactsSearchParts,
-    dedupeContacts,
-    dedupeContactsIsBusy,
-    groupCounts,
-    groupNames,
-    selectedContact,
-    setActiveGroup,
-    setContactsSearch,
-    ungroupedCount,
-  } = useContactsDomain({
-    appOwnerId: contactsOwnerId,
-    currentNsec,
-    isSeedLogin,
-    noGroupFilterValue: NO_GROUP_FILTER,
-    pushToast,
-    reassignContactMessages,
-    route,
-    t,
-    update,
-    upsert,
-    visibleOwnerIds: contactsVisibleOwnerIds,
-  });
-
-  const contactsLatestRef = React.useRef(contacts);
-  contactsLatestRef.current = contacts;
-
-  React.useEffect(() => {
-    const records = [];
-
-    for (const contact of contacts) {
-      const name = String(contact.name ?? "").trim();
-      const npub = normalizeNpubIdentifier(contact.npub);
-      if (!name || !npub) continue;
-
-      try {
-        const decoded = nip19.decode(npub);
-        if (decoded.type !== "npub" || typeof decoded.data !== "string") {
-          continue;
-        }
-
-        const pubkey = decoded.data.trim();
-        if (!pubkey) continue;
-        records.push({ name, npub, pubkey });
-      } catch {
-        // ignore invalid contact npubs
-      }
-    }
-
-    void setStoredPushContactNames(records);
-  }, [contacts]);
-
-  const activeContactsOwnerContactCount = contactsOwnerNewContactsCount;
-
-  const cashuTokensAllQuery = useMemo(
-    () =>
-      evolu.createQuery((db) =>
-        db.selectFrom("cashuToken").selectAll().orderBy("createdAt", "desc"),
-      ),
-    [],
-  );
-  const cashuTokensAll = useQuery(cashuTokensAllQuery);
 
   const activeCashuOwnerId = String(cashuOwnerId ?? "").trim();
   const visibleCashuOwnerIds = React.useMemo(
@@ -2210,148 +1839,6 @@ export const useAppShellComposition = () => {
     });
   }, [cashuTokensAllFiltered, cashuTokensFiltered, currentNpub, currentNsec]);
 
-  const {
-    appendLocalNostrMessage,
-    appendLocalNostrReaction,
-    chatMessages,
-    chatMessagesLatestRef,
-    enqueuePendingPayment,
-    knownNostrMessageIdentityIndex,
-    lastMessageByContactId,
-    nostrMessageWrapIdsRef,
-    nostrMessagesLatestRef,
-    nostrMessagesLocal,
-    nostrMessagesRecent,
-    nostrReactionWrapIdsRef,
-    nostrReactionsLatestRef,
-    nostrReactionsLocal,
-    pendingPayments,
-    reactionsByMessageId,
-    reassignLocalNostrMessagesContactId,
-    removeLocalNostrMessagesByContactId,
-    removePendingPayment,
-    softDeleteLocalNostrReaction,
-    softDeleteLocalNostrReactionsByWrapIds,
-    updateLocalNostrMessage,
-    updateLocalNostrReaction,
-  } = useMessagesDomain({
-    appOwnerId,
-    appOwnerIdRef,
-    chatForceScrollToBottomRef,
-    chatMessagesRef,
-    messagesOwnerId,
-    messagesOwnerIdRef,
-    recordMessagesOwnerWrite,
-    route,
-    visibleMessageOwnerIds,
-  });
-  reassignContactMessagesRef.current = reassignLocalNostrMessagesContactId;
-  const pendingArchivedContactThreadIdsRef = React.useRef(
-    new Map<string, string>(),
-  );
-
-  const evoluOwnersReadyForNostr = isSeedLogin
-    ? Boolean(
-        cashuOwnerId &&
-        contactsOwnerId &&
-        identityOwnerId &&
-        legacyIdentitiesOwnerId &&
-        legacyMessagesIdentityOwnerId &&
-        messagesOwnerId &&
-        metaOwnerId &&
-        transactionsOwnerId,
-      ) && historicalOwnerSetsReady
-    : Boolean(appOwnerId);
-  const evoluNostrOwnerKey = React.useMemo(() => {
-    if (!currentNpub || !evoluOwnersReadyForNostr) return "";
-
-    return [
-      currentNpub,
-      appOwnerId,
-      cashuOwnerId,
-      contactsOwnerId,
-      identityOwnerId,
-      legacyIdentitiesOwnerId,
-      legacyMessagesIdentityOwnerId,
-      messagesOwnerId,
-      metaOwnerId,
-      transactionsOwnerId,
-    ]
-      .map((value) => String(value ?? "").trim())
-      .filter(Boolean)
-      .join("|");
-  }, [
-    appOwnerId,
-    cashuOwnerId,
-    contactsOwnerId,
-    currentNpub,
-    evoluOwnersReadyForNostr,
-    identityOwnerId,
-    legacyIdentitiesOwnerId,
-    legacyMessagesIdentityOwnerId,
-    messagesOwnerId,
-    metaOwnerId,
-    transactionsOwnerId,
-  ]);
-  const nostrIdentityBootstrapReady =
-    Boolean(activeSyncedNostrIdentity) &&
-    !syncedNostrIdentityResolution.shouldMigrateLegacyIdentity &&
-    syncedNostrIdentityMatchesLocal;
-  const [
-    missingSyncedIdentityFallbackKey,
-    setMissingSyncedIdentityFallbackKey,
-  ] = React.useState("");
-  React.useEffect(() => {
-    if (!isSeedLogin || !evoluNostrOwnerKey || activeSyncedNostrIdentity) {
-      setMissingSyncedIdentityFallbackKey("");
-      return;
-    }
-
-    const timeoutId = window.setTimeout(() => {
-      setMissingSyncedIdentityFallbackKey(evoluNostrOwnerKey);
-    }, 8_000);
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [activeSyncedNostrIdentity, evoluNostrOwnerKey, isSeedLogin]);
-  const identityBootstrapReady = isSeedLogin
-    ? nostrIdentityBootstrapReady ||
-      missingSyncedIdentityFallbackKey === evoluNostrOwnerKey
-    : true;
-  const nostrBootstrapReady = useEvoluNostrBootstrapReady({
-    contactsSnapshot: contacts,
-    enabled: Boolean(currentNsec),
-    identitiesSnapshot: nostrIdentityRows,
-    identityReady: identityBootstrapReady,
-    messagesSnapshot: nostrMessagesLocal,
-    ownerKey: evoluNostrOwnerKey,
-    reactionsSnapshot: nostrReactionsLocal,
-    tokensSnapshot: cashuTokensAll,
-    transactionsSnapshot: transactionsBootstrapSnapshot,
-  });
-
-  const {
-    canSaveNewRelay,
-    connectedRelayCount,
-    newRelayUrl,
-    nostrFetchRelays,
-    nostrRelayOverallStatus,
-    pendingRelayDeleteUrl,
-    relayStatusByUrl,
-    relayUrls,
-    requestDeleteSelectedRelay,
-    saveNewRelay,
-    selectedRelayUrl,
-    setNewRelayUrl,
-  } = useRelayDomain({
-    currentNpub,
-    currentNsec,
-    networkEnabled: nostrBootstrapReady,
-    route,
-    setStatus,
-    t,
-  });
-
   React.useEffect(() => {
     appendIdentityChangeNoticesRef.current = ({
       changedAtSec,
@@ -2609,12 +2096,6 @@ export const useAppShellComposition = () => {
     topupPaidNavTimerRef,
     topupInvoiceQr,
   ]);
-
-  const [contactNewPrefill, setContactNewPrefill] = React.useState<null | {
-    lnAddress: string;
-    npub: string | null;
-    suggestedName: string | null;
-  }>(null);
   const [pendingDeepLinkText, setPendingDeepLinkText] = React.useState<
     string | null
   >(() => {
@@ -2952,51 +2433,6 @@ export const useAppShellComposition = () => {
     setMyProfileQr,
   });
 
-  // Intentionally no automatic publishing of kind-0 profile metadata.
-  // We only publish profile changes when the user does so explicitly.
-
-  useContactsNostrPrefetchEffects({
-    appOwnerId: contactsOwnerId,
-    canFetchFromNostr: nostrBootstrapReady,
-    contacts,
-    nostrFetchRelays,
-    nostrInFlight,
-    nostrMetadataInFlight,
-    nostrStatusByNpub,
-    nostrStatusInFlight,
-    rememberBlobAvatarUrl,
-    routeKind: route.kind,
-    setNostrPictureByNpub,
-    setNostrStatusByNpub,
-    update,
-    visibleOwnerIds: contactsVisibleOwnerIds,
-  });
-
-  const [unknownNameByNpub, setUnknownNameByNpub] = useState<
-    Record<string, string | null>
-  >({});
-
-  const buildUnknownDisplayName = React.useCallback(
-    (name: string | null, npub: string | null) => {
-      const prefix = t("unknownContactNamePrefix");
-      const normalizedName = String(name ?? "").trim();
-      const fallback = npub ? formatShortNpub(npub) : t("unknownContactTitle");
-      return `${prefix} ${normalizedName || fallback}`.trim();
-    },
-    [t],
-  );
-
-  const buildSavedContactName = React.useCallback(
-    (name: string | null, npub: string | null) => {
-      const normalizedName = String(name ?? "").trim();
-      return (
-        normalizedName ||
-        (npub ? formatShortNpub(npub) : t("unknownContactTitle"))
-      );
-    },
-    [t],
-  );
-
   const { isMainSwipeRoute } = useMainSwipePageEffects({
     contactsHeaderVisible,
     contactsPullDistanceRef,
@@ -3012,707 +2448,6 @@ export const useAppShellComposition = () => {
     mainSwipeScrollTimerRef,
     routeKind: route.kind,
   });
-
-  const unknownContacts = React.useMemo<UnknownChatContact[]>(() => {
-    const blockedPubkeys = new Set(
-      safeLocalStorageGetJson(BLOCKED_NOSTR_PUBKEYS_STORAGE_KEY, [])
-        .map((entry) => normalizePubkeyHex(entry))
-        .filter((entry): entry is string => Boolean(entry)),
-    );
-
-    const unknownById = new Map<string, UnknownChatContact>();
-
-    for (const [contactId, lastMessage] of lastMessageByContactId.entries()) {
-      const normalizedContactId = String(contactId ?? "").trim();
-      if (!normalizedContactId) continue;
-      if (!isUnknownContactId(normalizedContactId)) continue;
-
-      const candidatePubkeyFromLast = normalizePubkeyHex(lastMessage.pubkey);
-      const candidatePubkeyFromId =
-        readUnknownContactIdPubkey(normalizedContactId);
-      const candidatePubkeyFromThread = nostrMessagesLocal
-        .filter(
-          (message) =>
-            String(message.contactId ?? "").trim() === normalizedContactId,
-        )
-        .map((message) => normalizePubkeyHex(message.pubkey))
-        .find((pubkey) => {
-          if (!pubkey) return false;
-          if (blockedPubkeys.has(pubkey)) return false;
-          const ownPubkey = normalizePubkeyHex(chatOwnPubkeyHex);
-          if (ownPubkey && ownPubkey === pubkey) return false;
-          return true;
-        });
-
-      const unknownPubkeyHex =
-        candidatePubkeyFromId ??
-        candidatePubkeyFromThread ??
-        candidatePubkeyFromLast ??
-        null;
-      if (unknownPubkeyHex && blockedPubkeys.has(unknownPubkeyHex)) continue;
-      const ownPubkey = normalizePubkeyHex(chatOwnPubkeyHex);
-      if (unknownPubkeyHex && ownPubkey && unknownPubkeyHex === ownPubkey) {
-        continue;
-      }
-
-      const unknownNpub = encodeUnknownNpub(unknownPubkeyHex);
-      const bestName = unknownNpub
-        ? (unknownNameByNpub[unknownNpub] ?? null)
-        : null;
-
-      unknownById.set(normalizedContactId, {
-        id: normalizedContactId,
-        name: buildUnknownDisplayName(bestName, unknownNpub),
-        npub: unknownNpub,
-        lnAddress: null,
-        groupName: null,
-        isUnknownContact: true,
-        unknownPubkeyHex,
-      });
-    }
-
-    return Array.from(unknownById.values());
-  }, [
-    buildUnknownDisplayName,
-    chatOwnPubkeyHex,
-    lastMessageByContactId,
-    nostrMessagesLocal,
-    unknownNameByNpub,
-  ]);
-
-  React.useEffect(() => {
-    const activeContacts = contacts.filter((contact) => {
-      const archivedAtSec = Number(contact.archivedAtSec ?? 0);
-      return !Number.isFinite(archivedAtSec) || archivedAtSec <= 0;
-    });
-
-    for (const unknownContact of unknownContacts) {
-      const unknownContactId = String(unknownContact.id ?? "").trim();
-      const unknownNpub = normalizeNpubIdentifier(unknownContact.npub);
-      if (!unknownContactId || !unknownNpub) continue;
-
-      let knownContact = activeContacts.find((contact) => {
-        const knownContactId = String(contact.id ?? "").trim();
-        if (!knownContactId || knownContactId === unknownContactId) {
-          return false;
-        }
-        return normalizeNpubIdentifier(contact.npub) === unknownNpub;
-      });
-
-      let matchedByLightningAddress = false;
-      let matchedMetadata: NostrProfileMetadata | null = null;
-      if (!knownContact) {
-        matchedMetadata =
-          loadCachedProfileMetadata(unknownNpub)?.metadata ?? null;
-        const profileLightningAddress = matchedMetadata
-          ? omitSyntheticContactLightningAddress(
-              String(matchedMetadata.lud16 ?? "").trim() ||
-                String(matchedMetadata.lud06 ?? "").trim(),
-              unknownNpub,
-            )
-          : "";
-        const lightningContact = findUniqueContactByLightningAddress(
-          activeContacts,
-          profileLightningAddress,
-        );
-        if (lightningContact) {
-          knownContact = lightningContact;
-          matchedByLightningAddress = true;
-        }
-      }
-
-      const knownContactId = String(knownContact?.id ?? "").trim();
-      if (!knownContactId) continue;
-
-      if (matchedByLightningAddress && knownContact) {
-        const bestName = matchedMetadata
-          ? getBestNostrName(matchedMetadata)
-          : null;
-        const parsedNpub = Evolu.NonEmptyString1000.fromUnknown(unknownNpub);
-        if (!parsedNpub.ok) continue;
-        const parsedName = bestName
-          ? Evolu.NonEmptyString1000.fromUnknown(bestName)
-          : null;
-        const ownerId =
-          resolveContactRowOwnerLane(knownContact, contactsVisibleOwnerIds) ??
-          contactsOwnerId;
-        const payload = {
-          id: knownContact.id,
-          npub: parsedNpub.value,
-          ...(!String(knownContact.name ?? "").trim() && parsedName?.ok
-            ? { name: parsedName.value }
-            : {}),
-        };
-        const result = ownerId
-          ? update("contact", payload, { ownerId })
-          : update("contact", payload);
-        if (!result.ok) continue;
-      }
-
-      reassignLocalNostrMessagesContactId(unknownContactId, knownContactId);
-      setContactAttentionById((prev) => {
-        if (prev[unknownContactId] === undefined) return prev;
-        const next = { ...prev };
-        delete next[unknownContactId];
-        return next;
-      });
-    }
-  }, [
-    contacts,
-    contactsOwnerId,
-    contactsVisibleOwnerIds,
-    reassignLocalNostrMessagesContactId,
-    setContactAttentionById,
-    unknownContacts,
-    update,
-  ]);
-
-  const unknownContactNpubs = React.useMemo(() => {
-    const seen = new Set<string>();
-    const npubs: string[] = [];
-
-    for (const contact of unknownContacts) {
-      const npub = normalizeNpubIdentifier(contact.npub);
-      if (!npub) continue;
-      if (seen.has(npub)) continue;
-      seen.add(npub);
-      npubs.push(npub);
-    }
-
-    return npubs;
-  }, [unknownContacts]);
-
-  const chatMentionedNpubs = React.useMemo(() => {
-    const seen = new Set<string>();
-    const npubs: string[] = [];
-
-    for (const message of chatMessages) {
-      for (const npub of extractMentionedNpubs(String(message.content ?? ""))) {
-        if (seen.has(npub)) continue;
-        seen.add(npub);
-        npubs.push(npub);
-      }
-    }
-
-    return npubs;
-  }, [chatMessages]);
-
-  const prefetchedMessageNpubs = React.useMemo(() => {
-    const seen = new Set<string>();
-    const npubs: string[] = [];
-
-    for (const npub of unknownContactNpubs) {
-      if (seen.has(npub)) continue;
-      seen.add(npub);
-      npubs.push(npub);
-    }
-
-    for (const npub of chatMentionedNpubs) {
-      if (seen.has(npub)) continue;
-      seen.add(npub);
-      npubs.push(npub);
-    }
-
-    return npubs;
-  }, [chatMentionedNpubs, unknownContactNpubs]);
-
-  React.useEffect(() => {
-    const controller = new AbortController();
-    let cancelled = false;
-
-    const run = async () => {
-      for (const npub of prefetchedMessageNpubs) {
-        if (unknownNameByNpub[npub] !== undefined) continue;
-
-        const cached = loadCachedProfileMetadata(npub);
-        if (cached) {
-          const cachedName = cached.metadata
-            ? getBestNostrName(cached.metadata)
-            : null;
-          if (!cancelled) {
-            setUnknownNameByNpub((prev) =>
-              prev[npub] !== undefined ? prev : { ...prev, [npub]: cachedName },
-            );
-          }
-          continue;
-        }
-
-        if (!nostrBootstrapReady) continue;
-
-        if (nostrMetadataInFlight.current.has(npub)) continue;
-        nostrMetadataInFlight.current.add(npub);
-
-        try {
-          const metadata = await fetchNostrProfileMetadata(npub, {
-            signal: controller.signal,
-            relays: nostrFetchRelays,
-          });
-          saveCachedProfileMetadata(npub, metadata);
-          if (cancelled) return;
-          setUnknownNameByNpub((prev) => ({
-            ...prev,
-            [npub]: metadata ? getBestNostrName(metadata) : null,
-          }));
-        } catch {
-          saveCachedProfileMetadata(npub, null);
-          if (cancelled) return;
-          setUnknownNameByNpub((prev) => ({
-            ...prev,
-            [npub]: null,
-          }));
-        } finally {
-          nostrMetadataInFlight.current.delete(npub);
-        }
-      }
-    };
-
-    void run();
-
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, [
-    nostrBootstrapReady,
-    nostrFetchRelays,
-    nostrMetadataInFlight,
-    prefetchedMessageNpubs,
-    unknownNameByNpub,
-  ]);
-
-  React.useEffect(() => {
-    const controller = new AbortController();
-    let cancelled = false;
-
-    const run = async () => {
-      for (const npub of prefetchedMessageNpubs) {
-        const cached = loadCachedProfilePicture(npub);
-        const shouldRefreshCachedPicture = isCachedProfilePictureStale(cached);
-
-        if (cached) {
-          setNostrPictureByNpub((prev) =>
-            prev[npub] === cached.url ? prev : { ...prev, [npub]: cached.url },
-          );
-        }
-
-        try {
-          const blobUrl = await loadCachedProfileAvatarObjectUrl(npub);
-          if (cancelled) return;
-          if (blobUrl) {
-            setNostrPictureByNpub((prev) => ({
-              ...prev,
-              [npub]: rememberBlobAvatarUrl(npub, blobUrl),
-            }));
-            if (!shouldRefreshCachedPicture) continue;
-          }
-        } catch {
-          // ignore
-        }
-
-        if (cached && !shouldRefreshCachedPicture) continue;
-
-        if (!nostrBootstrapReady) continue;
-
-        if (nostrInFlight.current.has(npub)) continue;
-        nostrInFlight.current.add(npub);
-
-        try {
-          if (cached && shouldRefreshCachedPicture) {
-            const metadata = await fetchNostrProfileMetadata(npub, {
-              signal: controller.signal,
-              relays: nostrFetchRelays,
-            });
-            if (cancelled) return;
-            if (!metadata) continue;
-
-            saveCachedProfileMetadata(npub, metadata);
-            const refreshedUrl = getNostrProfilePictureUrl(metadata);
-            if (refreshedUrl) {
-              saveCachedProfilePicture(npub, refreshedUrl);
-              const blobUrl = await cacheProfileAvatarFromUrl(
-                npub,
-                refreshedUrl,
-                {
-                  signal: controller.signal,
-                },
-              );
-              if (cancelled) return;
-              setNostrPictureByNpub((prev) => ({
-                ...prev,
-                [npub]: rememberBlobAvatarUrl(npub, blobUrl || refreshedUrl),
-              }));
-            } else {
-              saveCachedProfilePicture(npub, null);
-              void deleteCachedProfileAvatar(npub);
-              rememberBlobAvatarUrl(npub, null);
-              setNostrPictureByNpub((prev) => ({
-                ...prev,
-                [npub]: null,
-              }));
-            }
-          } else {
-            const url = await fetchNostrProfilePicture(npub, {
-              signal: controller.signal,
-              relays: nostrFetchRelays,
-            });
-            saveCachedProfilePicture(npub, url);
-            if (cancelled) return;
-
-            if (url) {
-              const blobUrl = await cacheProfileAvatarFromUrl(npub, url, {
-                signal: controller.signal,
-              });
-              if (cancelled) return;
-              setNostrPictureByNpub((prev) => ({
-                ...prev,
-                [npub]: rememberBlobAvatarUrl(npub, blobUrl || url),
-              }));
-            } else {
-              setNostrPictureByNpub((prev) => {
-                const existing = prev[npub];
-                if (typeof existing === "string" && existing.trim())
-                  return prev;
-                if (existing === null) return prev;
-                return { ...prev, [npub]: null };
-              });
-            }
-          }
-        } catch {
-          if (cancelled) return;
-          if (!cached) {
-            saveCachedProfilePicture(npub, null);
-            setNostrPictureByNpub((prev) => {
-              const existing = prev[npub];
-              if (typeof existing === "string" && existing.trim()) return prev;
-              if (existing === null) return prev;
-              return { ...prev, [npub]: null };
-            });
-          }
-        } finally {
-          nostrInFlight.current.delete(npub);
-        }
-      }
-    };
-
-    void run();
-
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, [
-    nostrBootstrapReady,
-    nostrFetchRelays,
-    nostrInFlight,
-    prefetchedMessageNpubs,
-    rememberBlobAvatarUrl,
-    setNostrPictureByNpub,
-  ]);
-
-  const unknownContactById = React.useMemo(() => {
-    const byId = new Map<string, UnknownChatContact>();
-    for (const contact of unknownContacts) {
-      const id = String(contact.id ?? "").trim();
-      if (!id) continue;
-      byId.set(id, contact);
-    }
-    return byId;
-  }, [unknownContacts]);
-
-  const selectedChatContact = React.useMemo<ChatSelectedContact | null>(() => {
-    if (route.kind !== "chat" && route.kind !== "bankPaymentOffer") return null;
-
-    const chatId = String(
-      route.kind === "chat" ? route.id : route.chatId,
-    ).trim();
-    if (!chatId) return null;
-
-    const source = selectedContact ?? unknownContactById.get(chatId) ?? null;
-    if (!source) return null;
-
-    const normalizedId = String(source.id ?? "").trim();
-    if (!normalizedId) return null;
-
-    const normalizedNpub = normalizeNpubIdentifier(source.npub);
-    const normalizedUnknownPubkeyHex = normalizePubkeyHex(
-      readObjectField(source, "unknownPubkeyHex"),
-    );
-    const sourceGroupName = String(source.groupName ?? "").trim();
-    const isUnknownContact =
-      readObjectField(source, "isUnknownContact") === true;
-
-    return {
-      id: normalizedId,
-      ...(sourceGroupName ? { groupName: sourceGroupName } : {}),
-      ...(source.name !== undefined
-        ? { name: String(source.name ?? "").trim() || null }
-        : {}),
-      ...(source.lnAddress !== undefined
-        ? { lnAddress: String(source.lnAddress ?? "").trim() || null }
-        : {}),
-      ...(normalizedNpub ? { npub: normalizedNpub } : {}),
-      ...(normalizedUnknownPubkeyHex
-        ? { unknownPubkeyHex: normalizedUnknownPubkeyHex }
-        : {}),
-      ...(isUnknownContact ? { isUnknownContact: true } : {}),
-    };
-  }, [route, selectedContact, unknownContactById]);
-
-  const displayContacts = React.useMemo<DisplayContact[]>(() => {
-    return [...contacts, ...unknownContacts];
-  }, [contacts, unknownContacts]);
-
-  const displayContactById = React.useMemo(() => {
-    const byId = new Map<string, DisplayContact>();
-    for (const contact of displayContacts) {
-      const id = String(contact.id ?? "").trim();
-      if (!id) continue;
-      byId.set(id, contact);
-    }
-    return byId;
-  }, [displayContacts]);
-
-  const displayContactsSearchData = React.useMemo(() => {
-    return displayContacts.map((contact) => {
-      const idKey = String(contact.id ?? "").trim();
-      const groupName = String(contact.groupName ?? "").trim();
-      const normalizedNpub = normalizeNpubIdentifier(contact.npub);
-      const statusFilterValues = normalizedNpub
-        ? extractStatusFilterCurrencies(nostrStatusByNpub[normalizedNpub])
-        : [];
-      const haystack = [
-        contact.name,
-        contact.npub,
-        contact.lnAddress,
-        contact.groupName,
-        contact.unknownPubkeyHex,
-        ...statusFilterValues,
-      ]
-        .map((value) =>
-          String(value ?? "")
-            .trim()
-            .toLowerCase(),
-        )
-        .filter(Boolean)
-        .join(" ");
-
-      return {
-        contact,
-        idKey,
-        groupName,
-        haystack,
-        statusFilterValues,
-      };
-    });
-  }, [displayContacts, nostrStatusByNpub]);
-
-  const { statusFilterCounts, statusFilterCurrencies } = React.useMemo(() => {
-    const currencyCounts = new Map<string, number>();
-
-    for (const contact of displayContacts) {
-      const normalizedNpub = normalizeNpubIdentifier(contact.npub);
-      if (!normalizedNpub) continue;
-
-      for (const currency of extractStatusFilterCurrencies(
-        nostrStatusByNpub[normalizedNpub],
-      )) {
-        currencyCounts.set(currency, (currencyCounts.get(currency) ?? 0) + 1);
-      }
-    }
-
-    const currencies = [...currencyCounts.entries()]
-      .sort((left, right) => {
-        if (right[1] !== left[1]) return right[1] - left[1];
-        return left[0].localeCompare(right[0]);
-      })
-      .map(([currency]) => currency);
-    return {
-      statusFilterCounts: currencyCounts,
-      statusFilterCurrencies: currencies,
-    };
-  }, [displayContacts, nostrStatusByNpub]);
-
-  const contactFilterOptions = React.useMemo(() => {
-    const options: Array<{ count: number; label: string; value: string }> = [];
-    if (ungroupedCount > 0) {
-      options.push({
-        count: ungroupedCount,
-        label: t("noGroup"),
-        value: NO_GROUP_FILTER,
-      });
-    }
-    const archivedCount = displayContacts.filter(
-      (contact) => Number(contact.archivedAtSec ?? 0) > 0,
-    ).length;
-    options.push({
-      count: archivedCount,
-      label: t("archiveFilter"),
-      value: ARCHIVED_CONTACTS_FILTER,
-    });
-    for (const groupName of groupNames) {
-      options.push({
-        count: groupCounts.get(groupName) ?? 0,
-        label: groupName,
-        value: groupName,
-      });
-    }
-    for (const currency of statusFilterCurrencies) {
-      options.push({
-        count: statusFilterCounts.get(currency) ?? 0,
-        label: currency,
-        value: buildStatusFilterValue(currency),
-      });
-    }
-    return options.sort((left, right) => {
-      if (right.count !== left.count) return right.count - left.count;
-      return left.label.localeCompare(right.label);
-    });
-  }, [
-    displayContacts,
-    groupCounts,
-    groupNames,
-    statusFilterCounts,
-    statusFilterCurrencies,
-    t,
-    ungroupedCount,
-  ]);
-
-  React.useEffect(() => {
-    if (activeGroup === ARCHIVED_CONTACTS_FILTER) return;
-    if (!isStatusFilterValue(activeGroup)) return;
-
-    const selectedCurrency = parseStatusFilterValue(activeGroup);
-    if (!selectedCurrency) {
-      setActiveGroup(null);
-      return;
-    }
-
-    if (!statusFilterCurrencies.includes(selectedCurrency)) {
-      setActiveGroup(null);
-    }
-  }, [activeGroup, setActiveGroup, statusFilterCurrencies]);
-
-  const visibleContacts = useVisibleContacts<DisplayContact>({
-    activeGroup,
-    contactAttentionById,
-    contactNameCollator,
-    contactsSearchData: displayContactsSearchData,
-    contactsSearchParts,
-    lastMessageByContactId,
-    noGroupFilterValue: NO_GROUP_FILTER,
-    pinnedContactId: recentlyAddedContactId,
-  });
-  const bankPaymentOfferContacts = React.useMemo(() => {
-    const sortedContacts = [
-      ...visibleContacts.pinned,
-      ...visibleContacts.conversations,
-      ...visibleContacts.others,
-    ];
-    return sortedContacts.flatMap((contact) => {
-      const normalizedNpub = normalizeNpubIdentifier(contact.npub);
-      if (!normalizedNpub) return [];
-      if (
-        !extractStatusFilterCurrencies(
-          nostrStatusByNpub[normalizedNpub],
-        ).includes(LINKY_BANK_PAYMENT_OFFER_RECIPIENT_STATUS_CURRENCY)
-      ) {
-        return [];
-      }
-
-      return [
-        {
-          ...contact,
-          pictureUrl: nostrPictureByNpub[normalizedNpub] ?? null,
-        },
-      ];
-    });
-  }, [
-    nostrPictureByNpub,
-    nostrStatusByNpub,
-    visibleContacts.pinned,
-    visibleContacts.conversations,
-    visibleContacts.others,
-  ]);
-
-  const {
-    addNewContactFromIdentifier,
-    addNewContactFromSearchResult,
-    clearContactForm,
-    contactEditsSavable,
-    contactSuggestions,
-    editingId,
-    form,
-    handleSaveContact,
-    isSavingContact,
-    openScannedContactPendingNpubRef,
-    refreshContactFromNostr,
-    resetEditedContactFieldFromNostr,
-    searchNewContact,
-    setForm,
-  } = useContactEditor({
-    activeOwnerContactsCount: activeContactsOwnerContactCount,
-    appOwnerId: contactsOwnerId,
-    contactNewPrefill,
-    contacts,
-    currentNpub,
-    insert,
-    nostrFetchRelays,
-    recordTransactionsOwnerWrite,
-    route,
-    selectedContact,
-    setContactNewPrefill,
-    setPendingDeleteId,
-    setRecentlyAddedContactId,
-    recordContactsOwnerWrite,
-    setStatus,
-    t,
-    transactionsOwnerId,
-    update,
-    upsert,
-  });
-
-  const closeContactDetail = React.useCallback(() => {
-    clearContactForm();
-    setPendingDeleteId(null);
-    navigateTo({ route: "contacts" });
-  }, [clearContactForm]);
-
-  const openNewContactPage = React.useCallback(() => {
-    if (activeContactsOwnerContactCount >= MAX_CONTACTS_PER_OWNER) {
-      const message = t("contactsLimitReached").replace(
-        "{max}",
-        String(MAX_CONTACTS_PER_OWNER),
-      );
-      pushToast(message);
-      return;
-    }
-
-    setPendingDeleteId(null);
-    setPayAmount("");
-    clearContactForm();
-    const prefill = contactNewPrefill;
-    setContactNewPrefill(null);
-    if (prefill) {
-      setForm({
-        name: String(prefill.suggestedName ?? ""),
-        npub: String(prefill.npub ?? ""),
-        lnAddress: String(prefill.lnAddress ?? ""),
-        group: "",
-      });
-    }
-    navigateTo({ route: "contactNew" });
-  }, [
-    activeContactsOwnerContactCount,
-    clearContactForm,
-    contactNewPrefill,
-    pushToast,
-    setContactNewPrefill,
-    setForm,
-    t,
-  ]);
-
-  const canAddContact =
-    activeContactsOwnerContactCount < MAX_CONTACTS_PER_OWNER;
 
   const clearPendingDeleteOnMenuChange = React.useCallback(() => {
     setPendingDeleteId(null);
@@ -3748,671 +2483,6 @@ export const useAppShellComposition = () => {
     },
     [],
   );
-
-  const publishWrappedWithRetry = React.useCallback(
-    async (
-      pool: AppNostrPool,
-      relays: string[],
-      wrapForMe: NostrToolsEvent,
-      wrapForContact: NostrToolsEvent,
-    ): Promise<PublishWrappedResult> => {
-      return await publishWrappedWithRetryBase({
-        pool,
-        relays,
-        wrapForMe,
-        wrapForContact,
-      });
-    },
-    [],
-  );
-
-  const publishSingleWrappedWithRetry = React.useCallback(
-    async (
-      pool: AppNostrPool,
-      relays: string[],
-      event: NostrToolsEvent,
-    ): Promise<{ anySuccess: boolean; error: string | null }> => {
-      return await publishSingleWrappedWithRetryBase({
-        event,
-        pool,
-        relays,
-      });
-    },
-    [],
-  );
-
-  const requestBankPaymentOffer = React.useCallback(
-    async (args: {
-      amountSat?: unknown;
-      amountText: string;
-      contacts: readonly { id?: unknown; name?: unknown; npub?: unknown }[];
-      spdPayload?: unknown;
-    }): Promise<boolean> => {
-      const amountSatRaw = Number(args.amountSat ?? 0);
-      const amountSat =
-        Number.isFinite(amountSatRaw) && amountSatRaw > 0
-          ? Math.round(amountSatRaw)
-          : null;
-      const amountText = String(args.amountText ?? "").trim();
-      const spdPayload = String(args.spdPayload ?? "").trim();
-      if (!amountText) {
-        setStatus(t("spdPaymentOfferMissingAmount"));
-        return false;
-      }
-      if (args.contacts.length === 0) {
-        setStatus(t("spdPaymentOfferFailed"));
-        return false;
-      }
-      if (!currentNsec) {
-        setStatus(t("profileMissingNpub"));
-        return false;
-      }
-
-      try {
-        const { getPublicKey } = await import("nostr-tools");
-        const decodedMe = nip19.decode(currentNsec);
-        if (
-          decodedMe.type !== "nsec" ||
-          !(decodedMe.data instanceof Uint8Array)
-        ) {
-          throw new Error("invalid nsec");
-        }
-        const privBytes = decodedMe.data;
-        const myPubHex = getPublicKey(privBytes);
-
-        const recipients: {
-          contactId: string;
-          contactPubHex: string;
-        }[] = [];
-        for (const contact of args.contacts) {
-          const contactId = String(contact.id ?? "").trim();
-          const contactNpub = normalizeNpubIdentifier(contact.npub);
-          if (!contactId || !contactNpub) continue;
-
-          const decodedContact = nip19.decode(contactNpub);
-          if (
-            decodedContact.type !== "npub" ||
-            typeof decodedContact.data !== "string"
-          ) {
-            continue;
-          }
-          const contactPubHex = decodedContact.data.trim();
-          if (!contactPubHex) continue;
-          recipients.push({ contactId, contactPubHex });
-        }
-
-        if (recipients.length === 0) {
-          setStatus(t("chatMissingContactNpub"));
-          return false;
-        }
-
-        const offerId = makeLocalId();
-        if (spdPayload) {
-          bankPaymentOfferSpdPayloadByOfferIdRef.current.set(
-            offerId,
-            spdPayload,
-          );
-        }
-
-        const pool = await getSharedAppNostrPool();
-        let sentCount = 0;
-
-        for (const recipient of recipients) {
-          const clientId = makeLocalId();
-          const baseEvent = createLinkyBankPaymentOfferEvent({
-            amountSat,
-            amountText,
-            clientId,
-            createdAt: Math.ceil(Date.now() / 1e3),
-            offerId,
-            offererPublicKey: myPubHex,
-            recipientPublicKey: recipient.contactPubHex,
-            senderPublicKey: myPubHex,
-            status: "offered",
-          });
-
-          const wrapForMe = wrapEventWithoutPushMarker(
-            baseEvent,
-            privBytes,
-            myPubHex,
-          );
-          const wrapForContact = wrapEventWithPushMarker(
-            baseEvent,
-            privBytes,
-            recipient.contactPubHex,
-          );
-
-          const publishOutcome = await publishWrappedWithRetry(
-            pool,
-            NOSTR_RELAYS,
-            wrapForMe,
-            wrapForContact,
-          );
-
-          if (!publishOutcome.anySuccess) continue;
-          sentCount += 1;
-
-          const messageWrapId =
-            String(wrapForMe.id ?? "").trim() ||
-            String(wrapForContact.id ?? "").trim() ||
-            `bank-payment-offer:${clientId}`;
-          upsertBankPaymentOfferMessage({
-            clientId,
-            contactId: recipient.contactId,
-            content: baseEvent.content,
-            createdAtSec: baseEvent.created_at,
-            direction: "out",
-            id: `bank-payment-offer:${recipient.contactId}:${offerId}`,
-            localOnly: true,
-            pubkey: myPubHex,
-            rumorId: null,
-            status: "sent",
-            wrapId: messageWrapId,
-          });
-        }
-
-        if (sentCount === 0) {
-          setStatus(t("spdPaymentOfferFailed"));
-          return false;
-        }
-
-        return true;
-      } catch (error) {
-        setStatus(
-          `${t("errorPrefix")}: ${getUnknownErrorMessage(error, "publish failed")}`,
-        );
-        return false;
-      }
-    },
-    [
-      currentNsec,
-      publishWrappedWithRetry,
-      setStatus,
-      t,
-      upsertBankPaymentOfferMessage,
-    ],
-  );
-
-  const respondToBankPaymentOffer = React.useCallback(
-    async (
-      message: LocalNostrMessage,
-      nextStatus: Exclude<LinkyBankPaymentOfferStatus, "offered">,
-      options?: { spdPayload?: string | null; withPush?: boolean },
-    ): Promise<boolean> => {
-      const offerInfo = getLinkyBankPaymentOfferInfo(
-        String(message.content ?? ""),
-      );
-      if (!offerInfo) {
-        setStatus(t("spdPaymentOfferFailed"));
-        return false;
-      }
-      if (!currentNsec) {
-        setStatus(t("profileMissingNpub"));
-        return false;
-      }
-
-      try {
-        const { getPublicKey } = await import("nostr-tools");
-        const decodedMe = nip19.decode(currentNsec);
-        if (
-          decodedMe.type !== "nsec" ||
-          !(decodedMe.data instanceof Uint8Array)
-        ) {
-          throw new Error("invalid nsec");
-        }
-        const privBytes = decodedMe.data;
-        const myPubHex = getPublicKey(privBytes);
-        const messageDirection = String(message.direction ?? "").trim();
-        const offererPublicKey =
-          String(offerInfo.offererPublicKey ?? "").trim() ||
-          (messageDirection === "out"
-            ? myPubHex
-            : String(message.pubkey ?? "").trim());
-
-        if (!offererPublicKey) {
-          setStatus(t("spdPaymentOfferFailed"));
-          return false;
-        }
-
-        const messageContactId = String(message.contactId ?? "").trim();
-        const messageContact =
-          contacts.find(
-            (contact) => String(contact.id ?? "").trim() === messageContactId,
-          ) ?? null;
-        const contactNpub = normalizeNpubIdentifier(messageContact?.npub);
-        let contactPubkey: string | null = null;
-        if (contactNpub) {
-          const decodedContact = nip19.decode(contactNpub);
-          if (
-            decodedContact.type === "npub" &&
-            typeof decodedContact.data === "string"
-          ) {
-            contactPubkey = decodedContact.data.trim() || null;
-          }
-        }
-
-        const messagePubkey = String(message.pubkey ?? "").trim();
-        const recipientPublicKey =
-          offererPublicKey === myPubHex
-            ? (contactPubkey ??
-              (messagePubkey !== myPubHex ? messagePubkey : ""))
-            : offererPublicKey;
-        if (!recipientPublicKey || recipientPublicKey === myPubHex) {
-          setStatus(t("spdPaymentOfferFailed"));
-          return false;
-        }
-
-        const clientId = makeLocalId();
-        const baseEvent = createLinkyBankPaymentOfferEvent({
-          amountSat: offerInfo.amountSat,
-          amountText: offerInfo.amountText,
-          clientId,
-          createdAt: Math.ceil(Date.now() / 1e3),
-          offerId: offerInfo.offerId,
-          offererPublicKey,
-          recipientPublicKey,
-          senderPublicKey: myPubHex,
-          spdPayload: options?.spdPayload ?? offerInfo.spdPayload,
-          status: nextStatus,
-        });
-
-        const wrapForMe = wrapEventWithoutPushMarker(
-          baseEvent,
-          privBytes,
-          myPubHex,
-        );
-        const withPush =
-          options?.withPush ??
-          shouldPushLinkyBankPaymentOfferStatus(nextStatus);
-        const wrapForContact = withPush
-          ? wrapEventWithPushMarker(baseEvent, privBytes, recipientPublicKey)
-          : wrapEventWithoutPushMarker(
-              baseEvent,
-              privBytes,
-              recipientPublicKey,
-            );
-
-        const pool = await getSharedAppNostrPool();
-        const publishOutcome = await publishWrappedWithRetry(
-          pool,
-          NOSTR_RELAYS,
-          wrapForMe,
-          wrapForContact,
-        );
-
-        if (!publishOutcome.anySuccess) {
-          setStatus(t("spdPaymentOfferFailed"));
-          return false;
-        }
-
-        const messageWrapId =
-          String(wrapForMe.id ?? "").trim() ||
-          String(wrapForContact.id ?? "").trim() ||
-          `bank-payment-offer:${clientId}`;
-        upsertBankPaymentOfferMessage({
-          clientId,
-          contactId: String(message.contactId ?? "").trim(),
-          content: baseEvent.content,
-          createdAtSec: baseEvent.created_at,
-          direction: offererPublicKey === myPubHex ? "out" : "in",
-          id: `bank-payment-offer:${offerInfo.offerId}`,
-          localOnly: true,
-          pubkey: offererPublicKey === myPubHex ? myPubHex : offererPublicKey,
-          rumorId: null,
-          status: "sent",
-          wrapId: messageWrapId,
-        });
-
-        return true;
-      } catch (error) {
-        setStatus(
-          `${t("errorPrefix")}: ${getUnknownErrorMessage(error, "publish failed")}`,
-        );
-        return false;
-      }
-    },
-    [
-      currentNsec,
-      contacts,
-      publishWrappedWithRetry,
-      setStatus,
-      t,
-      upsertBankPaymentOfferMessage,
-    ],
-  );
-
-  const getBankPaymentOfferGroupMessages = React.useCallback(
-    (message: LocalNostrMessage): LocalNostrMessage[] => {
-      const offerInfo = getLinkyBankPaymentOfferInfo(
-        String(message.content ?? ""),
-      );
-      if (!offerInfo) return [message];
-
-      const group = bankPaymentOfferMessages.filter((candidate) => {
-        const candidateInfo = getLinkyBankPaymentOfferInfo(
-          String(candidate.content ?? ""),
-        );
-        return candidateInfo?.offerId === offerInfo.offerId;
-      });
-
-      if (
-        !group.some(
-          (candidate) =>
-            String(candidate.contactId ?? "").trim() ===
-            String(message.contactId ?? "").trim(),
-        )
-      ) {
-        group.push(message);
-      }
-
-      return group;
-    },
-    [bankPaymentOfferMessages],
-  );
-
-  const isBankPaymentOfferCanceled = React.useCallback(
-    (offerId: string): boolean => {
-      const normalizedOfferId = String(offerId ?? "").trim();
-      if (!normalizedOfferId) return false;
-
-      return bankPaymentOfferMessages.some((message) => {
-        const info = getLinkyBankPaymentOfferInfo(
-          String(message.content ?? ""),
-        );
-        return (
-          info?.offerId === normalizedOfferId && info.status === "canceled"
-        );
-      });
-    },
-    [bankPaymentOfferMessages],
-  );
-
-  const respondToBankPaymentOfferWithGroupState = React.useCallback(
-    async (
-      message: LocalNostrMessage,
-      nextStatus: Exclude<LinkyBankPaymentOfferStatus, "offered">,
-      options?: { spdPayload?: string | null; withPush?: boolean },
-    ): Promise<boolean> => {
-      if (nextStatus !== "canceled" && nextStatus !== "settled") {
-        return await respondToBankPaymentOffer(message, nextStatus, options);
-      }
-
-      const group = getBankPaymentOfferGroupMessages(message);
-      const cancellationPushContactId =
-        nextStatus === "canceled"
-          ? (group
-              .filter((candidate) => {
-                const info = getLinkyBankPaymentOfferInfo(
-                  String(candidate.content ?? ""),
-                );
-                return (
-                  info?.status === "accepted" ||
-                  info?.status === "bank_details_sent" ||
-                  info?.status === "bank_paid"
-                );
-              })
-              .sort((left, right) => {
-                const leftInfo = getLinkyBankPaymentOfferInfo(
-                  String(left.content ?? ""),
-                );
-                const rightInfo = getLinkyBankPaymentOfferInfo(
-                  String(right.content ?? ""),
-                );
-                const rank = (status: LinkyBankPaymentOfferStatus): number =>
-                  status === "bank_paid"
-                    ? 0
-                    : status === "bank_details_sent"
-                      ? 1
-                      : 2;
-                const rankDifference =
-                  rank(leftInfo?.status ?? "accepted") -
-                  rank(rightInfo?.status ?? "accepted");
-                if (rankDifference !== 0) return rankDifference;
-                return (
-                  Number(leftInfo?.statusUpdatedAtSec ?? left.createdAtSec) -
-                  Number(rightInfo?.statusUpdatedAtSec ?? right.createdAtSec)
-                );
-              })[0]?.contactId ?? null)
-          : null;
-      let sentAny = false;
-
-      for (const groupMessage of group) {
-        const info = getLinkyBankPaymentOfferInfo(
-          String(groupMessage.content ?? ""),
-        );
-        if (!info) continue;
-        if (info.status === nextStatus) {
-          sentAny = true;
-          continue;
-        }
-        if (nextStatus === "canceled" && info.status === "settled") continue;
-
-        const sent = await respondToBankPaymentOffer(groupMessage, nextStatus, {
-          ...(options?.spdPayload !== undefined
-            ? { spdPayload: options.spdPayload }
-            : {}),
-          withPush:
-            nextStatus === "canceled" &&
-            String(groupMessage.contactId ?? "").trim() ===
-              String(cancellationPushContactId ?? "").trim(),
-        });
-        sentAny = sentAny || sent;
-      }
-
-      return sentAny;
-    },
-    [getBankPaymentOfferGroupMessages, respondToBankPaymentOffer],
-  );
-
-  React.useEffect(() => {
-    if (!currentNsec) return;
-    if (bankPaymentOfferMessages.length === 0) return;
-
-    let cancelled = false;
-
-    const run = async () => {
-      try {
-        const { getPublicKey } = await import("nostr-tools");
-        const decodedMe = nip19.decode(currentNsec);
-        if (
-          decodedMe.type !== "nsec" ||
-          !(decodedMe.data instanceof Uint8Array)
-        ) {
-          return;
-        }
-
-        const myPubHex = getPublicKey(decodedMe.data);
-        const groups = new Map<
-          string,
-          {
-            info: ReturnType<typeof getLinkyBankPaymentOfferInfo>;
-            message: LocalNostrMessage;
-          }[]
-        >();
-
-        for (const message of bankPaymentOfferMessages) {
-          const info = getLinkyBankPaymentOfferInfo(
-            String(message.content ?? ""),
-          );
-          if (!info) continue;
-          if (String(info.offererPublicKey ?? "").trim() !== myPubHex) {
-            continue;
-          }
-
-          const group = groups.get(info.offerId) ?? [];
-          group.push({ info, message });
-          groups.set(info.offerId, group);
-        }
-
-        for (const [offerId, group] of groups) {
-          if (cancelled) return;
-
-          const hasActiveBankDetails = group.some(
-            (entry) =>
-              entry.info?.status === "bank_details_sent" ||
-              entry.info?.status === "bank_paid",
-          );
-          if (hasActiveBankDetails) continue;
-
-          const accepted = group
-            .filter((entry) => entry.info?.status === "accepted")
-            .sort((a, b) => {
-              const aSec =
-                a.info?.statusUpdatedAtSec ??
-                Number(a.message.createdAtSec ?? 0);
-              const bSec =
-                b.info?.statusUpdatedAtSec ??
-                Number(b.message.createdAtSec ?? 0);
-              if (aSec !== bSec) return aSec - bSec;
-              return String(a.message.contactId ?? "").localeCompare(
-                String(b.message.contactId ?? ""),
-              );
-            });
-
-          const candidate = accepted[0] ?? null;
-          if (!candidate?.info) continue;
-
-          const spdPayload =
-            bankPaymentOfferSpdPayloadByOfferIdRef.current.get(offerId) ?? "";
-          if (!spdPayload) continue;
-
-          const candidateKey = `${offerId}:${String(candidate.message.contactId ?? "").trim()}`;
-          if (autoSentBankDetailsOfferIdsRef.current.has(candidateKey)) {
-            continue;
-          }
-
-          autoSentBankDetailsOfferIdsRef.current.add(candidateKey);
-          const sent = await respondToBankPaymentOffer(
-            candidate.message,
-            "bank_details_sent",
-            { spdPayload },
-          );
-          if (!sent) {
-            autoSentBankDetailsOfferIdsRef.current.delete(candidateKey);
-          }
-        }
-      } catch {
-        // Best effort; the sender can retry when the accepted event reappears.
-      }
-    };
-
-    void run();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [bankPaymentOfferMessages, currentNsec, respondToBankPaymentOffer]);
-
-  const bankPaymentOfferExpiryGroups = React.useMemo(() => {
-    if (!currentNpub || bankPaymentOfferMessages.length === 0) return [];
-
-    let myPubHex: string;
-    try {
-      const decoded = nip19.decode(currentNpub);
-      if (decoded.type !== "npub" || typeof decoded.data !== "string") {
-        return [];
-      }
-      myPubHex = decoded.data;
-    } catch {
-      return [];
-    }
-
-    const groups = new Map<
-      string,
-      {
-        info: NonNullable<ReturnType<typeof getLinkyBankPaymentOfferInfo>>;
-        message: LocalNostrMessage;
-      }[]
-    >();
-    for (const message of bankPaymentOfferMessages) {
-      const info = getLinkyBankPaymentOfferInfo(String(message.content ?? ""));
-      if (
-        !info ||
-        String(info.offererPublicKey ?? "").trim() !== myPubHex ||
-        isLinkyBankPaymentOfferTerminalStatus(info.status)
-      ) {
-        continue;
-      }
-      const group = groups.get(info.offerId) ?? [];
-      group.push({ info, message });
-      groups.set(info.offerId, group);
-    }
-
-    const nowSec = Math.floor(Date.now() / 1e3);
-    const statusPriority: LinkyBankPaymentOfferStatus[] = [
-      "bank_paid",
-      "bank_details_sent",
-      "accepted",
-      "offered",
-    ];
-    return Array.from(groups.values()).flatMap((group) => {
-      const activeStatus = statusPriority.find((status) =>
-        group.some((entry) => entry.info.status === status),
-      );
-      if (!activeStatus) return [];
-
-      const phaseStartedAtSec = Math.min(
-        ...group
-          .filter((entry) => entry.info.status === activeStatus)
-          .map(
-            (entry) =>
-              entry.info.statusUpdatedAtSec ||
-              Number(entry.message.createdAtSec ?? 0) ||
-              nowSec,
-          ),
-      );
-      return [
-        {
-          expiresAtMs:
-            (phaseStartedAtSec + LINKY_BANK_PAYMENT_OFFER_PHASE_TTL_SEC) *
-            1_000,
-          messages: group.map((entry) => entry.message),
-        },
-      ];
-    });
-  }, [bankPaymentOfferMessages, currentNpub]);
-
-  React.useEffect(() => {
-    const nextExpiryMs = Math.min(
-      ...bankPaymentOfferExpiryGroups.map((group) => group.expiresAtMs),
-    );
-    if (!Number.isFinite(nextExpiryMs)) return;
-
-    let cancelled = false;
-    let timeoutId = 0;
-    const expireDueGroups = () => {
-      if (cancelled) return;
-      if (bankPaymentOfferExpiryInFlightRef.current) {
-        timeoutId = window.setTimeout(expireDueGroups, 100);
-        return;
-      }
-
-      bankPaymentOfferExpiryInFlightRef.current = true;
-      void (async () => {
-        try {
-          const nowMs = Date.now();
-          for (const group of bankPaymentOfferExpiryGroups) {
-            if (group.expiresAtMs > nowMs) continue;
-            for (const message of group.messages) {
-              if (cancelled) return;
-              await respondToBankPaymentOffer(message, "canceled");
-            }
-          }
-        } finally {
-          bankPaymentOfferExpiryInFlightRef.current = false;
-        }
-      })();
-    };
-    timeoutId = window.setTimeout(
-      expireDueGroups,
-      Math.max(0, nextExpiryMs - Date.now()),
-    );
-
-    return () => {
-      cancelled = true;
-      window.clearTimeout(timeoutId);
-    };
-  }, [bankPaymentOfferExpiryGroups, respondToBankPaymentOffer]);
 
   const payContactWithCashuMessage =
     usePayContactWithCashuMessage<ContactRowLike>({
@@ -4502,19 +2572,6 @@ export const useAppShellComposition = () => {
       t,
     ],
   );
-
-  useNostrPendingFlush({
-    activePublishClientIdsRef: activeNostrMessagePublishClientIdsRef,
-    chatSeenWrapIdsRef,
-    contacts,
-    currentNsec,
-    enabled: nostrBootstrapReady,
-    nostrMessagesLocal,
-    nostrReactionsLocal,
-    publishWrappedWithRetry,
-    updateLocalNostrReaction,
-    updateLocalNostrMessage,
-  });
 
   usePaymentsDomain({
     cashuIsBusy,
@@ -5296,10 +3353,6 @@ export const useAppShellComposition = () => {
     t,
   ]);
 
-  const contactsOnboardingHasSentMessage = useMemo(() => {
-    return nostrMessagesRecent.some((m) => String(m.direction ?? "") === "out");
-  }, [nostrMessagesRecent]);
-
   const scannedTextHandlerRef = React.useRef<
     (rawValue: string) => Promise<void>
   >(async () => {});
@@ -5422,180 +3475,6 @@ export const useAppShellComposition = () => {
     touchMintInfo,
   });
 
-  const handleDelete = (id: ContactId) => {
-    const normalizedContactId = String(id ?? "").trim();
-    const contactToArchive =
-      contacts.find(
-        (contact) => String(contact.id ?? "").trim() === normalizedContactId,
-      ) ?? null;
-    const archivedContactNpub = normalizeNpubIdentifier(contactToArchive?.npub);
-    let unknownThreadContactId: string | null = null;
-    if (archivedContactNpub) {
-      try {
-        const decodedContact = nip19.decode(archivedContactNpub);
-        if (
-          decodedContact.type === "npub" &&
-          typeof decodedContact.data === "string"
-        ) {
-          unknownThreadContactId = buildUnknownContactId(decodedContact.data);
-        }
-      } catch {
-        unknownThreadContactId = null;
-      }
-    }
-
-    const archivedAtSec = Math.ceil(Date.now() / 1e3);
-    const storedContactOwnerId = contactToArchive
-      ? resolveContactRowOwnerLane(contactToArchive, contactsVisibleOwnerIds)
-      : null;
-    const archiveOwnerId = storedContactOwnerId ?? contactsOwnerId;
-    const result = archiveOwnerId
-      ? update("contact", { id, archivedAtSec }, { ownerId: archiveOwnerId })
-      : update("contact", { id, archivedAtSec });
-    if (result.ok) {
-      if (
-        unknownThreadContactId &&
-        unknownThreadContactId !== normalizedContactId
-      ) {
-        pendingArchivedContactThreadIdsRef.current.set(
-          normalizedContactId,
-          unknownThreadContactId,
-        );
-      }
-      recordContactsOwnerWrite();
-      setStatus(t("contactArchived"));
-      closeContactDetail();
-      return;
-    }
-    setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
-  };
-
-  const restoreArchivedContact = React.useCallback(
-    (id: ContactId) => {
-      const contactToRestore =
-        contacts.find((contact) => contact.id === id) ?? null;
-      const storedContactOwnerId = contactToRestore
-        ? resolveContactRowOwnerLane(contactToRestore, contactsVisibleOwnerIds)
-        : null;
-      const restoreOwnerId = storedContactOwnerId ?? contactsOwnerId;
-      const result = restoreOwnerId
-        ? update(
-            "contact",
-            { id, archivedAtSec: null },
-            { ownerId: restoreOwnerId },
-          )
-        : update("contact", { id, archivedAtSec: null });
-
-      if (result.ok) {
-        const restoredNpub = normalizeNpubIdentifier(contactToRestore?.npub);
-        if (restoredNpub) {
-          try {
-            const decodedContact = nip19.decode(restoredNpub);
-            if (
-              decodedContact.type === "npub" &&
-              typeof decodedContact.data === "string"
-            ) {
-              const unknownContactId = buildUnknownContactId(
-                decodedContact.data,
-              );
-              if (unknownContactId) {
-                reassignLocalNostrMessagesContactId(
-                  unknownContactId,
-                  String(id),
-                );
-              }
-            }
-          } catch {
-            // Ignore malformed archived contact identifiers.
-          }
-        }
-        recordContactsOwnerWrite();
-        setStatus(t("contactRestored"));
-        closeContactDetail();
-        return;
-      }
-
-      setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
-    },
-    [
-      closeContactDetail,
-      contacts,
-      contactsOwnerId,
-      contactsVisibleOwnerIds,
-      recordContactsOwnerWrite,
-      reassignLocalNostrMessagesContactId,
-      setStatus,
-      t,
-      update,
-    ],
-  );
-
-  const blockPubkeyAndPublishMuteList = React.useCallback(
-    async (pubkeyHex: string): Promise<boolean> => {
-      const normalizedPubkey = normalizePubkeyHex(pubkeyHex);
-      if (!normalizedPubkey) return false;
-
-      const mergedBlockedPubkeys = Array.from(
-        new Set(
-          safeLocalStorageGetJson(BLOCKED_NOSTR_PUBKEYS_STORAGE_KEY, [])
-            .map((entry) => normalizePubkeyHex(entry))
-            .filter((entry): entry is string => Boolean(entry))
-            .concat(normalizedPubkey),
-        ),
-      );
-
-      safeLocalStorageSetJson(
-        BLOCKED_NOSTR_PUBKEYS_STORAGE_KEY,
-        mergedBlockedPubkeys,
-      );
-
-      if (!currentNsec) return true;
-
-      try {
-        const { finalizeEvent, getPublicKey } = await import("nostr-tools");
-
-        const decodedMe = nip19.decode(currentNsec);
-        if (
-          decodedMe.type !== "nsec" ||
-          !(decodedMe.data instanceof Uint8Array)
-        ) {
-          return true;
-        }
-
-        const relays = Array.from(
-          new Set(
-            nostrFetchRelays
-              .map((relay) => String(relay ?? "").trim())
-              .filter(Boolean),
-          ),
-        );
-        if (relays.length === 0) return true;
-
-        const privBytes = decodedMe.data;
-        const pubkey = getPublicKey(privBytes);
-        const baseEvent = {
-          kind: 10000,
-          created_at: Math.ceil(Date.now() / 1e3),
-          tags: mergedBlockedPubkeys.map((blockedPubkey) => [
-            "p",
-            blockedPubkey,
-          ]),
-          content: "",
-          pubkey,
-        } satisfies UnsignedEvent;
-
-        const signed = finalizeEvent(baseEvent, privBytes);
-        const pool = await getSharedAppNostrPool();
-        void Promise.allSettled(pool.publish(relays, signed));
-      } catch {
-        // Local blocklist still applies even if mute-list publish fails.
-      }
-
-      return true;
-    },
-    [currentNsec, nostrFetchRelays],
-  );
-
   const {
     checkAllCashuTokensAndDeleteInvalid,
     checkAndRefreshCashuToken,
@@ -5687,22 +3566,6 @@ export const useAppShellComposition = () => {
       window.clearInterval(intervalId);
     };
   }, [hasAnyIssuedTokensForBackgroundCheck]);
-
-  const copyText = React.useCallback(
-    async (value: string) => {
-      try {
-        const copied = await writeClipboardText(value);
-        if (!copied) {
-          pushToast(t("copyFailed"));
-          return;
-        }
-        pushToast(t("copiedToClipboard"));
-      } catch {
-        pushToast(t("copyFailed"));
-      }
-    },
-    [pushToast, t],
-  );
 
   const closeShareOptions = React.useCallback(() => {
     setShareOptionsText(null);
@@ -6325,463 +4188,6 @@ export const useAppShellComposition = () => {
       "profile",
     );
   }, [currentNpub, pushToast, t, writeNfcUriWithToast]);
-
-  const requestDeleteCurrentContact = () => {
-    if (!editingId) return;
-    if (pendingDeleteId === editingId) {
-      setPendingDeleteId(null);
-      handleDelete(editingId);
-      return;
-    }
-    setPendingDeleteId(editingId);
-  };
-
-  const { openFeedbackContact } = useFeedbackContact<(typeof contacts)[number]>(
-    {
-      appOwnerId: contactsOwnerId,
-      contacts,
-      insert,
-      pushToast,
-      t,
-      update,
-    },
-  );
-
-  const clearContactAttention = React.useCallback((contactId: string) => {
-    const normalizedContactId = String(contactId ?? "").trim();
-    if (!normalizedContactId) return;
-
-    setContactAttentionById((prev) => {
-      if (prev[normalizedContactId] === undefined) return prev;
-      const next = { ...prev };
-      delete next[normalizedContactId];
-      return next;
-    });
-  }, []);
-
-  React.useEffect(() => {
-    for (const contact of contacts) {
-      const contactId = String(contact.id ?? "").trim();
-      if (!contactId) continue;
-      const unknownContactId =
-        pendingArchivedContactThreadIdsRef.current.get(contactId);
-      if (!unknownContactId) continue;
-
-      const archivedAtSec = Number(contact.archivedAtSec ?? 0);
-      if (!Number.isFinite(archivedAtSec) || archivedAtSec <= 0) continue;
-
-      pendingArchivedContactThreadIdsRef.current.delete(contactId);
-      reassignLocalNostrMessagesContactId(contactId, unknownContactId);
-      clearContactAttention(unknownContactId);
-    }
-  }, [clearContactAttention, contacts, reassignLocalNostrMessagesContactId]);
-
-  const blockArchivedContact = React.useCallback(async () => {
-    if (route.kind !== "contactEdit") return;
-    if (!selectedContact?.id) return;
-
-    const normalizedNpub = normalizeNpubIdentifier(selectedContact.npub);
-    if (!normalizedNpub) {
-      setStatus(t("chatMissingContactNpub"));
-      return;
-    }
-
-    const confirmed = window.confirm(t("chatUnknownContactBlockConfirm"));
-    if (!confirmed) return;
-
-    let blockedPubkey: string | null = null;
-    try {
-      const decoded = nip19.decode(normalizedNpub);
-      if (decoded.type === "npub" && typeof decoded.data === "string") {
-        blockedPubkey = normalizePubkeyHex(decoded.data);
-      }
-    } catch {
-      blockedPubkey = null;
-    }
-
-    if (!blockedPubkey) {
-      setStatus(t("chatMissingContactNpub"));
-      return;
-    }
-
-    await blockPubkeyAndPublishMuteList(blockedPubkey);
-
-    const contactId = String(selectedContact.id ?? "").trim();
-    if (contactId) {
-      removeLocalNostrMessagesByContactId(contactId);
-      clearContactAttention(contactId);
-    }
-
-    const result = contactsOwnerId
-      ? (() => {
-          const scoped = update(
-            "contact",
-            { id: selectedContact.id, isDeleted: Evolu.sqliteTrue },
-            { ownerId: contactsOwnerId },
-          );
-          if (scoped.ok) return scoped;
-          return update("contact", {
-            id: selectedContact.id,
-            isDeleted: Evolu.sqliteTrue,
-          });
-        })()
-      : update("contact", {
-          id: selectedContact.id,
-          isDeleted: Evolu.sqliteTrue,
-        });
-
-    if (result.ok) {
-      recordContactsOwnerWrite();
-      setStatus(t("contactBlocked"));
-      closeContactDetail();
-      return;
-    }
-
-    setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
-  }, [
-    blockPubkeyAndPublishMuteList,
-    clearContactAttention,
-    closeContactDetail,
-    contactsOwnerId,
-    recordContactsOwnerWrite,
-    removeLocalNostrMessagesByContactId,
-    route.kind,
-    selectedContact,
-    setStatus,
-    t,
-    update,
-  ]);
-
-  const openContactPay = React.useCallback(
-    (
-      contactId: string,
-      fromChat = false,
-      intent: "pay" | "request" = "pay",
-    ) => {
-      const knownContact =
-        contacts.find((row) => String(row.id ?? "").trim() === contactId) ??
-        null;
-      if (!knownContact) return;
-
-      contactPayBackToChatRef.current = fromChat ? knownContact.id : null;
-      setContactPaymentIntent(intent);
-      navigateTo({ route: "contactPay", id: knownContact.id });
-    },
-    [contacts],
-  );
-
-  const openContactDetail = React.useCallback(
-    (contact: DisplayContact) => {
-      const contactId = String(contact.id ?? "").trim();
-      if (!contactId) return;
-
-      setPendingDeleteId(null);
-      clearContactAttention(contactId);
-      contactPayBackToChatRef.current = null;
-
-      if (contact.isUnknownContact) {
-        navigateTo({ route: "chat", id: contactId });
-        return;
-      }
-
-      const knownContact =
-        contacts.find((row) => String(row.id ?? "").trim() === contactId) ??
-        null;
-      if (!knownContact) {
-        navigateTo({ route: "contacts" });
-        return;
-      }
-
-      const npub = String(knownContact.npub ?? "").trim();
-      const ln = String(knownContact.lnAddress ?? "").trim();
-      if (!npub) {
-        if (ln) {
-          openContactPay(knownContact.id);
-          return;
-        }
-        navigateTo({ route: "contact", id: knownContact.id });
-        return;
-      }
-      navigateTo({ route: "chat", id: String(knownContact.id) });
-    },
-    [clearContactAttention, contacts, openContactPay],
-  );
-
-  const addUnknownContactFromChat = React.useCallback(async () => {
-    if (route.kind !== "chat") return;
-    if (!selectedChatContact?.isUnknownContact) return;
-
-    const contactId = String(selectedChatContact.id ?? "").trim();
-    const npub = normalizeNpubIdentifier(selectedChatContact.npub);
-    if (!contactId || !npub) {
-      setStatus(t("chatUnknownContactAddFailed"));
-      return;
-    }
-
-    const existing = contacts.find(
-      (contact) => normalizeNpubIdentifier(contact.npub) === npub,
-    );
-
-    if (existing?.id) {
-      reassignLocalNostrMessagesContactId(contactId, existing.id);
-      clearContactAttention(contactId);
-      setStatus(t("contactSaved"));
-      navigateTo({ route: "chat", id: String(existing.id) });
-      return;
-    }
-
-    const bestName = unknownNameByNpub[npub] ?? null;
-    const savedName = buildSavedContactName(bestName, npub);
-    const payload = {
-      name: savedName as typeof Evolu.NonEmptyString1000.Type,
-      npub: npub as typeof Evolu.NonEmptyString1000.Type,
-      lnAddress: null,
-      groupName: null,
-    };
-
-    pendingUnknownContactAddRef.current = {
-      sourceContactId: contactId,
-      targetNpub: npub,
-    };
-
-    const result = contactsOwnerId
-      ? (() => {
-          const scoped = insert("contact", payload, {
-            ownerId: contactsOwnerId,
-          });
-          if (scoped.ok) return scoped;
-          return insert("contact", payload);
-        })()
-      : insert("contact", payload);
-
-    if (!result.ok) {
-      pendingUnknownContactAddRef.current = null;
-      setStatus(`${t("errorPrefix")}: ${String(result.error ?? "")}`);
-      return;
-    }
-
-    recordContactsOwnerWrite();
-  }, [
-    clearContactAttention,
-    contactsOwnerId,
-    buildSavedContactName,
-    contacts,
-    insert,
-    pendingUnknownContactAddRef,
-    recordContactsOwnerWrite,
-    reassignLocalNostrMessagesContactId,
-    route.kind,
-    selectedChatContact,
-    setStatus,
-    t,
-    unknownNameByNpub,
-  ]);
-
-  const blockUnknownContactFromChat = React.useCallback(async () => {
-    if (route.kind !== "chat") return;
-    if (!selectedChatContact?.isUnknownContact) return;
-
-    const confirmed = window.confirm(t("chatUnknownContactBlockConfirm"));
-    if (!confirmed) return;
-
-    const contactId = String(selectedChatContact.id ?? "").trim();
-    if (!contactId) return;
-
-    const unknownPubkeyHex = (() => {
-      const directPubkey = normalizePubkeyHex(
-        selectedChatContact.unknownPubkeyHex,
-      );
-      if (directPubkey) return directPubkey;
-
-      const normalizedNpub = normalizeNpubIdentifier(selectedChatContact.npub);
-      if (!normalizedNpub) return null;
-
-      try {
-        const decoded = nip19.decode(normalizedNpub);
-        if (decoded.type !== "npub" || typeof decoded.data !== "string") {
-          return null;
-        }
-        return normalizePubkeyHex(decoded.data);
-      } catch {
-        return null;
-      }
-    })();
-
-    if (!unknownPubkeyHex) return;
-
-    await blockPubkeyAndPublishMuteList(unknownPubkeyHex);
-
-    removeLocalNostrMessagesByContactId(contactId);
-    clearContactAttention(contactId);
-    setStatus(t("chatUnknownContactBlocked"));
-    navigateTo({ route: "contacts" });
-  }, [
-    blockPubkeyAndPublishMuteList,
-    clearContactAttention,
-    removeLocalNostrMessagesByContactId,
-    route.kind,
-    selectedChatContact?.npub,
-    selectedChatContact?.unknownPubkeyHex,
-    selectedChatContact,
-    setStatus,
-    t,
-  ]);
-
-  const getNpubMessageContactInfo = React.useCallback(
-    (rawNpub: string) => {
-      const npub = normalizeNpubIdentifier(rawNpub);
-      if (!npub) return null;
-
-      const knownContact =
-        contacts.find(
-          (contact) => normalizeNpubIdentifier(contact.npub) === npub,
-        ) ?? null;
-      const derivedProfile = deriveDefaultProfile(npub, lang);
-      const displayName = buildSavedContactName(
-        String(knownContact?.name ?? "").trim() ||
-          unknownNameByNpub[npub] ||
-          null,
-        npub,
-      );
-      const pictureUrl =
-        nostrPictureByNpub[npub] ?? derivedProfile.pictureUrl ?? null;
-
-      return {
-        displayName,
-        isSaved:
-          Boolean(knownContact) ||
-          normalizeNpubIdentifier(currentNpub) === npub,
-        npub,
-        pictureUrl,
-      };
-    },
-    [
-      buildSavedContactName,
-      contacts,
-      currentNpub,
-      lang,
-      nostrPictureByNpub,
-      unknownNameByNpub,
-    ],
-  );
-
-  const mentionContacts = React.useMemo(
-    () =>
-      contacts.flatMap((contact) => {
-        const name = String(contact.name ?? "").trim();
-        const npub = normalizeNpubIdentifier(contact.npub);
-        if (!name || !npub) return [];
-        const groupName = String(contact.groupName ?? "").trim();
-        return [
-          {
-            name,
-            npub,
-            groupName: groupName || null,
-            statusNames: extractStatusFilterCurrencies(nostrStatusByNpub[npub]),
-          },
-        ];
-      }),
-    [contacts, nostrStatusByNpub],
-  );
-
-  const openNpubMessageContact = React.useCallback(
-    (rawNpub: string) => {
-      const npub = normalizeNpubIdentifier(rawNpub);
-      if (!npub) return;
-
-      const existing = contacts.find(
-        (contact) => normalizeNpubIdentifier(contact.npub) === npub,
-      );
-      if (existing?.id) {
-        navigateTo({ route: "contact", id: existing.id as ContactId });
-        return;
-      }
-
-      const myNpub = normalizeNpubIdentifier(currentNpub);
-      if (myNpub && myNpub === npub) {
-        navigateTo({ route: "profile" });
-        return;
-      }
-
-      if (activeContactsOwnerContactCount >= MAX_CONTACTS_PER_OWNER) {
-        setStatus(
-          t("contactsLimitReached").replace(
-            "{max}",
-            String(MAX_CONTACTS_PER_OWNER),
-          ),
-        );
-        return;
-      }
-
-      const defaultProfile = deriveDefaultProfile(npub, lang);
-      const payload = {
-        name: buildSavedContactName(
-          unknownNameByNpub[npub] ?? defaultProfile.name,
-          npub,
-        ) as typeof Evolu.NonEmptyString1000.Type,
-        npub: npub as typeof Evolu.NonEmptyString1000.Type,
-        lnAddress: null,
-        groupName: null,
-      };
-
-      const result = contactsOwnerId
-        ? (() => {
-            const scoped = insert("contact", payload, {
-              ownerId: contactsOwnerId,
-            });
-            if (scoped.ok) return scoped;
-            return insert("contact", payload);
-          })()
-        : insert("contact", payload);
-
-      if (!result.ok) {
-        setStatus(`${t("errorPrefix")}: ${String(result.error ?? "")}`);
-        return;
-      }
-
-      openScannedContactPendingNpubRef.current = npub;
-      recordContactsOwnerWrite();
-      setStatus(t("contactSaved"));
-    },
-    [
-      activeContactsOwnerContactCount,
-      buildSavedContactName,
-      contacts,
-      contactsOwnerId,
-      currentNpub,
-      insert,
-      lang,
-      openScannedContactPendingNpubRef,
-      recordContactsOwnerWrite,
-      setStatus,
-      t,
-      unknownNameByNpub,
-    ],
-  );
-
-  React.useEffect(() => {
-    const pending = pendingUnknownContactAddRef.current;
-    if (!pending) return;
-
-    const existing = contacts.find(
-      (contact) =>
-        normalizeNpubIdentifier(contact.npub) === pending.targetNpub &&
-        Boolean(contact.id),
-    );
-    if (!existing?.id) return;
-
-    pendingUnknownContactAddRef.current = null;
-    reassignLocalNostrMessagesContactId(pending.sourceContactId, existing.id);
-    clearContactAttention(pending.sourceContactId);
-    setStatus(t("contactSaved"));
-    navigateTo({ route: "chat", id: String(existing.id) });
-  }, [
-    clearContactAttention,
-    contacts,
-    reassignLocalNostrMessagesContactId,
-    setStatus,
-    t,
-  ]);
 
   const handleSelectContact = React.useCallback(
     (contact: DisplayContact) => {
@@ -7910,98 +5316,6 @@ export const useAppShellComposition = () => {
     };
   }, [appOwnerIdValue, isCashuTokenKnownAny, resolveOwnerIdForWrite, upsert]);
 
-  useChatNostrSyncEffect({
-    appendLocalNostrMessage,
-    appendLocalNostrReaction,
-    chatMessages,
-    chatMessagesLatestRef,
-    chatSeenWrapIdsRef,
-    currentNsec,
-    enabled: nostrBootstrapReady,
-    knownNostrMessageIdentityIndex,
-    logPayStep,
-    nostrMessageWrapIdsRef,
-    nostrReactionWrapIdsRef,
-    nostrReactionsLatestRef,
-    route,
-    selectedContact: selectedChatContact,
-    softDeleteLocalNostrReactionsByWrapIds,
-    updateLocalNostrMessage,
-    updateLocalNostrReaction,
-  });
-
-  const sendChatMessage = useSendChatMessage({
-    activePublishClientIdsRef: activeNostrMessagePublishClientIdsRef,
-    appendLocalNostrMessage,
-    chatDraft,
-    chatSeenWrapIdsRef,
-    chatSendIsBusy,
-    currentNsec,
-    publishWrappedWithRetry,
-    route,
-    replyContext,
-    replyContextRef,
-    selectedContact:
-      route.kind === "chat" || route.kind === "bankPaymentOffer"
-        ? selectedChatContact
-        : selectedContact,
-    setReplyContext,
-    setChatDraft,
-    setChatSendIsBusy,
-    setStatus,
-    t,
-    triggerChatScrollToBottom,
-    updateLocalNostrMessage,
-  });
-
-  const editChatMessage = useEditChatMessage({
-    chatDraft,
-    chatSendIsBusy,
-    currentNsec,
-    editContext,
-    publishWrappedWithRetry,
-    route,
-    selectedContact: selectedChatContact,
-    setChatDraft,
-    setChatSendIsBusy,
-    setEditContext,
-    setStatus,
-    t,
-    updateLocalNostrMessage,
-  });
-
-  const sendReaction = useSendReaction({
-    appendLocalNostrReaction,
-    currentNsec,
-    publishWrappedWithRetry,
-    reactionsByMessageId,
-    route,
-    selectedContact: selectedChatContact,
-    setStatus,
-    softDeleteLocalNostrReaction,
-    t,
-    updateLocalNostrReaction,
-  });
-
-  const sendChatOrEditMessage = React.useCallback(async () => {
-    if (editContext) {
-      await editChatMessage();
-      return;
-    }
-    await sendChatMessage();
-  }, [editChatMessage, editContext, sendChatMessage]);
-
-  const sendChatImage = React.useCallback(
-    async (file: File) => {
-      if (editContext) return;
-      await sendChatMessage({
-        clearDraft: false,
-        imageFile: file,
-      });
-    },
-    [editContext, sendChatMessage],
-  );
-
   const requestSelectedContact = React.useCallback(async () => {
     if (route.kind !== "contactPay") return;
     if (!selectedContact) return;
@@ -8090,65 +5404,6 @@ export const useAppShellComposition = () => {
     t,
   ]);
 
-  const onReplyToChatMessage = React.useCallback(
-    (message: LocalNostrMessage) => {
-      const rumorId = String(message.rumorId ?? "").trim();
-      if (!rumorId) return;
-      setEditContext(null);
-      setReplyContext({
-        replyToId: rumorId,
-        rootMessageId: String(message.rootMessageId ?? "").trim() || rumorId,
-        replyToContent: String(message.content ?? "").trim() || null,
-      });
-    },
-    [],
-  );
-
-  const onEditChatMessage = React.useCallback((message: LocalNostrMessage) => {
-    const isOut = String(message.direction ?? "") === "out";
-    if (!isOut) return;
-    const rumorId = String(message.rumorId ?? "").trim();
-    if (!rumorId) return;
-    const messageId = String(message.id ?? "").trim();
-    if (!messageId) return;
-
-    setReplyContext(null);
-    const content = String(message.content ?? "");
-    setEditContext({
-      messageId,
-      rumorId,
-      originalContent:
-        String(message.originalContent ?? "").trim() || content || "",
-    });
-    setChatDraft(content);
-  }, []);
-
-  const onReactToChatMessage = React.useCallback(
-    (message: LocalNostrMessage, emoji: string) => {
-      const messageRumorId = String(message.rumorId ?? "").trim();
-      const messageAuthorPubkey = String(message.pubkey ?? "").trim();
-      if (!messageRumorId || !messageAuthorPubkey) return;
-      void sendReaction({
-        emoji,
-        messageAuthorPubkey,
-        messageKind: parsePrivateImageMessage(message.content) ? 15 : 14,
-        messageRumorId,
-      });
-    },
-    [sendReaction],
-  );
-
-  const onCopyChatMessage = React.useCallback(
-    (message: LocalNostrMessage) => {
-      const content = String(message.content ?? "");
-      const copyContent = parsePrivateImageMessage(content)
-        ? privateImagePreviewText(t)
-        : content;
-      void copyText(copyContent);
-    },
-    [copyText, t],
-  );
-
   const onPayChatPaymentRequest = React.useCallback(
     async (
       message: LocalNostrMessage,
@@ -8186,34 +5441,6 @@ export const useAppShellComposition = () => {
       setCashuIsBusy,
     ],
   );
-
-  const onDeclineChatPaymentRequest = React.useCallback(
-    async (message: LocalNostrMessage) => {
-      const requestRumorId = String(message.rumorId ?? "").trim();
-      if (!requestRumorId) return;
-
-      await sendChatMessage({
-        clearDraft: false,
-        replyContext: {
-          replyToId: requestRumorId,
-          rootMessageId:
-            String(message.rootMessageId ?? "").trim() || requestRumorId,
-          replyToContent: String(message.content ?? "").trim() || null,
-        },
-        text: buildLinkyPaymentRequestDeclineMessage(requestRumorId),
-      });
-    },
-    [sendChatMessage],
-  );
-
-  const onCancelReply = React.useCallback(() => {
-    setReplyContext(null);
-  }, []);
-
-  const onCancelEdit = React.useCallback(() => {
-    setEditContext(null);
-    setChatDraft("");
-  }, []);
 
   const contactPayBackToChatId = contactPayBackToChatRef.current;
   const topbar = React.useMemo(
@@ -8275,18 +5502,6 @@ export const useAppShellComposition = () => {
     (text: string) =>
       getCashuTokenMessageInfoBase(text, cashuTokensAllFiltered),
     [cashuTokensAllFiltered],
-  );
-
-  const openInboxMessageToast = React.useCallback(
-    (params: { contactId: string; messageId?: string }) => {
-      const contactId = String(params.contactId ?? "").trim();
-      if (!contactId) return;
-      const messageId = String(params.messageId ?? "").trim();
-
-      navigateTo({ route: "chat", id: contactId });
-      triggerChatScrollToBottom(messageId || undefined);
-    },
-    [triggerChatScrollToBottom],
   );
 
   const openNotificationChat = React.useCallback(
@@ -8750,33 +5965,6 @@ export const useAppShellComposition = () => {
     ],
   );
 
-  useInboxNotificationsSync({
-    appendLocalNostrMessage,
-    appendLocalNostrReaction,
-    bankPaymentOfferMessages,
-    contacts,
-    currentNsec,
-    enabled: nostrBootstrapReady,
-    formatDisplayedAmountText,
-    maybeShowPwaNotification,
-    nostrFetchRelays,
-    knownNostrMessageIdentityIndex,
-    nostrMessageWrapIdsRef,
-    nostrMessagesLatestRef,
-    nostrMessagesRecent,
-    nostrReactionWrapIdsRef,
-    nostrReactionsLatestRef,
-    onBankPaymentOfferMessage: upsertBankPaymentOfferMessage,
-    onOpenInboxMessageToast: openInboxMessageToast,
-    pushToast,
-    route,
-    setContactAttentionById,
-    softDeleteLocalNostrReactionsByWrapIds,
-    t,
-    updateLocalNostrMessage,
-    updateLocalNostrReaction,
-  });
-
   const handleContactIdentifierScanned = React.useCallback(
     async (identifier: string) => {
       await addNewContactFromIdentifier(identifier);
@@ -9105,61 +6293,6 @@ export const useAppShellComposition = () => {
     handleScannedText,
     scannedTextHandlerRef,
   });
-
-  const chatMessagesWithBankPaymentOffers = React.useMemo(() => {
-    if (route.kind !== "chat") return chatMessages;
-
-    const activeContactId = String(route.id ?? "").trim();
-    if (!activeContactId) return chatMessages;
-
-    const offerMessages = bankPaymentOfferMessages.filter(
-      (message) => String(message.contactId ?? "").trim() === activeContactId,
-    );
-    if (offerMessages.length === 0) return chatMessages;
-
-    const seenKeys = new Set<string>();
-    for (const message of chatMessages) {
-      const offerId = getLinkyBankPaymentOfferInfo(
-        String(message.content ?? ""),
-      )?.offerId;
-      if (offerId) seenKeys.add(`offer:${offerId}`);
-      const wrapId = String(message.wrapId ?? "").trim();
-      if (wrapId) seenKeys.add(`wrap:${wrapId}`);
-      const clientId = String(message.clientId ?? "").trim();
-      if (clientId) seenKeys.add(`client:${clientId}`);
-      const id = String(message.id ?? "").trim();
-      if (id) seenKeys.add(`id:${id}`);
-    }
-
-    const merged = [...chatMessages];
-    for (const message of offerMessages) {
-      const offerId = getLinkyBankPaymentOfferInfo(
-        String(message.content ?? ""),
-      )?.offerId;
-      const wrapId = String(message.wrapId ?? "").trim();
-      const clientId = String(message.clientId ?? "").trim();
-      const id = String(message.id ?? "").trim();
-      if (offerId && seenKeys.has(`offer:${offerId}`)) continue;
-      if (wrapId && seenKeys.has(`wrap:${wrapId}`)) continue;
-      if (clientId && seenKeys.has(`client:${clientId}`)) continue;
-      if (id && seenKeys.has(`id:${id}`)) continue;
-
-      merged.push(message);
-      if (offerId) seenKeys.add(`offer:${offerId}`);
-      if (wrapId) seenKeys.add(`wrap:${wrapId}`);
-      if (clientId) seenKeys.add(`client:${clientId}`);
-      if (id) seenKeys.add(`id:${id}`);
-    }
-
-    merged.sort((a, b) => {
-      const createdA = Number(a.createdAtSec ?? 0);
-      const createdB = Number(b.createdAtSec ?? 0);
-      if (createdA !== createdB) return createdA - createdB;
-      return String(a.id ?? "").localeCompare(String(b.id ?? ""));
-    });
-
-    return merged;
-  }, [bankPaymentOfferMessages, chatMessages, route]);
 
   useChatMessageEffects({
     autoAcceptedChatMessageIdsRef,

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -1,12 +1,9 @@
 import { Share } from "@capacitor/share";
-import type { Proof } from "@cashu/cashu-ts";
 import * as Evolu from "@evolu/common";
 import { useQuery } from "@evolu/react";
-import { nip19, type UnsignedEvent } from "nostr-tools";
+import { nip19 } from "nostr-tools";
 import React, { useMemo, useState } from "react";
-import { createSendTokenWithTokensAtMint } from "../cashuSend";
 import { ContactCard } from "../components/ContactCard";
-import { deriveDefaultProfile } from "../derivedProfile";
 import {
   evolu,
   normalizeEvoluServerUrl,
@@ -21,11 +18,6 @@ import {
 import { navigateTo, useRouting } from "../hooks/useRouting";
 import { useToasts } from "../hooks/useToasts";
 import { getInitialLang, translations, type Lang } from "../i18n";
-import {
-  inferLightningAddressFromLnurlTarget,
-  redeemLnurlWithdraw,
-  type LnurlWithdrawPreview,
-} from "../lnurlPay";
 import { NOSTR_RELAYS } from "../nostrProfile";
 import { writeClipboardText } from "../platform/clipboard";
 import {
@@ -45,26 +37,11 @@ import {
   type PasswordManagerSaveResult,
 } from "../platform/passwordManager";
 import { isNativePlatform } from "../platform/runtime";
-import { getCashuDeterministicSeedFromStorage } from "../utils/cashuDeterministic";
 import {
-  isCashuOutputsAlreadySignedError,
-  isCashuOutputsArePendingError,
-} from "../utils/cashuErrors";
-import { getCashuLib } from "../utils/cashuLib";
-import { cashuAmountToNumber } from "../utils/cashuProofs";
-import { createLoadedCashuWallet } from "../utils/cashuWallet";
-import {
-  CASHU_AUTOSWAP_MIN_SOURCE_SUM,
-  CASHU_ONBOARDING_SET_MAIN_MINT_STORAGE_KEY,
   CONTACTS_ONBOARDING_HAS_BACKUPED_KEYS_STORAGE_KEY,
-  CONTACTS_ONBOARDING_HAS_PAID_STORAGE_KEY,
   FEEDBACK_CONTACT_NPUB,
   LOCAL_MINT_INFO_STORAGE_KEY_PREFIX,
-  LOCAL_PENDING_TOPUP_QUOTE_STORAGE_KEY_PREFIX,
-  MAX_CONTACTS_PER_OWNER,
   PENDING_DEEP_LINK_TEXT_STORAGE_KEY,
-  WALLET_WARNING_BALANCE_THRESHOLD_SAT,
-  WALLET_WARNING_DISMISSED_STORAGE_KEY,
 } from "../utils/constants";
 import { buildCashuDeepLink, parseNativeDeepLinkUrl } from "../utils/deepLinks";
 import {
@@ -77,37 +54,25 @@ import {
   type DisplayCurrency,
 } from "../utils/displayAmounts";
 import {
-  getLightningInvoicePreview,
-  type LightningInvoicePreview,
-} from "../utils/lightningInvoice";
-import {
-  CASHU_DEFAULT_MINT_OVERRIDE_STORAGE_KEY,
   extractPpk,
-  isTestMintUrl,
   MAIN_MINT_URL,
   normalizeMintUrl,
   PRESET_MINTS,
 } from "../utils/mint";
 import { normalizeNpubIdentifier } from "../utils/nostrNpub";
-import { parseNpubCashProfileInfo } from "../utils/npubCashInfo";
 import {
   getInitialAllowedDisplayCurrencies,
-  getInitialCashuAutoswapEnabled,
   getInitialDisplayCurrency,
-  getInitialLightningInvoiceAutoPayLimit,
-  getInitialPayWithCashuEnabled,
   safeLocalStorageGet,
   safeLocalStorageRemove,
   safeLocalStorageSet,
   safeLocalStorageSetJson,
-  withLocalStorageLeaseLock,
 } from "../utils/storage";
-import { getUnknownErrorMessage } from "../utils/unknown";
-import { makeLocalId } from "../utils/validation";
-import { useCashuTokenChecks } from "./hooks/cashu/useCashuTokenChecks";
-import { useNpubCashClaim } from "./hooks/cashu/useNpubCashClaim";
-import { useRestoreMissingTokens } from "./hooks/cashu/useRestoreMissingTokens";
-import { useSaveCashuFromText } from "./hooks/cashu/useSaveCashuFromText";
+import {
+  createCashuTokensAllQuery,
+  logPayStep,
+  useCashuWalletComposition,
+} from "./hooks/composition/useCashuWalletComposition";
 import { useIdentityOwnersComposition } from "./hooks/composition/useIdentityOwnersComposition";
 import { usePaymentMoneyComposition } from "./hooks/composition/usePaymentMoneyComposition";
 import { useProfileComposition } from "./hooks/composition/useProfileComposition";
@@ -131,61 +96,25 @@ import {
 } from "./hooks/messages/contactIdentity";
 import { hasKnownNostrMessageIdentity } from "./hooks/messages/messageHelpers";
 import { useChatMessageEffects } from "./hooks/messages/useChatMessageEffects";
-import { useNpubCashMintSelection } from "./hooks/mint/useNpubCashMintSelection";
-import { useContactPayMethod } from "./hooks/payments/useContactPayMethod";
-import { usePayContactWithCashuMessage } from "./hooks/payments/usePayContactWithCashuMessage";
-import { useRouteAmountResetEffects } from "./hooks/payments/useRouteAmountResetEffects";
-import { shouldKeepTopupQuoteAfterClaimError } from "./hooks/topup/topupMintClaim";
-import {
-  isClaimableMintQuoteState,
-  readMintQuoteState,
-} from "./hooks/topup/topupMintQuoteState";
-import {
-  requestMintQuoteBolt11,
-  useTopupInvoiceQuoteEffects,
-  type TopupMintQuoteDraft,
-} from "./hooks/topup/useTopupInvoiceQuoteEffects";
-import { useAnonymousPaymentTelemetry } from "./hooks/useAnonymousPaymentTelemetry";
 import { useAppDataTransfer } from "./hooks/useAppDataTransfer";
 import { useAppPreferences } from "./hooks/useAppPreferences";
 import { useArmedDeleteTimeouts } from "./hooks/useArmedDeleteTimeouts";
-import { useCashuDomain } from "./hooks/useCashuDomain";
 import { useFiatRates } from "./hooks/useFiatRates";
 import { useGuideScannerDomain } from "./hooks/useGuideScannerDomain";
-import { useLightningPaymentsDomain } from "./hooks/useLightningPaymentsDomain";
 import { useMainSwipePageEffects } from "./hooks/useMainSwipePageEffects";
-import { useMintDomain } from "./hooks/useMintDomain";
 import { useOwnerScopedStorage } from "./hooks/useOwnerScopedStorage";
-import { usePaidOverlayState } from "./hooks/usePaidOverlayState";
-import { usePaymentsDomain } from "./hooks/usePaymentsDomain";
-import { useProfileNpubCashEffects } from "./hooks/useProfileNpubCashEffects";
 import { useScannedTextHandler } from "./hooks/useScannedTextHandler";
 import { useScannedTextHandlerRefBridge } from "./hooks/useScannedTextHandlerRefBridge";
 import { useStatusToasts } from "./hooks/useStatusToasts";
 import { useStoragePersistRequestEffect } from "./hooks/useStoragePersistRequestEffect";
 import {
-  appendPendingAutoswapClaim,
-  claimAutoswapPendingEntry,
-  makePendingAutoswapClaimsKey,
-  readPendingAutoswapClaims,
-  type AutoswapPendingClaim,
-} from "./lib/autoswapClaim";
-import {
   getLinkyBankPaymentOfferInfo,
   isLinkyBankPaymentOfferEvent,
   setLinkyBankPaymentOfferMinimized,
 } from "./lib/bankPaymentOffer";
-import { resolveCashuRowStoredOwnerLane } from "./lib/cashuOwnerLane";
-import { isCashuRowCandidateBetter } from "./lib/cashuRowPreference";
-import { createCashuTokenId } from "./lib/cashuTokenIdentity";
 import {
   CASHU_TOKEN_STATE_EXTERNALIZED,
-  CASHU_TOKEN_STATE_RESERVED,
   isCashuTokenAcceptedState,
-  isCashuTokenDefinitivelySpent,
-  isCashuTokenEmittedState,
-  isCashuTokenIssuedState,
-  isCashuTokenReservedState,
 } from "./lib/cashuTokenState";
 import {
   buildIdentityChangeMessageContent,
@@ -203,108 +132,33 @@ import {
   ONBOARDING_TUTORIAL_OWNER_META_SCOPE,
 } from "./lib/onboardingTutorialSync";
 import {
-  buildPaymentAmountAttempts,
-  buildPaymentFailureAmountAttempts,
-  getPaymentAmountReserveCap,
-  isRetryablePaymentAmountFailure,
-} from "./lib/paymentAmountFallback";
-import {
-  canOfferPaymentMintMelt,
-  getPaymentMintMeltPlan,
-} from "./lib/paymentMintMelt";
-import {
-  buildCashuMintCandidates as buildCashuMintCandidatesBase,
-  selectSingleMintCandidateForAmount,
-} from "./lib/paymentMintSelection";
-import {
-  buildCashuPaymentRequestMessage,
-  parseCashuPaymentRequestMessage,
-  type CashuPaymentRequestMessageInfo,
-} from "./lib/paymentRequestMessage";
-import {
   parsePrivateImageMessage,
   privateImageMessageFromEvent,
 } from "./lib/privateImageMessage";
 import {
   getLinkyBankPaymentOfferPaymentNoticeOfferId,
   isLinkyBankPaymentOfferPaymentNoticeEvent,
-  LINKY_PAYMENT_NOTICE_CONTEXT_BANK_PAYMENT_OFFER,
-  wrapEventWithoutPushMarker,
-  wrapEventWithPushMarker,
 } from "./lib/pushWrappedEvent";
 import { showPwaNotification } from "./lib/pwaNotifications";
-import { getCashuTokenMessageInfo as getCashuTokenMessageInfoBase } from "./lib/tokenMessageInfo";
 import {
   extractCashuTokenFromText,
   extractCashuTokenFromText as extractCashuTokenFromTextFromUrl,
-  extractCashuTokenMeta,
 } from "./lib/tokenText";
 import {
   buildTopbar,
   buildTopbarRight,
   buildTopbarTitle,
 } from "./lib/topbarConfig";
-import {
-  isExpiredPendingTopupQuote,
-  isLikelyCorsOrNetworkError,
-  isSameTopupMintQuote,
-  makeClaimedTopupQuoteLockKey,
-  makeClaimedTopupQuoteStorageKey,
-  readClaimedTopupQuoteFromStorage,
-  readPendingTopupQuoteFromStorage,
-  toPendingTopupQuoteStorage,
-  toTopupMintQuoteDraft,
-  type ClaimedTopupQuoteStorage,
-} from "./lib/topupQuoteStorage";
-import { mintTopupProofs } from "./lib/topupProofRecovery";
-import type {
-  ContactRowLike,
-  LocalNostrMessage,
-  PaymentLogData,
-} from "./types/appTypes";
+import type { ContactRowLike, LocalNostrMessage } from "./types/appTypes";
 import {
   useContactsMessagingComposition,
   type DisplayContact,
 } from "./hooks/composition/useContactsMessagingComposition";
 
 type TranslationKey = keyof (typeof translations)["cs"];
-type LoadedCashuWallet = Awaited<ReturnType<typeof createLoadedCashuWallet>>;
 
 const hasTranslationKey = (key: string): key is TranslationKey =>
   Object.prototype.hasOwnProperty.call(translations.cs, key);
-
-type CashuProofPayload = Record<string, unknown> & {
-  C: string;
-  amount: number;
-  secret: string;
-};
-
-const isCashuProofPayload = (value: unknown): value is CashuProofPayload => {
-  if (typeof value !== "object" || value === null) return false;
-  return (
-    Reflect.get(value, "amount") !== undefined &&
-    typeof Reflect.get(value, "secret") === "string" &&
-    typeof Reflect.get(value, "C") === "string"
-  );
-};
-
-const normalizeCashuProofPayload = (
-  proof: unknown,
-): CashuProofPayload | null => {
-  if (!isCashuProofPayload(proof)) return null;
-  return {
-    ...proof,
-    amount: cashuAmountToNumber(Reflect.get(proof, "amount")),
-  };
-};
-
-const logPayStep = (step: string, data?: PaymentLogData): void => {
-  try {
-    console.log("[linky][pay]", step, data ?? {});
-  } catch {
-    // ignore logging errors
-  }
-};
 
 interface QueuedNotificationOpenDetail {
   value: unknown;
@@ -312,8 +166,6 @@ interface QueuedNotificationOpenDetail {
 
 export const useAppShellComposition = () => {
   const { insert, update, upsert } = useEvolu();
-
-  const hasMintOverrideRef = React.useRef(false);
 
   const route = useRouting();
   const { dismissToast, toasts, pushToast } = useToasts();
@@ -437,13 +289,6 @@ export const useAppShellComposition = () => {
   const [status, setStatus] = useState<string | null>(null);
   const importDataFileInputRef = React.useRef<HTMLInputElement | null>(null);
 
-  const topupInvoiceStartBalanceRef = React.useRef<number | null>(null);
-  const topupInvoicePaidHandledRef = React.useRef(false);
-  const [pendingCashuDeleteId, setPendingCashuDeleteId] =
-    useState<CashuTokenId | null>(null);
-  const [pendingMintDeleteUrl, setPendingMintDeleteUrl] = useState<
-    string | null
-  >(null);
   const [pendingEvoluServerDeleteUrl, setPendingEvoluServerDeleteUrl] =
     useState<string | null>(null);
   const [contactsHeaderVisible, setContactsHeaderVisible] = useState(false);
@@ -457,14 +302,6 @@ export const useAppShellComposition = () => {
   const [displayCurrency, setDisplayCurrency] = useState<DisplayCurrency>(() =>
     getInitialDisplayCurrency(),
   );
-  const [payWithCashuEnabled, setPayWithCashuEnabled] = useState<boolean>(() =>
-    getInitialPayWithCashuEnabled(),
-  );
-  const [cashuAutoswapEnabled, setCashuAutoswapEnabled] = useState<boolean>(
-    () => getInitialCashuAutoswapEnabled(),
-  );
-  const [lightningInvoiceAutoPayLimit, setLightningInvoiceAutoPayLimit] =
-    useState<number>(() => getInitialLightningInvoiceAutoPayLimit());
 
   const pendingNotificationOpenDetailsRef = React.useRef<
     QueuedNotificationOpenDetail[]
@@ -578,52 +415,6 @@ export const useAppShellComposition = () => {
     return "disconnected" as const;
   }, [evoluActiveServerUrls, evoluHasError, evoluServerStatusByUrl, syncOwner]);
 
-  const pendingTopupStorageKey = `${LOCAL_PENDING_TOPUP_QUOTE_STORAGE_KEY_PREFIX}.${String(appOwnerId ?? "anon")}`;
-
-  useAnonymousPaymentTelemetry({
-    appOwnerId,
-    makeLocalStorageKey,
-  });
-
-  React.useEffect(() => {
-    appOwnerIdRef.current = appOwnerId;
-    if (!appOwnerId) return;
-    const overrideKey = makeLocalStorageKey(
-      CASHU_DEFAULT_MINT_OVERRIDE_STORAGE_KEY,
-    );
-    const overrideRaw = safeLocalStorageGet(overrideKey);
-    const override = normalizeMintUrl(overrideRaw);
-    const shouldSeedMainMint =
-      safeLocalStorageGet(CASHU_ONBOARDING_SET_MAIN_MINT_STORAGE_KEY) === "1";
-
-    if (!override && shouldSeedMainMint) {
-      const seededMint = normalizeMintUrl(MAIN_MINT_URL);
-      if (seededMint) {
-        safeLocalStorageSet(overrideKey, seededMint);
-        safeLocalStorageRemove(CASHU_ONBOARDING_SET_MAIN_MINT_STORAGE_KEY);
-        hasMintOverrideRef.current = true;
-        setDefaultMintUrl(seededMint);
-        setDefaultMintUrlDraft(seededMint);
-        // Mirror the onboarding-seeded value into Evolu so a brand-new
-        // account converges to cashu.cz across devices even before the user
-        // touches the mint UI.
-        upsertDefaultMintToOwnerMetaRef.current(seededMint);
-        return;
-      }
-    }
-
-    if (override) {
-      hasMintOverrideRef.current = true;
-      setDefaultMintUrl(override);
-      setDefaultMintUrlDraft(override);
-    } else {
-      if (shouldSeedMainMint) {
-        safeLocalStorageRemove(CASHU_ONBOARDING_SET_MAIN_MINT_STORAGE_KEY);
-      }
-      hasMintOverrideRef.current = false;
-    }
-  }, [appOwnerId, appOwnerIdRef, makeLocalStorageKey]);
-
   // Evolu error subscription handled by useEvoluLastError.
 
   const [evoluWipeStorageIsBusy, setEvoluWipeStorageIsBusy] =
@@ -644,300 +435,12 @@ export const useAppShellComposition = () => {
     }
   }, [evoluWipeStorageIsBusy, lang, pushToast]);
 
-  const [cashuDraft, setCashuDraft] = useState("");
-  const cashuDraftRef = React.useRef<HTMLTextAreaElement | null>(null);
-  const [cashuEmitAmount, setCashuEmitAmount] = useState("");
-  const [cashuIsBusy, setCashuIsBusy] = useState(false);
-  const [cashuBulkCheckIsBusy, setCashuBulkCheckIsBusy] = useState(false);
-  const [tokensRestoreIsBusy, setTokensRestoreIsBusy] = useState(false);
   const [shareOptionsText, setShareOptionsText] = useState<string | null>(null);
-
-  const cashuOpQueueRef = React.useRef<Promise<void>>(Promise.resolve());
-  const enqueueCashuOp = React.useCallback((op: () => Promise<void>) => {
-    const next = cashuOpQueueRef.current.then(op, op);
-    cashuOpQueueRef.current = next.catch(() => {});
-    return next;
-  }, []);
-
-  const [defaultMintUrl, setDefaultMintUrl] = useState<string | null>(null);
-  const [defaultMintUrlDraft, setDefaultMintUrlDraft] = useState<string>("");
 
   const [contactPaymentIntent, setContactPaymentIntent] = useState<
     "pay" | "request"
   >("pay");
   const [payAmount, setPayAmount] = useState<string>("");
-  const [lnAddressPayAmount, setLnAddressPayAmount] = useState<string>("");
-
-  const [topupAmount, setTopupAmount] = useState<string>("");
-  const [topupInvoice, setTopupInvoice] = useState<string | null>(null);
-  const [topupInvoiceCashuRequest, setTopupInvoiceCashuRequest] = useState<
-    string | null
-  >(null);
-  const [topupInvoiceQr, setTopupInvoiceQr] = useState<string | null>(null);
-  const [topupInvoiceQrPayload, setTopupInvoiceQrPayload] = useState<
-    string | null
-  >(null);
-  const [topupInvoiceError, setTopupInvoiceError] = useState<string | null>(
-    null,
-  );
-  const [topupInvoiceIsBusy, setTopupInvoiceIsBusy] = useState(false);
-  const [topupMintQuote, setTopupMintQuote] =
-    useState<TopupMintQuoteDraft | null>(null);
-
-  React.useEffect(() => {
-    if (!appOwnerId) {
-      setTopupMintQuote(null);
-      return;
-    }
-
-    const stored = readPendingTopupQuoteFromStorage(pendingTopupStorageKey);
-    if (!stored) {
-      safeLocalStorageRemove(pendingTopupStorageKey);
-      setTopupMintQuote(null);
-      return;
-    }
-
-    if (isExpiredPendingTopupQuote(stored.createdAtMs)) {
-      safeLocalStorageRemove(pendingTopupStorageKey);
-      setTopupMintQuote(null);
-      return;
-    }
-
-    const nextQuote = toTopupMintQuoteDraft(stored);
-    setTopupMintQuote((current) => {
-      if (isSameTopupMintQuote(current, nextQuote)) return current;
-      return nextQuote;
-    });
-  }, [appOwnerId, pendingTopupStorageKey]);
-
-  React.useEffect(() => {
-    if (!appOwnerId) return;
-
-    if (!topupMintQuote) {
-      safeLocalStorageRemove(pendingTopupStorageKey);
-      return;
-    }
-
-    safeLocalStorageSet(
-      pendingTopupStorageKey,
-      JSON.stringify(toPendingTopupQuoteStorage(topupMintQuote)),
-    );
-  }, [appOwnerId, pendingTopupStorageKey, topupMintQuote]);
-  const [pendingCashuTokenContactPickId, setPendingCashuTokenContactPickId] =
-    useState<CashuTokenId | null>(null);
-
-  const [
-    pendingLightningInvoiceConfirmation,
-    setPendingLightningInvoiceConfirmation,
-  ] = useState<LightningInvoicePreview | null>(null);
-  const [
-    pendingLnurlWithdrawConfirmation,
-    setPendingLnurlWithdrawConfirmation,
-  ] = useState<LnurlWithdrawPreview | null>(null);
-  const [
-    pendingMintAutoswapChangeConfirmation,
-    setPendingMintAutoswapChangeConfirmation,
-  ] = useState<{
-    fromMint: string;
-    toMint: string;
-  } | null>(null);
-  const pendingMintAutoswapChangeResolverRef = React.useRef<
-    ((confirmed: boolean) => void) | null
-  >(null);
-  const [
-    pendingPaymentMintMeltConfirmation,
-    setPendingPaymentMintMeltConfirmation,
-  ] = useState<{
-    fromMint: string;
-    toMint: string;
-  } | null>(null);
-  const meltLargestForeignMintToMainMintRef = React.useRef<() => Promise<void>>(
-    async () => {},
-  );
-  const [lnurlWithdrawIsBusy, setLnurlWithdrawIsBusy] = useState(false);
-
-  const npubCashClaimInFlightRef = React.useRef(false);
-  const npubCashMintSyncRef = React.useRef<string | null>(null);
-
-  const {
-    paidOverlayIsOpen,
-    paidOverlayTitle,
-    showPaidOverlay,
-    topupPaidNavTimerRef,
-  } = usePaidOverlayState({
-    t,
-  });
-
-  const finalizeTopupInvoicePaid = React.useCallback(
-    (args: { amountSat: number; gainedToken?: string | null }) => {
-      if (topupInvoicePaidHandledRef.current) return;
-
-      const amountSat = args.amountSat;
-      const topupInvoice = topupMintQuote?.invoice ?? null;
-      const topupInvoicePreview = topupInvoice
-        ? getLightningInvoicePreview(topupInvoice)
-        : null;
-
-      logPaymentEvent({
-        amount: amountSat,
-        details:
-          topupInvoice || args.gainedToken
-            ? {
-                ...(args.gainedToken ? { gainedToken: args.gainedToken } : {}),
-                ...(topupInvoice ? { lightningInvoice: topupInvoice } : {}),
-                ...(topupInvoicePreview?.description
-                  ? { lightningMemo: topupInvoicePreview.description }
-                  : {}),
-              }
-            : null,
-        direction: "in",
-        method: "lightning_invoice",
-        mint: topupMintQuote?.mintUrl ?? defaultMintUrl ?? null,
-        status: "ok",
-        unit: topupMintQuote?.unit ?? "sat",
-      });
-
-      topupInvoicePaidHandledRef.current = true;
-      topupInvoiceStartBalanceRef.current = null;
-      setTopupAmount("");
-      setTopupInvoice(null);
-      setTopupInvoiceQr(null);
-      setTopupInvoiceError(null);
-      setTopupInvoiceIsBusy(false);
-
-      const displayAmount = formatDisplayedAmountParts(amountSat);
-      showPaidOverlay(
-        t("topupOverlay")
-          .replace(
-            "{amount}",
-            `${displayAmount.approxPrefix}${displayAmount.amountText}`,
-          )
-          .replace("{unit}", displayAmount.unitLabel),
-      );
-
-      if (topupPaidNavTimerRef.current !== null) {
-        try {
-          window.clearTimeout(topupPaidNavTimerRef.current);
-        } catch {
-          // ignore
-        }
-      }
-
-      topupPaidNavTimerRef.current = window.setTimeout(() => {
-        topupPaidNavTimerRef.current = null;
-        navigateTo({ route: "wallet" });
-      }, 1400);
-    },
-    [
-      defaultMintUrl,
-      formatDisplayedAmountParts,
-      logPaymentEvent,
-      setTopupAmount,
-      setTopupInvoice,
-      setTopupInvoiceError,
-      setTopupInvoiceIsBusy,
-      setTopupInvoiceQr,
-      showPaidOverlay,
-      t,
-      topupMintQuote,
-      topupPaidNavTimerRef,
-    ],
-  );
-
-  // Default mint cross-tab + cross-device sync via Evolu `ownerMeta`.
-  //
-  // Background: the per-owner localStorage override
-  // (`linky.cashu.defaultMintOverride.v1.<owner>`) is tab-local, so other
-  // tabs (and other devices) don't see the change until reload. ownerMeta is
-  // an Evolu lane that already propagates via BroadcastChannel (same-origin
-  // tabs, instant) and via the Evolu sync server (other devices), so we
-  // mirror the default-mint value into it.
-  const ownerMetaDefaultMintRowId = React.useMemo(
-    () => Evolu.createIdFromString<"OwnerMeta">("owner-pointer-defaultMint"),
-    [],
-  );
-
-  const ownerMetaDefaultMintQuery = useMemo(
-    () =>
-      evolu.createQuery((db) =>
-        db
-          .selectFrom("ownerMeta")
-          .selectAll()
-          .where("isDeleted", "is not", Evolu.sqliteTrue)
-          .where(
-            "scope",
-            "=",
-            "defaultMint" as typeof Evolu.NonEmptyString100.Type,
-          ),
-      ),
-    [],
-  );
-  const ownerMetaDefaultMintRows = useQuery(ownerMetaDefaultMintQuery);
-
-  const ownerMetaDefaultMintValue = React.useMemo(() => {
-    for (const row of ownerMetaDefaultMintRows) {
-      if (typeof row !== "object" || row === null) continue;
-      if (!("value" in row)) continue;
-      const raw = String(row.value ?? "").trim();
-      if (!raw) continue;
-      const cleaned = normalizeMintUrl(raw);
-      if (cleaned) return cleaned;
-    }
-    return null;
-  }, [ownerMetaDefaultMintRows]);
-
-  // ownerMeta -> local state: when another tab/device wrote a different
-  // default mint, pick it up here. This is the ONLY direction watched as an
-  // effect. A symmetric `defaultMintUrl -> ownerMeta` watcher would
-  // ping-pong with the remote: in the same render where this effect queues
-  // setDefaultMintUrl(remoteValue), the symmetric effect would read the
-  // STALE local `defaultMintUrl` and upsert it back, racing with the remote
-  // value. Two devices in this state oscillate every few ms (visible in
-  // ownerMeta CRDT history). Explicit pushes happen instead from
-  // `upsertDefaultMintToOwnerMeta` called by user actions and the seed
-  // effect.
-  React.useEffect(() => {
-    if (!ownerMetaDefaultMintValue) return;
-    if (!appOwnerId) return;
-    const current = normalizeMintUrl(defaultMintUrl ?? "");
-    if (current === ownerMetaDefaultMintValue) return;
-    setDefaultMintUrl(ownerMetaDefaultMintValue);
-    setDefaultMintUrlDraft(ownerMetaDefaultMintValue);
-    hasMintOverrideRef.current = true;
-    try {
-      const overrideKey = makeLocalStorageKey(
-        CASHU_DEFAULT_MINT_OVERRIDE_STORAGE_KEY,
-      );
-      safeLocalStorageSet(overrideKey, ownerMetaDefaultMintValue);
-    } catch {
-      // ignore
-    }
-  }, [
-    appOwnerId,
-    defaultMintUrl,
-    makeLocalStorageKey,
-    ownerMetaDefaultMintValue,
-  ]);
-
-  const upsertDefaultMintToOwnerMeta = React.useCallback(
-    (mintUrl: string | null | undefined) => {
-      if (!metaOwnerId) return;
-      const cleaned = normalizeMintUrl(mintUrl ?? "");
-      if (!cleaned) return;
-      if (cleaned === ownerMetaDefaultMintValue) return;
-      upsert(
-        "ownerMeta",
-        {
-          id: ownerMetaDefaultMintRowId,
-          scope: "defaultMint" as typeof Evolu.NonEmptyString100.Type,
-          value: cleaned as typeof Evolu.NonEmptyString1000.Type,
-        },
-        { ownerId: metaOwnerId },
-      );
-    },
-    [metaOwnerId, ownerMetaDefaultMintRowId, ownerMetaDefaultMintValue, upsert],
-  );
-
   const onboardingTutorialOwnerId = isSeedLogin ? metaOwnerId : appOwnerId;
   const onboardingTutorialOwnerMetaQuery = useMemo(
     () =>
@@ -968,29 +471,6 @@ export const useAppShellComposition = () => {
       ownerId: onboardingTutorialOwnerId,
     });
   }, [contactsOnboardingDismissedSynced, onboardingTutorialOwnerId, upsert]);
-
-  const upsertDefaultMintToOwnerMetaRef = React.useRef(
-    upsertDefaultMintToOwnerMeta,
-  );
-  React.useEffect(() => {
-    upsertDefaultMintToOwnerMetaRef.current = upsertDefaultMintToOwnerMeta;
-  }, [upsertDefaultMintToOwnerMeta]);
-
-  const resolveOwnerIdForWrite = React.useCallback(async () => {
-    if (cashuOwnerIdRef.current) return cashuOwnerIdRef.current;
-    if (isSeedLogin) return null;
-    try {
-      const owner = await evolu.appOwner;
-      return owner?.id ?? null;
-    } catch {
-      return null;
-    }
-  }, [cashuOwnerIdRef, isSeedLogin]);
-
-  React.useEffect(() => {
-    if (!appOwnerId) return;
-    migrateLegacyPaymentEventsToEvolu(appOwnerId, transactionsOwnerId);
-  }, [appOwnerId, migrateLegacyPaymentEventsToEvolu, transactionsOwnerId]);
 
   const evoluHistoryAllowedOwnerIds = React.useMemo(() => {
     const ids = [
@@ -1029,43 +509,13 @@ export const useAppShellComposition = () => {
 
   const contactPayBackToChatRef = React.useRef<ContactId | null>(null);
 
-  useRouteAmountResetEffects({
-    contactPayBackToChatRef,
-    contactsHeaderVisible,
-    routeKind: route.kind,
-    setContactPaymentIntent,
-    setLnAddressPayAmount,
-    setPayAmount,
-  });
-
-  const topupRecipientNprofile = React.useMemo(() => {
-    try {
-      const decoded = nip19.decode(currentNpub ?? "");
-      if (decoded.type !== "npub" || typeof decoded.data !== "string") {
-        return null;
-      }
-      return nip19.nprofileEncode({
-        pubkey: decoded.data,
-        relays: NOSTR_RELAYS,
-      });
-    } catch {
-      return null;
-    }
-  }, [currentNpub]);
-
   useStatusToasts({
     pushToast,
     setStatus,
     status,
   });
 
-  const cashuTokensAllQuery = useMemo(
-    () =>
-      evolu.createQuery((db) =>
-        db.selectFrom("cashuToken").selectAll().orderBy("createdAt", "desc"),
-      ),
-    [],
-  );
+  const cashuTokensAllQuery = useMemo(createCashuTokensAllQuery, []);
   const cashuTokensAll = useQuery(cashuTokensAllQuery);
 
   const copyText = React.useCallback(
@@ -1253,592 +703,6 @@ export const useAppShellComposition = () => {
     upsert,
   });
 
-  useArmedDeleteTimeouts({
-    pendingCashuDeleteId,
-    pendingDeleteId,
-    pendingEvoluServerDeleteUrl,
-    pendingMintDeleteUrl,
-    setPendingCashuDeleteId,
-    setPendingDeleteId,
-    setPendingEvoluServerDeleteUrl,
-    setPendingMintDeleteUrl,
-  });
-
-  const activeCashuOwnerId = String(cashuOwnerId ?? "").trim();
-  const visibleCashuOwnerIds = React.useMemo(
-    () =>
-      new Set(
-        cashuVisibleOwnerIds
-          .map((ownerId) => String(ownerId ?? "").trim())
-          .filter(Boolean),
-      ),
-    [cashuVisibleOwnerIds],
-  );
-  const readCashuRowOwnerId = React.useCallback((row: unknown): string => {
-    if (typeof row !== "object" || row === null) return "";
-    if (!("ownerId" in row)) return "";
-    const ownerId = row.ownerId;
-    if (typeof ownerId !== "string") return "";
-    return ownerId.trim();
-  }, []);
-
-  const readCashuRowAliases = React.useCallback(
-    (row: { rawToken?: string | null; token?: string | null } | null) => {
-      return [
-        String(row?.rawToken ?? "").trim(),
-        String(row?.token ?? "").trim(),
-      ].filter(Boolean);
-    },
-    [],
-  );
-
-  const dedupeVisibleCashuRows = React.useCallback(
-    function dedupeVisibleCashuRows<
-      TRow extends {
-        id?: string | null;
-        isDeleted?: unknown;
-        ownerId?: unknown;
-        rawToken?: string | null;
-        state?: unknown;
-        token?: string | null;
-      },
-    >(rows: readonly TRow[]): TRow[] {
-      if (visibleCashuOwnerIds.size === 0) return [];
-
-      const ownerRank = new Map<string, number>();
-      let rank = 0;
-      for (const normalizedOwnerId of visibleCashuOwnerIds) {
-        if (!normalizedOwnerId || ownerRank.has(normalizedOwnerId)) continue;
-        ownerRank.set(normalizedOwnerId, rank);
-        rank += 1;
-      }
-
-      const canonicalByAlias = new Map<string, string>();
-      const bestByCanonical = new Map<string, TRow>();
-      const readRowCandidates = (row: TRow): string[] => {
-        const id = String(row.id ?? "").trim();
-        return id
-          ? [id, ...readCashuRowAliases(row)]
-          : readCashuRowAliases(row);
-      };
-
-      const isCandidateBetter = (candidate: TRow, existing: TRow): boolean => {
-        return isCashuRowCandidateBetter({
-          activeOwnerId: activeCashuOwnerId,
-          candidate,
-          existing,
-          ownerRank,
-        });
-      };
-
-      for (const row of rows) {
-        const ownerId = readCashuRowOwnerId(row);
-        if (!visibleCashuOwnerIds.has(ownerId)) continue;
-
-        const rowCandidates = readRowCandidates(row);
-        if (rowCandidates.length === 0) continue;
-
-        const canonicalKey =
-          rowCandidates.find((candidate) => canonicalByAlias.has(candidate)) ??
-          rowCandidates[0];
-        const existing = bestByCanonical.get(canonicalKey);
-
-        if (!existing || isCandidateBetter(row, existing)) {
-          bestByCanonical.set(canonicalKey, row);
-        }
-
-        for (const candidate of rowCandidates) {
-          canonicalByAlias.set(candidate, canonicalKey);
-        }
-      }
-
-      return rows.filter((row) => {
-        const rowCandidates = readRowCandidates(row);
-        if (rowCandidates.length === 0) return false;
-
-        const canonicalKey =
-          rowCandidates.find((candidate) => canonicalByAlias.has(candidate)) ??
-          rowCandidates[0];
-        return bestByCanonical.get(canonicalKey) === row;
-      });
-    },
-    [
-      activeCashuOwnerId,
-      readCashuRowAliases,
-      readCashuRowOwnerId,
-      visibleCashuOwnerIds,
-    ],
-  );
-
-  const cashuTokensAllFiltered = React.useMemo(() => {
-    return dedupeVisibleCashuRows(cashuTokensAll);
-  }, [cashuTokensAll, dedupeVisibleCashuRows]);
-
-  const cashuTokensFiltered = React.useMemo(
-    () => cashuTokensAllFiltered.filter((row) => !row.isDeleted),
-    [cashuTokensAllFiltered],
-  );
-
-  const cashuTokensWithMeta = useMemo(
-    () =>
-      cashuTokensFiltered.flatMap((row) => {
-        const meta = extractCashuTokenMeta({
-          amount: row.amount,
-          mint: row.mint,
-          rawToken: row.rawToken,
-          token: row.token,
-          unit: row.unit,
-        });
-        const amount = meta.amount ?? 0;
-        if (amount <= 0) return [];
-
-        return [
-          {
-            ...row,
-            mint: meta.mint ?? null,
-            unit: meta.unit ?? null,
-            amount,
-            tokenText: meta.tokenText,
-          },
-        ];
-      }),
-    [cashuTokensFiltered],
-  );
-
-  const {
-    cashuTokensHydratedRef,
-    ensureCashuTokenPersisted,
-    isCashuTokenKnownAny,
-    isCashuTokenStored,
-    rememberCashuTokenKnown,
-  } = useCashuDomain({
-    appOwnerId: cashuOwnerId,
-    appOwnerIdRef: cashuOwnerIdRef,
-    cashuTokensAll,
-    upsert,
-    logPaymentEvent,
-  });
-
-  const migratedMisplacedCashuTokenIdsRef = React.useRef<Set<string>>(
-    new Set(),
-  );
-
-  React.useEffect(() => {
-    if (!appOwnerId) return;
-
-    const sourceOwnerId = String(appOwnerId ?? "").trim();
-    if (!sourceOwnerId) return;
-    if (!activeCashuOwnerId) return;
-    if (sourceOwnerId === activeCashuOwnerId) return;
-    if (!cashuOwnerId) return;
-
-    const activeRows = cashuTokensAll.filter((row) => {
-      if (row.isDeleted) return false;
-      return readCashuRowOwnerId(row) === activeCashuOwnerId;
-    });
-
-    const hasActiveDuplicate = (row: (typeof cashuTokensAll)[number]) => {
-      const identityToken = String(row.rawToken ?? row.token ?? "").trim();
-      const rowCandidates = [
-        String(row.id ?? "").trim(),
-        identityToken ? String(createCashuTokenId(identityToken)) : "",
-        String(row.rawToken ?? "").trim(),
-        String(row.token ?? "").trim(),
-      ].filter(Boolean);
-      if (rowCandidates.length === 0) return false;
-
-      return activeRows.some((activeRow) => {
-        const activeIdentityToken = String(
-          activeRow.rawToken ?? activeRow.token ?? "",
-        ).trim();
-        const activeCandidates = [
-          String(activeRow.id ?? "").trim(),
-          activeIdentityToken
-            ? String(createCashuTokenId(activeIdentityToken))
-            : "",
-          String(activeRow.rawToken ?? "").trim(),
-          String(activeRow.token ?? "").trim(),
-        ].filter(Boolean);
-
-        return rowCandidates.some((candidate) =>
-          activeCandidates.includes(candidate),
-        );
-      });
-    };
-
-    const misplacedRows = cashuTokensAll.filter((row) => {
-      if (row.isDeleted) return false;
-      return readCashuRowOwnerId(row) === sourceOwnerId;
-    });
-
-    for (const row of misplacedRows) {
-      const rowId = String(row.id ?? "").trim();
-      if (!rowId) continue;
-      if (migratedMisplacedCashuTokenIdsRef.current.has(rowId)) continue;
-
-      if (!hasActiveDuplicate(row)) {
-        const token = String(row.token ?? row.rawToken ?? "").trim();
-        const rawToken = String(row.rawToken ?? "").trim();
-        const state = String(row.state ?? "").trim() || "accepted";
-        const error = String(row.error ?? "").trim();
-
-        if (token) {
-          const payload: {
-            id: CashuTokenId;
-            token: typeof Evolu.NonEmptyString.Type;
-            state: typeof Evolu.NonEmptyString100.Type;
-            error?: typeof Evolu.NonEmptyString1000.Type;
-          } = {
-            id: createCashuTokenId(rawToken || token),
-            token: token as typeof Evolu.NonEmptyString.Type,
-            state: state as typeof Evolu.NonEmptyString100.Type,
-          };
-
-          if (error) {
-            payload.error = error as typeof Evolu.NonEmptyString1000.Type;
-          }
-
-          const insertResult = upsert("cashuToken", payload, {
-            ownerId: cashuOwnerId,
-          });
-          if (!insertResult.ok) continue;
-        }
-      }
-
-      migratedMisplacedCashuTokenIdsRef.current.add(rowId);
-
-      update(
-        "cashuToken",
-        {
-          id: row.id as CashuTokenId,
-          isDeleted: Evolu.sqliteTrue,
-        },
-        { ownerId: appOwnerId },
-      );
-    }
-  }, [
-    activeCashuOwnerId,
-    appOwnerId,
-    cashuOwnerId,
-    cashuTokensAll,
-    upsert,
-    readCashuRowOwnerId,
-    update,
-  ]);
-
-  React.useEffect(() => {
-    if (!topupMintQuote) return;
-
-    let cancelled = false;
-    let claimInFlight = false;
-    let lastLoggedClaimError = "";
-    // Cache the loaded wallet across the 5s polling ticks within this
-    // effect mount. Each tick only does a `checkMintQuote` + the eventual
-    // mintProofs, neither of which needs a fresh `loadMint()`. The effect
-    // tears down when topupMintQuote changes, so the cache is naturally
-    // scoped to one quote / one mintUrl+unit pair.
-    let cachedWallet: LoadedCashuWallet | null = null;
-    const run = async () => {
-      if (claimInFlight) return;
-      claimInFlight = true;
-      try {
-        const quoteId = String(topupMintQuote.quote ?? "").trim();
-        if (!quoteId) return;
-
-        const topupOwnerKey = String(appOwnerId ?? "anon");
-        const claimStorageKey = makeClaimedTopupQuoteStorageKey({
-          ownerId: topupOwnerKey,
-          mintUrl: topupMintQuote.mintUrl,
-          quote: quoteId,
-        });
-        const claimLockKey = makeClaimedTopupQuoteLockKey({
-          ownerId: topupOwnerKey,
-          mintUrl: topupMintQuote.mintUrl,
-          quote: quoteId,
-        });
-
-        const insertClaimedTopupToken = async (
-          claimed: ClaimedTopupQuoteStorage,
-        ) => {
-          if (isCashuTokenKnownAny(claimed.token)) return true;
-
-          const ownerId = await resolveOwnerIdForWrite();
-          const payload = {
-            id: createCashuTokenId(claimed.token),
-            token: claimed.token as typeof Evolu.NonEmptyString.Type,
-            state: "accepted" as typeof Evolu.NonEmptyString100.Type,
-          };
-
-          const result = ownerId
-            ? upsert("cashuToken", payload, { ownerId })
-            : upsert("cashuToken", payload);
-          if (!result.ok) {
-            setStatus(
-              `${t("errorPrefix")}: ${getUnknownErrorMessage(result.error, "unknown")}`,
-            );
-            return false;
-          }
-
-          return true;
-        };
-
-        const claimedBeforeRun =
-          readClaimedTopupQuoteFromStorage(claimStorageKey);
-        if (claimedBeforeRun) {
-          const restored = await insertClaimedTopupToken(claimedBeforeRun);
-          if (restored && !cancelled) {
-            if (route.kind === "topupInvoice" && claimedBeforeRun.amount > 0) {
-              finalizeTopupInvoicePaid({
-                amountSat: claimedBeforeRun.amount,
-                gainedToken: claimedBeforeRun.token,
-              });
-            }
-            setTopupMintQuote(null);
-          }
-          return;
-        }
-
-        const { Mint, Wallet, MintQuoteState, getEncodedToken } =
-          await getCashuLib();
-        await withLocalStorageLeaseLock({
-          key: claimLockKey,
-          ttlMs: 15_000,
-          timeoutMs: 2_000,
-          waitMs: 50,
-          fn: async () => {
-            const alreadyClaimed =
-              readClaimedTopupQuoteFromStorage(claimStorageKey);
-            if (alreadyClaimed) {
-              const restored = await insertClaimedTopupToken(alreadyClaimed);
-              if (restored && !cancelled) {
-                if (
-                  route.kind === "topupInvoice" &&
-                  alreadyClaimed.amount > 0
-                ) {
-                  finalizeTopupInvoicePaid({
-                    amountSat: alreadyClaimed.amount,
-                    gainedToken: alreadyClaimed.token,
-                  });
-                }
-                setTopupMintQuote(null);
-              }
-              return;
-            }
-
-            let wallet = cachedWallet;
-            if (!wallet) {
-              const det = getCashuDeterministicSeedFromStorage();
-              wallet = await createLoadedCashuWallet({
-                Mint,
-                Wallet,
-                mintUrl: topupMintQuote.mintUrl,
-                ...(topupMintQuote.unit ? { unit: topupMintQuote.unit } : {}),
-                ...(det ? { bip39seed: det.bip39seed } : {}),
-              });
-              cachedWallet = wallet;
-            }
-
-            const status = await wallet.checkMintQuoteBolt11(quoteId);
-            const quoteState = readMintQuoteState(status);
-            if (!isClaimableMintQuoteState(quoteState, MintQuoteState)) {
-              return;
-            }
-
-            const unit = wallet.unit ?? topupMintQuote.unit ?? null;
-            const proofs = await mintTopupProofs({
-              amount: topupMintQuote.amount,
-              mintUrl: topupMintQuote.mintUrl,
-              quoteId,
-              unit,
-              wallet,
-            });
-            const token = String(
-              getEncodedToken({
-                mint: topupMintQuote.mintUrl,
-                proofs,
-                ...(unit ? { unit } : {}),
-              }) ?? "",
-            ).trim();
-            if (!token) throw new Error("Mint produced empty token");
-
-            safeLocalStorageSetJson(claimStorageKey, {
-              amount: topupMintQuote.amount,
-              claimedAtMs: Date.now(),
-              mintUrl: topupMintQuote.mintUrl,
-              quote: quoteId,
-              token,
-              unit,
-            });
-
-            if (!isCashuTokenKnownAny(token)) {
-              const ownerId = await resolveOwnerIdForWrite();
-              const payload = {
-                id: createCashuTokenId(token),
-                token: token as typeof Evolu.NonEmptyString.Type,
-                state: "accepted" as typeof Evolu.NonEmptyString100.Type,
-              };
-
-              const result = ownerId
-                ? upsert("cashuToken", payload, { ownerId })
-                : upsert("cashuToken", payload);
-              if (!result.ok) {
-                setStatus(
-                  `${t("errorPrefix")}: ${getUnknownErrorMessage(result.error, "unknown")}`,
-                );
-                return;
-              }
-            }
-
-            if (route.kind === "topupInvoice") {
-              finalizeTopupInvoicePaid({
-                amountSat: topupMintQuote.amount,
-                gainedToken: token,
-              });
-            } else {
-              const displayAmount = formatDisplayedAmountParts(
-                topupMintQuote.amount,
-              );
-              showPaidOverlay(
-                t("topupOverlay")
-                  .replace(
-                    "{amount}",
-                    `${displayAmount.approxPrefix}${displayAmount.amountText}`,
-                  )
-                  .replace("{unit}", displayAmount.unitLabel),
-              );
-            }
-
-            if (!cancelled) setTopupMintQuote(null);
-          },
-        });
-      } catch (error) {
-        const message = getUnknownErrorMessage(error, "unknown");
-        const errorKey = `${topupMintQuote.mintUrl}:${message}`;
-        if (errorKey !== lastLoggedClaimError) {
-          lastLoggedClaimError = errorKey;
-          console.warn("[linky][topup] mint claim failed", {
-            error: message,
-            likelyCors: isLikelyCorsOrNetworkError(message),
-            mintUrl: topupMintQuote.mintUrl,
-            route: route.kind,
-          });
-        }
-        if (
-          shouldKeepTopupQuoteAfterClaimError(
-            error,
-            (e: unknown) =>
-              isCashuOutputsAlreadySignedError(e) ||
-              isCashuOutputsArePendingError(e),
-          )
-        ) {
-          setStatus(`${t("restoreFailed")}: ${message}`);
-        } else if (isCashuOutputsAlreadySignedError(error) && !cancelled) {
-          // Recovery already ran inside mintTopupProofs. Drop the pending
-          // quote so the 5s tick stops re-issuing the same failing mint
-          // call against the same deterministic counter.
-          setTopupMintQuote(null);
-        }
-      } finally {
-        claimInFlight = false;
-      }
-    };
-
-    void run();
-    const intervalId = window.setInterval(() => {
-      void run();
-    }, 5000);
-    const runWhenVisible = () => {
-      if (
-        typeof document !== "undefined" &&
-        document.visibilityState === "hidden"
-      ) {
-        return;
-      }
-      void run();
-    };
-
-    window.addEventListener("focus", runWhenVisible);
-    window.addEventListener("pageshow", runWhenVisible);
-    window.addEventListener("online", runWhenVisible);
-    document.addEventListener("visibilitychange", runWhenVisible);
-
-    return () => {
-      cancelled = true;
-      window.clearInterval(intervalId);
-      window.removeEventListener("focus", runWhenVisible);
-      window.removeEventListener("pageshow", runWhenVisible);
-      window.removeEventListener("online", runWhenVisible);
-      document.removeEventListener("visibilitychange", runWhenVisible);
-    };
-  }, [
-    appOwnerId,
-    formatDisplayedAmountParts,
-    finalizeTopupInvoicePaid,
-    upsert,
-    isCashuTokenKnownAny,
-    resolveOwnerIdForWrite,
-    topupMintQuote,
-    t,
-    route.kind,
-    showPaidOverlay,
-    setStatus,
-  ]);
-
-  const {
-    getMintIconUrl,
-    getMintRuntime,
-    isMintDeleted,
-    mintInfoByUrl,
-    mintInfoDeduped,
-    refreshMintInfo,
-    setMintIconUrlByMint,
-    setMintInfoAll,
-    touchMintInfo,
-  } = useMintDomain({
-    appOwnerId,
-    appOwnerIdRef,
-    cashuTokensAll: cashuTokensAllFiltered,
-    defaultMintUrl,
-    rememberSeenMint,
-  });
-
-  // Tutorial progress remains local-only.
-
-  React.useEffect(() => {
-    if (!import.meta.env.DEV) return;
-
-    try {
-      if (localStorage.getItem("linky_debug_evolu_snapshot") !== "1") return;
-    } catch {
-      return;
-    }
-
-    // Debug: log Evolu state without secrets.
-    // NOTE: Relays and derived npub are Nostr/runtime state, not stored in Evolu.
-    console.log("[linky][evolu] snapshot", {
-      nostrIdentity: {
-        hasNsec: Boolean(currentNsec),
-        hasNpub: Boolean(currentNpub),
-      },
-      cashuTokens: cashuTokensFiltered.map((t) => ({
-        id: String(t.id ?? ""),
-        mint: String(t.mint ?? ""),
-        amount: Number(t.amount ?? 0) || 0,
-        state: String(t.state ?? ""),
-      })),
-      cashuTokensAll: {
-        count: cashuTokensAllFiltered.length,
-        newest10: cashuTokensAllFiltered.slice(0, 10).map((t) => ({
-          id: String(t.id ?? ""),
-          mint: String(t.mint ?? ""),
-          amount: Number(t.amount ?? 0) || 0,
-          state: String(t.state ?? ""),
-          isDeleted: Boolean(t.isDeleted),
-        })),
-      },
-    });
-  }, [cashuTokensAllFiltered, cashuTokensFiltered, currentNpub, currentNsec]);
-
   React.useEffect(() => {
     appendIdentityChangeNoticesRef.current = ({
       changedAtSec,
@@ -1880,222 +744,6 @@ export const useAppShellComposition = () => {
     lastMessageByContactId,
   ]);
 
-  React.useEffect(() => {
-    const pendingTokens = cashuTokensAllFiltered.filter((row) => {
-      const state = String(row.state ?? "");
-      if (state !== "pending") return false;
-      const isDeleted = Boolean(row.isDeleted);
-      return !isDeleted;
-    });
-    if (pendingTokens.length === 0) return;
-
-    for (const row of pendingTokens) {
-      const tokenText = String(row.token ?? row.rawToken ?? "").trim();
-      if (!tokenText) continue;
-      const hasMessage = nostrMessagesLocal.some((m) => {
-        const isOut = String(m.direction ?? "") === "out";
-        const matches = String(m.content ?? "").trim() === tokenText;
-        const status = String(m.status ?? "sent");
-        return isOut && matches && status !== "pending";
-      });
-      if (!hasMessage) continue;
-      const payload = {
-        id: row.id as CashuTokenId,
-        isDeleted: Evolu.sqliteTrue,
-      };
-      // Target the lane that holds the row (Evolu keys rows by (ownerId, id));
-      // deleting under the active lane no-ops on rows in older cashu-n lanes.
-      const rowOwnerId = resolveCashuRowStoredOwnerLane(row) ?? cashuOwnerId;
-      if (rowOwnerId) {
-        update("cashuToken", payload, { ownerId: rowOwnerId });
-      } else {
-        update("cashuToken", payload);
-      }
-    }
-  }, [cashuOwnerId, cashuTokensAllFiltered, nostrMessagesLocal, update]);
-
-  // lastMessageByContactId provided by the derived Nostr index above.
-
-  const cashuTotalBalance = useMemo(() => {
-    return cashuTokensWithMeta.reduce((sum, token) => {
-      if (!isCashuTokenAcceptedState(token.state)) return sum;
-      const amount = Number(token.amount ?? 0);
-      return sum + (Number.isFinite(amount) ? amount : 0);
-    }, 0);
-  }, [cashuTokensWithMeta]);
-
-  const cashuAcceptedMintBalances = useMemo(() => {
-    const balances = new Map<string, number>();
-    for (const token of cashuTokensWithMeta) {
-      if (!isCashuTokenAcceptedState(token.state)) continue;
-
-      const mint = normalizeMintUrl(String(token.mint ?? "").trim());
-      if (!mint) continue;
-
-      const amount = Number(token.amount ?? 0);
-      const nextAmount = Number.isFinite(amount) && amount > 0 ? amount : 0;
-      balances.set(mint, (balances.get(mint) ?? 0) + nextAmount);
-    }
-
-    return balances;
-  }, [cashuTokensWithMeta]);
-
-  const cashuBalance = useMemo(() => {
-    let largestBalance = 0;
-    for (const balance of cashuAcceptedMintBalances.values()) {
-      if (balance > largestBalance) largestBalance = balance;
-    }
-
-    return largestBalance;
-  }, [cashuAcceptedMintBalances]);
-
-  const paymentMintMeltPlan = React.useMemo(() => {
-    return getPaymentMintMeltPlan({
-      mainMint: normalizeMintUrl(defaultMintUrl ?? MAIN_MINT_URL),
-      balances: Array.from(cashuAcceptedMintBalances, ([mint, sum]) => ({
-        mint,
-        sum,
-      })),
-    });
-  }, [cashuAcceptedMintBalances, defaultMintUrl]);
-
-  const cashuBalanceAfterMelt = Math.max(
-    cashuBalance,
-    paymentMintMeltPlan?.maxBalanceAfterMelt ?? 0,
-  );
-
-  const requestPaymentMintMelt = React.useCallback(
-    (amountSat: number): boolean => {
-      if (
-        !canOfferPaymentMintMelt({
-          amountSat,
-          currentBalance: cashuBalance,
-          plan: paymentMintMeltPlan,
-        }) ||
-        !paymentMintMeltPlan
-      ) {
-        return false;
-      }
-
-      setPendingPaymentMintMeltConfirmation({
-        fromMint: paymentMintMeltPlan.fromMint,
-        toMint: paymentMintMeltPlan.toMint,
-      });
-      return true;
-    },
-    [cashuBalance, paymentMintMeltPlan],
-  );
-
-  const cashuHasMultipleAcceptedMints = cashuAcceptedMintBalances.size > 1;
-
-  const cashuOwnTokens = React.useMemo(
-    () =>
-      cashuTokensWithMeta.filter(
-        (token) =>
-          !isCashuTokenEmittedState(token.state) &&
-          !isCashuTokenReservedState(token.state),
-      ),
-    [cashuTokensWithMeta],
-  );
-
-  const cashuIssuedTokens = React.useMemo(
-    () =>
-      cashuTokensWithMeta.filter(
-        (token) =>
-          isCashuTokenEmittedState(token.state) ||
-          isCashuTokenReservedState(token.state),
-      ),
-    [cashuTokensWithMeta],
-  );
-
-  const cashuOwnSpentTokens = React.useMemo(
-    () =>
-      cashuOwnTokens.filter((token) =>
-        isCashuTokenDefinitivelySpent({
-          state: token.state,
-          error: token.error,
-        }),
-      ),
-    [cashuOwnTokens],
-  );
-
-  const [deleteSpentCashuTokensIsBusy, setDeleteSpentCashuTokensIsBusy] =
-    useState(false);
-  const deleteSpentCashuTokens = React.useCallback(async () => {
-    if (deleteSpentCashuTokensIsBusy) return;
-    const targets = cashuOwnSpentTokens.filter((token) => Boolean(token.id));
-    if (targets.length === 0) return;
-
-    setDeleteSpentCashuTokensIsBusy(true);
-    try {
-      const fallbackOwnerId = await resolveOwnerIdForWrite();
-      let deleted = 0;
-      for (const token of targets) {
-        const payload = {
-          id: token.id as CashuTokenId,
-          isDeleted: Evolu.sqliteTrue,
-        };
-        // Delete in the row's own lane; Evolu keys rows by (ownerId, id) so a
-        // delete under the active lane silently misses rows in older lanes.
-        const ownerId =
-          resolveCashuRowStoredOwnerLane(token) ?? fallbackOwnerId;
-        const result = ownerId
-          ? update("cashuToken", payload, { ownerId })
-          : update("cashuToken", payload);
-        if (result.ok) deleted += 1;
-      }
-      if (deleted > 0) {
-        setStatus(
-          t("cashuDeleteSpentDone").replace("{count}", String(deleted)),
-        );
-      }
-    } finally {
-      setDeleteSpentCashuTokensIsBusy(false);
-    }
-  }, [
-    cashuOwnSpentTokens,
-    deleteSpentCashuTokensIsBusy,
-    resolveOwnerIdForWrite,
-    setStatus,
-    t,
-    update,
-  ]);
-
-  const canPayWithCashu = cashuBalance > 0;
-
-  React.useEffect(() => {
-    if (route.kind !== "topupInvoice") return;
-    if (topupInvoiceIsBusy) return;
-    if (!topupInvoice || !topupInvoiceQr) return;
-
-    const amountSat = Number.parseInt(topupAmount.trim(), 10);
-    if (!Number.isFinite(amountSat) || amountSat <= 0) return;
-
-    if (topupInvoiceStartBalanceRef.current === null) {
-      topupInvoiceStartBalanceRef.current = cashuTotalBalance;
-      return;
-    }
-
-    if (topupInvoicePaidHandledRef.current) return;
-
-    const start = topupInvoiceStartBalanceRef.current ?? 0;
-    const expected = start + amountSat;
-    if (cashuTotalBalance < expected) return;
-
-    finalizeTopupInvoicePaid({ amountSat });
-  }, [
-    cashuTotalBalance,
-    finalizeTopupInvoicePaid,
-    formatDisplayedAmountParts,
-    route.kind,
-    showPaidOverlay,
-    t,
-    topupAmount,
-    topupInvoice,
-    topupInvoiceIsBusy,
-    topupPaidNavTimerRef,
-    topupInvoiceQr,
-  ]);
   const [pendingDeepLinkText, setPendingDeepLinkText] = React.useState<
     string | null
   >(() => {
@@ -2120,11 +768,6 @@ export const useAppShellComposition = () => {
     },
     [],
   );
-
-  const [postPaySaveContact, setPostPaySaveContact] = React.useState<null | {
-    lnAddress: string;
-    amountSat: number;
-  }>(null);
 
   const {
     cycleProfileAvatarControl,
@@ -2184,30 +827,209 @@ export const useAppShellComposition = () => {
     t,
   });
 
-  useTopupInvoiceQuoteEffects({
+  const {
+    applyDefaultMintSelection,
+    canPayWithCashu,
+    cancelPendingCashuContactSend,
+    cashuAutoswapEnabled,
+    cashuBalance,
+    cashuBalanceAfterMelt,
+    cashuBulkCheckIsBusy,
+    cashuDraft,
+    cashuDraftRef,
+    cashuEmitAmount,
+    cashuHasMultipleAcceptedMints,
+    cashuIsBusy,
+    cashuIssuedTokens,
+    cashuMeltToMainMintButtonLabel,
+    cashuOwnSpentTokens,
+    cashuOwnTokens,
+    cashuTokensAllFiltered,
+    cashuTokensFiltered,
+    cashuTokensHydratedRef,
+    cashuTotalBalance,
+    checkAllCashuTokensAndDeleteInvalid,
+    checkAndRefreshCashuToken,
+    checkIssuedCashuTokensAndDeleteClaimed,
+    checkSingleIssuedCashuTokenIsClaimed,
+    closeLightningInvoiceConfirmation,
+    closeLnurlWithdrawConfirmation,
+    closeMintAutoswapChangeConfirmation,
+    closePaymentMintMeltConfirmation,
+    confirmLightningInvoicePayment,
+    confirmLnurlWithdraw,
+    confirmMintAutoswapChangeConfirmation,
+    confirmPaymentMintMelt,
+    contactPayMethod,
+    defaultMintDisplay,
     defaultMintUrl,
-    effectiveMyLightningAddress,
-    routeKind: route.kind,
-    t,
+    defaultMintUrlDraft,
+    deleteSpentCashuTokens,
+    deleteSpentCashuTokensIsBusy,
+    dismissWalletWarning,
+    emitCashuToken,
+    getCashuTokenMessageInfo,
+    getMintIconUrl,
+    getMintRuntime,
+    handleMintIconError,
+    handleMintIconLoad,
+    isCashuTokenKnownAny,
+    isCashuTokenStored,
+    knownLnAddressPayContact,
+    knownLnAddressPayContactPictureUrl,
+    lightningInvoiceAutoPayLimit,
+    lnAddressPayAmount,
+    lnurlWithdrawIsBusy,
+    makeNip98AuthHeader,
+    markCashuTokenIssued,
+    meltLargestForeignMintToMainMint,
+    mintInfoByUrl,
+    onPayChatPaymentRequest,
+    paidOverlayIsOpen,
+    paidOverlayTitle,
+    payCashuPaymentRequest,
+    payLightningAddressWithCashu,
+    payLightningInvoiceWithCashu,
+    paySelectedContact,
+    payWithCashuEnabled,
+    pendingCashuContactSend,
+    pendingCashuDeleteId,
+    pendingCashuTokenContactPickId,
+    pendingLightningInvoiceConfirmation,
+    pendingLnurlWithdrawConfirmation,
+    pendingMintAutoswapChangeConfirmation,
+    pendingMintDeleteUrl,
+    pendingPaymentMintMeltConfirmation,
+    postPaySaveContact,
+    refreshMintInfo,
+    requestDeleteCashuToken,
+    requestSelectedContact,
+    reserveCashuToken,
+    restoreMissingTokens,
+    returnCashuTokenToWallet,
+    saveCashuFromText,
+    sendCashuTokenToContact,
+    setCashuAutoswapEnabled,
+    setCashuDraft,
+    setCashuEmitAmount,
+    setContactPayMethod,
+    setDefaultMintUrlDraft,
+    setLightningInvoiceAutoPayLimit,
+    setLnAddressPayAmount,
+    setMintIconUrlByMint,
+    setMintInfoAll,
+    setPayWithCashuEnabled,
+    setPendingCashuDeleteId,
+    setPendingLightningInvoiceConfirmation,
+    setPendingLnurlWithdrawConfirmation,
+    setPendingMintDeleteUrl,
+    setPostPaySaveContact,
+    setTopupAmount,
+    settleBankPaymentOffer,
+    showPaidOverlay,
+    startSendCashuTokenToContact,
+    tokensRestoreIsBusy,
     topupAmount,
     topupInvoice,
+    topupInvoiceCashuRequest,
     topupInvoiceError,
     topupInvoiceIsBusy,
-    topupInvoicePaidHandledRef,
     topupInvoiceQr,
-    topupInvoiceStartBalanceRef,
+    topupInvoiceQrPayload,
     topupMintQuote,
-    topupPaidNavTimerRef,
-    topupRefreshKey: myProfileName,
-    topupRecipientNprofile,
-    setTopupAmount,
-    setTopupInvoice,
-    setTopupInvoiceCashuRequest,
-    setTopupInvoiceError,
-    setTopupInvoiceIsBusy,
-    setTopupInvoiceQr,
-    setTopupInvoiceQrPayload,
-    setTopupMintQuote,
+    walletWarningApplies,
+    walletWarningDismissed,
+  } = useCashuWalletComposition({
+    cashuTokensAll,
+    contactPayBackToChatRef,
+    contactsHeaderVisible,
+    contactsMessaging: {
+      activeContactsOwnerContactCount,
+      activeNostrMessagePublishClientIdsRef,
+      appendLocalNostrMessage,
+      buildSavedContactName,
+      chatMessages,
+      chatSeenWrapIdsRef,
+      contacts,
+      enqueuePendingPayment,
+      isBankPaymentOfferCanceled,
+      nostrBootstrapReady,
+      nostrMessagesLocal,
+      nostrMessagesRecent,
+      nostrPictureByNpub,
+      openScannedContactPendingNpubRef,
+      pendingPayments,
+      publishSingleWrappedWithRetry,
+      publishWrappedWithRetry,
+      removePendingPayment,
+      respondToBankPaymentOfferWithGroupState,
+      selectedChatContact,
+      selectedContact,
+      sendChatMessage,
+      setContactsOnboardingHasPaid,
+      unknownNameByNpub,
+      updateLocalNostrMessage,
+    },
+    formatDisplayedAmountParts,
+    formatDisplayedAmountText,
+    identity: {
+      appOwnerId,
+      appOwnerIdRef,
+      cashuOwnerId,
+      cashuOwnerIdRef,
+      cashuVisibleOwnerIds,
+      contactsOwnerId,
+      currentNpub,
+      currentNsec,
+      isSeedLogin,
+      metaOwnerId,
+      recordContactsOwnerWrite,
+      transactionsOwnerId,
+    },
+    insert,
+    lang,
+    maybeShowPwaNotification,
+    ownerScopedStorage: {
+      logPaymentEvent,
+      makeLocalStorageKey,
+      migrateLegacyPaymentEventsToEvolu,
+      readSeenMintsFromStorage,
+      rememberSeenMint,
+    },
+    payAmount,
+    profile: {
+      effectiveMyLightningAddress,
+      myProfileName,
+      npubCashInfoInFlightRef,
+      npubCashInfoLoadedAtMsRef,
+      npubCashInfoLoadedForNpubRef,
+      npubCashServerBaseUrl,
+      ownedProfileLightningAddresses,
+      profileClaimLightningAddressServerBaseUrl,
+      setIsProfileEditing,
+      setMyProfileQr,
+      setOwnedProfileLightningAddresses,
+      setOwnedProfileLightningAddressesLoading,
+    },
+    pushToast,
+    route,
+    setContactPaymentIntent,
+    setPayAmount,
+    setStatus,
+    t,
+    update,
+    upsert,
+  });
+
+  useArmedDeleteTimeouts({
+    pendingCashuDeleteId,
+    pendingDeleteId,
+    pendingEvoluServerDeleteUrl,
+    pendingMintDeleteUrl,
+    setPendingCashuDeleteId,
+    setPendingDeleteId,
+    setPendingEvoluServerDeleteUrl,
+    setPendingMintDeleteUrl,
   });
 
   useAppPreferences({
@@ -2219,218 +1041,6 @@ export const useAppShellComposition = () => {
     lightningInvoiceAutoPayLimit,
     payWithCashuEnabled,
     showProfileQrOnTiltEnabled,
-  });
-
-  const defaultMintDisplay = useMemo(() => {
-    if (!defaultMintUrl) return null;
-    try {
-      const u = new URL(defaultMintUrl);
-      return u.host;
-    } catch {
-      return defaultMintUrl;
-    }
-  }, [defaultMintUrl]);
-
-  const currentMainMintAcceptedBalance = React.useMemo(() => {
-    const currentMainMint = normalizeMintUrl(defaultMintUrl ?? MAIN_MINT_URL);
-    if (!currentMainMint) return 0;
-
-    let sum = 0;
-    for (const row of cashuTokensWithMeta) {
-      if (!isCashuTokenAcceptedState(row.state)) continue;
-
-      const mint = normalizeMintUrl(String(row.mint ?? "").trim());
-      if (mint !== currentMainMint) continue;
-
-      const amount = Number(row.amount ?? 0);
-      if (Number.isFinite(amount) && amount > 0) {
-        sum += amount;
-      }
-    }
-
-    return sum;
-  }, [cashuTokensWithMeta, defaultMintUrl]);
-
-  const {
-    applyDefaultMintSelection: applyDefaultMintSelectionInner,
-    makeNip98AuthHeader,
-  } = useNpubCashMintSelection({
-    cashuAutoswapEnabled,
-    currentMainMintAcceptedBalance,
-    currentNpub,
-    currentNsec,
-    defaultMintUrl,
-    defaultMintUrlDraft,
-    hasMintOverrideRef,
-    makeLocalStorageKey,
-    npubCashServerBaseUrl,
-    ownedLightningAddresses: ownedProfileLightningAddresses,
-    profileClaimLightningAddressServerBaseUrl,
-    npubCashMintSyncRef,
-    pushToast,
-    requestMintAutoswapChangeConfirmation: React.useCallback(
-      (args: { fromMint: string; toMint: string }) => {
-        pendingMintAutoswapChangeResolverRef.current?.(false);
-        return new Promise<boolean>((resolve) => {
-          pendingMintAutoswapChangeResolverRef.current = resolve;
-          setPendingMintAutoswapChangeConfirmation(args);
-        });
-      },
-      [],
-    ),
-    setCashuAutoswapEnabled,
-    setDefaultMintUrl,
-    setDefaultMintUrlDraft,
-    setStatus,
-    t,
-  });
-
-  const applyDefaultMintSelection = React.useCallback(
-    async (mintUrl: string): Promise<void> => {
-      await applyDefaultMintSelectionInner(mintUrl);
-      // Mirror the user's explicit choice into Evolu's ownerMeta so other
-      // tabs/devices converge. Done here (not in a defaultMintUrl-watch
-      // effect) to avoid stale-closure ping-pong with the remote.
-      upsertDefaultMintToOwnerMetaRef.current(mintUrl);
-    },
-    [applyDefaultMintSelectionInner],
-  );
-
-  React.useEffect(() => {
-    if (!currentNpub || !currentNsec) {
-      setOwnedProfileLightningAddresses([]);
-      setOwnedProfileLightningAddressesLoading(false);
-      return;
-    }
-
-    setOwnedProfileLightningAddresses([]);
-    setOwnedProfileLightningAddressesLoading(true);
-
-    const controller = new AbortController();
-    let cancelled = false;
-
-    const loadOwnedLightningAddresses = async () => {
-      try {
-        const url = `${profileClaimLightningAddressServerBaseUrl}/api/v1/info`;
-        const auth = await makeNip98AuthHeader(url, "GET");
-        const response = await fetch(url, {
-          method: "GET",
-          headers: { Authorization: auth },
-          signal: controller.signal,
-        });
-        if (!response.ok) {
-          if (!cancelled) {
-            setOwnedProfileLightningAddresses([]);
-            setOwnedProfileLightningAddressesLoading(false);
-          }
-          return;
-        }
-
-        const json = await response.json();
-        if (cancelled) return;
-
-        const info = parseNpubCashProfileInfo(json);
-        setOwnedProfileLightningAddresses(info.ownedLightningAddresses);
-        setOwnedProfileLightningAddressesLoading(false);
-      } catch {
-        if (cancelled) return;
-        setOwnedProfileLightningAddresses([]);
-        setOwnedProfileLightningAddressesLoading(false);
-      }
-    };
-
-    void loadOwnedLightningAddresses();
-
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, [
-    currentNpub,
-    currentNsec,
-    makeNip98AuthHeader,
-    profileClaimLightningAddressServerBaseUrl,
-    setOwnedProfileLightningAddresses,
-    setOwnedProfileLightningAddressesLoading,
-  ]);
-
-  React.useEffect(() => {
-    const selectedMint = normalizeMintUrl(defaultMintUrl ?? MAIN_MINT_URL);
-    if (!cashuAutoswapEnabled) return;
-    if (!isTestMintUrl(selectedMint)) return;
-    setCashuAutoswapEnabled(false);
-  }, [cashuAutoswapEnabled, defaultMintUrl, setCashuAutoswapEnabled]);
-
-  const resolvePendingMintAutoswapChangeConfirmation = React.useCallback(
-    (confirmed: boolean) => {
-      const resolve = pendingMintAutoswapChangeResolverRef.current;
-      pendingMintAutoswapChangeResolverRef.current = null;
-      setPendingMintAutoswapChangeConfirmation(null);
-      resolve?.(confirmed);
-    },
-    [],
-  );
-
-  const closeMintAutoswapChangeConfirmation = React.useCallback(() => {
-    resolvePendingMintAutoswapChangeConfirmation(false);
-  }, [resolvePendingMintAutoswapChangeConfirmation]);
-
-  const confirmMintAutoswapChangeConfirmation = React.useCallback(() => {
-    resolvePendingMintAutoswapChangeConfirmation(true);
-  }, [resolvePendingMintAutoswapChangeConfirmation]);
-
-  React.useEffect(() => {
-    return () => {
-      pendingMintAutoswapChangeResolverRef.current?.(false);
-      pendingMintAutoswapChangeResolverRef.current = null;
-    };
-  }, []);
-
-  const { claimNpubCashOnce, claimNpubCashOnceLatestRef } = useNpubCashClaim({
-    cashuIsBusy,
-    cashuTokensAll,
-    currentNpub: nostrBootstrapReady ? currentNpub : null,
-    currentNsec: nostrBootstrapReady ? currentNsec : null,
-    enqueueCashuOp,
-    ensureCashuTokenPersisted,
-    formatDisplayedAmountParts,
-    upsert,
-    isMintDeleted,
-    logPaymentEvent,
-    makeLocalStorageKey,
-    makeNip98AuthHeader,
-    maybeShowPwaNotification,
-    mintInfoByUrl,
-    npubCashServerBaseUrl,
-    npubCashClaimInFlightRef,
-    refreshMintInfo,
-    resolveOwnerIdForWrite,
-    rememberCashuTokenKnown,
-    routeKind: route.kind,
-    setCashuIsBusy,
-    setStatus,
-    showPaidOverlay,
-    t,
-    touchMintInfo,
-  });
-
-  useProfileNpubCashEffects({
-    claimNpubCashOnce,
-    claimNpubCashOnceLatestRef,
-    currentNpub,
-    currentNsec,
-    hasMintOverrideRef,
-    makeNip98AuthHeader,
-    networkEnabled: nostrBootstrapReady,
-    npubCashServerBaseUrl,
-    npubCashInfoInFlightRef,
-    npubCashInfoLoadedAtMsRef,
-    npubCashInfoLoadedForNpubRef,
-    routeKind: route.kind,
-    setDefaultMintUrl,
-    setDefaultMintUrlDraft,
-    setIsProfileEditing,
-    setMyProfileQr,
   });
 
   const { isMainSwipeRoute } = useMainSwipePageEffects({
@@ -2459,899 +1069,6 @@ export const useAppShellComposition = () => {
       onOpen: clearPendingDeleteOnMenuChange,
       route,
     });
-
-  const [contactPayMethod, setContactPayMethod] = useState<
-    null | "cashu" | "lightning"
-  >(null);
-  useContactPayMethod({
-    payWithCashuEnabled,
-    routeKind: route.kind,
-    selectedContactLnAddress: String(selectedContact?.lnAddress ?? ""),
-    selectedContactNpub: String(selectedContact?.npub ?? ""),
-    setContactPayMethod,
-  });
-
-  const buildCashuMintCandidates = React.useCallback(
-    (
-      mintGroups: Map<string, { tokens: string[]; sum: number }>,
-      preferredMint: string | null,
-    ) => {
-      return buildCashuMintCandidatesBase(
-        mintGroups,
-        normalizeMintUrl(preferredMint ?? ""),
-      );
-    },
-    [],
-  );
-
-  const payContactWithCashuMessage =
-    usePayContactWithCashuMessage<ContactRowLike>({
-      activePublishClientIdsRef: activeNostrMessagePublishClientIdsRef,
-      appendLocalNostrMessage,
-      buildCashuMintCandidates,
-      cashuBalance,
-      cashuTokensAll,
-      cashuTokensWithMeta,
-      chatSeenWrapIdsRef,
-      currentNpub,
-      currentNsec,
-      defaultMintUrl,
-      enqueuePendingPayment,
-      formatDisplayedAmountParts,
-      upsert,
-      logPayStep,
-      logPaymentEvent,
-      nostrMessagesLocal,
-      payWithCashuEnabled,
-      publishSingleWrappedWithRetry,
-      publishWrappedWithRetry,
-      pushToast,
-      resolveOwnerIdForWrite,
-      setContactsOnboardingHasPaid,
-      setStatus,
-      showPaidOverlay,
-      t,
-      update,
-      updateLocalNostrMessage,
-    });
-
-  const settleBankPaymentOffer = React.useCallback(
-    async (message: LocalNostrMessage) => {
-      if (cashuIsBusy) return;
-
-      const offerInfo = getLinkyBankPaymentOfferInfo(
-        String(message.content ?? ""),
-      );
-      if (!offerInfo || offerInfo.status !== "bank_paid") {
-        setStatus(t("spdPaymentOfferFailed"));
-        return;
-      }
-      if (isBankPaymentOfferCanceled(offerInfo.offerId)) {
-        setStatus(t("bankPaymentOfferStatusCanceled"));
-        return;
-      }
-      if (!offerInfo.amountSat) {
-        setStatus(t("payInvalidAmount"));
-        return;
-      }
-
-      const contactId = String(message.contactId ?? "").trim();
-      const contact =
-        contacts.find(
-          (candidate) => String(candidate.id ?? "").trim() === contactId,
-        ) ?? null;
-      if (!contact) {
-        setStatus(t("contactNotFound"));
-        return;
-      }
-
-      setCashuIsBusy(true);
-      try {
-        const result = await payContactWithCashuMessage({
-          contact,
-          amountSat: offerInfo.amountSat,
-          logCompletedOnly: true,
-          paymentNoticeContext: LINKY_PAYMENT_NOTICE_CONTEXT_BANK_PAYMENT_OFFER,
-          paymentNoticeOfferId: offerInfo.offerId,
-        });
-        if (!result.ok) return;
-
-        await respondToBankPaymentOfferWithGroupState(message, "settled");
-      } finally {
-        setCashuIsBusy(false);
-      }
-    },
-    [
-      cashuIsBusy,
-      contacts,
-      isBankPaymentOfferCanceled,
-      payContactWithCashuMessage,
-      respondToBankPaymentOfferWithGroupState,
-      setCashuIsBusy,
-      setStatus,
-      t,
-    ],
-  );
-
-  usePaymentsDomain({
-    cashuIsBusy,
-    contacts,
-    currentNpub,
-    currentNsec,
-    payContactWithCashuMessage,
-    pendingPayments,
-    pushToast,
-    removePendingPayment,
-    setCashuIsBusy,
-    t,
-  });
-
-  const paySelectedContact = React.useCallback(async () => {
-    if (cashuIsBusy) return;
-    if (route.kind !== "contactPay") return;
-    if (!selectedContact) return;
-
-    const amountSat = Number.parseInt(String(payAmount ?? "").trim(), 10);
-    if (!Number.isFinite(amountSat) || amountSat <= 0) {
-      setStatus(t("payInvalidAmount"));
-      return;
-    }
-
-    if (amountSat > cashuBalance) {
-      if (!requestPaymentMintMelt(amountSat)) {
-        setStatus(t("payInsufficient"));
-      }
-      return;
-    }
-
-    const normalizedMethod =
-      contactPayMethod === "lightning" || contactPayMethod === "cashu"
-        ? contactPayMethod
-        : "cashu";
-
-    if (normalizedMethod === "lightning") {
-      const lnAddress = String(selectedContact.lnAddress ?? "").trim();
-      if (!lnAddress) {
-        setStatus(t("payMissingLn"));
-        return;
-      }
-      setLnAddressPayAmount(String(amountSat));
-      navigateTo({ route: "lnAddressPay", lnAddress });
-      return;
-    }
-
-    setCashuIsBusy(true);
-    try {
-      await payContactWithCashuMessage({
-        contact: selectedContact,
-        amountSat,
-      });
-    } finally {
-      setCashuIsBusy(false);
-    }
-  }, [
-    cashuIsBusy,
-    cashuBalance,
-    contactPayMethod,
-    payAmount,
-    payContactWithCashuMessage,
-    requestPaymentMintMelt,
-    route.kind,
-    selectedContact,
-    setCashuIsBusy,
-    setLnAddressPayAmount,
-    setStatus,
-    t,
-  ]);
-
-  const findContactForCashuPaymentRequest = React.useCallback(
-    (requestInfo: CashuPaymentRequestMessageInfo) => {
-      const requestPubkeyHex = normalizePubkeyHex(
-        requestInfo.transportPubkeyHex,
-      );
-      if (!requestPubkeyHex) return null;
-
-      for (const contact of contacts) {
-        const normalizedNpub = normalizeNpubIdentifier(contact.npub);
-        if (!normalizedNpub) continue;
-
-        try {
-          const decoded = nip19.decode(normalizedNpub);
-          if (decoded.type !== "npub") continue;
-          if (typeof decoded.data !== "string") continue;
-          if (decoded.data === requestPubkeyHex) return contact;
-        } catch {
-          // ignore malformed contact npubs
-        }
-      }
-
-      return null;
-    },
-    [contacts],
-  );
-
-  const ensureContactForCashuPaymentRequest = React.useCallback(
-    (requestInfo: CashuPaymentRequestMessageInfo): ContactRowLike | null => {
-      const existing = findContactForCashuPaymentRequest(requestInfo);
-      if (existing?.id) return existing;
-
-      const requestPubkeyHex = normalizePubkeyHex(
-        requestInfo.transportPubkeyHex,
-      );
-      if (!requestPubkeyHex) return null;
-
-      let npub: string | null = null;
-      try {
-        npub = nip19.npubEncode(requestPubkeyHex);
-      } catch {
-        return null;
-      }
-
-      const normalizedNpub = normalizeNpubIdentifier(npub);
-      if (!normalizedNpub) return null;
-
-      const duplicate = contacts.find(
-        (contact) => normalizeNpubIdentifier(contact.npub) === normalizedNpub,
-      );
-      if (duplicate?.id) return duplicate;
-
-      if (activeContactsOwnerContactCount >= MAX_CONTACTS_PER_OWNER) {
-        setStatus(
-          t("contactsLimitReached").replace(
-            "{max}",
-            String(MAX_CONTACTS_PER_OWNER),
-          ),
-        );
-        return null;
-      }
-
-      const defaultProfile = deriveDefaultProfile(normalizedNpub, lang);
-      const contactName = buildSavedContactName(
-        unknownNameByNpub[normalizedNpub] ?? defaultProfile.name,
-        normalizedNpub,
-      );
-      const payload = {
-        name: contactName as typeof Evolu.NonEmptyString1000.Type,
-        npub: normalizedNpub as typeof Evolu.NonEmptyString1000.Type,
-        lnAddress: null,
-        groupName: null,
-      };
-
-      const result = contactsOwnerId
-        ? (() => {
-            const scoped = insert("contact", payload, {
-              ownerId: contactsOwnerId,
-            });
-            if (scoped.ok) return scoped;
-            return insert("contact", payload);
-          })()
-        : insert("contact", payload);
-
-      if (!result.ok) {
-        setStatus(`${t("errorPrefix")}: ${String(result.error ?? "")}`);
-        return null;
-      }
-
-      recordContactsOwnerWrite();
-      openScannedContactPendingNpubRef.current = normalizedNpub;
-
-      return {
-        id: result.value.id,
-        name: contactName,
-        npub: normalizedNpub,
-        lnAddress: null,
-        groupName: null,
-        ownerId: contactsOwnerId,
-      };
-    },
-    [
-      activeContactsOwnerContactCount,
-      buildSavedContactName,
-      contacts,
-      contactsOwnerId,
-      findContactForCashuPaymentRequest,
-      insert,
-      lang,
-      openScannedContactPendingNpubRef,
-      recordContactsOwnerWrite,
-      setStatus,
-      t,
-      unknownNameByNpub,
-    ],
-  );
-
-  const findPreviousCashuPaymentRequestMessage = React.useCallback(
-    (
-      requestInfo: CashuPaymentRequestMessageInfo,
-      contactId: string,
-    ): LocalNostrMessage | null => {
-      const normalizedContactId = String(contactId ?? "").trim();
-      if (!normalizedContactId) return null;
-
-      const requestId = String(requestInfo.requestId ?? "").trim();
-      const encodedRequest = String(requestInfo.encodedRequest ?? "").trim();
-      if (!requestId && !encodedRequest) return null;
-
-      const candidates = [
-        ...chatMessages,
-        ...nostrMessagesRecent,
-        ...nostrMessagesLocal,
-      ];
-
-      for (let index = candidates.length - 1; index >= 0; index -= 1) {
-        const message = candidates[index];
-        if (String(message.contactId ?? "").trim() !== normalizedContactId) {
-          continue;
-        }
-        if (String(message.direction ?? "").trim() !== "in") continue;
-
-        const rumorId = String(message.rumorId ?? "").trim();
-        if (!rumorId) continue;
-
-        const previousInfo = parseCashuPaymentRequestMessage(
-          String(message.content ?? ""),
-        );
-        if (!previousInfo) continue;
-
-        const previousRequestId = String(previousInfo.requestId ?? "").trim();
-        if (requestId && previousRequestId === requestId) return message;
-
-        if (
-          !requestId &&
-          String(previousInfo.encodedRequest ?? "").trim() === encodedRequest
-        ) {
-          return message;
-        }
-      }
-
-      return null;
-    },
-    [chatMessages, nostrMessagesLocal, nostrMessagesRecent],
-  );
-
-  const payCashuPaymentRequestViaPost = React.useCallback(
-    async (requestInfo: CashuPaymentRequestMessageInfo): Promise<boolean> => {
-      const postUrlRaw = String(requestInfo.transportPostUrl ?? "").trim();
-      if (!postUrlRaw) return false;
-
-      let postUrl: URL;
-      try {
-        postUrl = new URL(postUrlRaw);
-      } catch {
-        setStatus(t("paymentRequestUnknownContact"));
-        return false;
-      }
-
-      if (postUrl.protocol !== "https:" && postUrl.protocol !== "http:") {
-        setStatus(t("paymentRequestUnknownContact"));
-        return false;
-      }
-
-      if (cashuBalance < requestInfo.amount) {
-        setStatus(t("payInsufficient"));
-        return true;
-      }
-
-      setCashuIsBusy(true);
-
-      const cashuWriteOwnerId = await resolveOwnerIdForWrite();
-      const insertCashuToken = (args: {
-        amount: number | null;
-        mint: string | null;
-        state: "accepted" | "pending";
-        token: string;
-        unit: string | null;
-      }) => {
-        const payload: {
-          id: CashuTokenId;
-          token: typeof Evolu.NonEmptyString.Type;
-          state: typeof Evolu.NonEmptyString100.Type;
-        } = {
-          id: createCashuTokenId(args.token),
-          token: args.token as typeof Evolu.NonEmptyString.Type,
-          state: args.state as typeof Evolu.NonEmptyString100.Type,
-        };
-
-        return cashuWriteOwnerId
-          ? upsert("cashuToken", payload, { ownerId: cashuWriteOwnerId })
-          : upsert("cashuToken", payload);
-      };
-
-      const updateCashuToken = (
-        payload: {
-          id: CashuTokenId;
-          isDeleted: typeof Evolu.sqliteTrue;
-        },
-        targetOwnerId?: Evolu.OwnerId | null,
-      ) => {
-        const ownerId = targetOwnerId ?? cashuWriteOwnerId;
-        return ownerId
-          ? update("cashuToken", payload, { ownerId })
-          : update("cashuToken", payload);
-      };
-
-      let sentAmountSat = 0;
-      let usedMint: string | null = null;
-      let usedInputTokens: string[] = [];
-      let sendToken: string | null = null;
-      let sendTokenAmount = 0;
-      let sendProofs: Proof[] = [];
-      let sendTokenUnit: string | null = null;
-      let gainedToken: string | null = null;
-      let lastError: unknown = null;
-
-      try {
-        const requestedMints = new Set<string>();
-        for (const mintUrl of requestInfo.mintUrls) {
-          const normalizedMint = normalizeMintUrl(mintUrl);
-          if (normalizedMint) requestedMints.add(normalizedMint);
-        }
-
-        const mintGroups = new Map<string, { tokens: string[]; sum: number }>();
-        for (const row of cashuTokensWithMeta) {
-          if (!isCashuTokenAcceptedState(row.state)) continue;
-          const mint = normalizeMintUrl(String(row.mint ?? "").trim());
-          if (!mint) continue;
-          if (requestedMints.size > 0 && !requestedMints.has(mint)) continue;
-
-          const tokenText = String(row.token ?? row.rawToken ?? "").trim();
-          if (!tokenText) continue;
-
-          const amount = Number(row.amount ?? 0) || 0;
-          const entry = mintGroups.get(mint) ?? { tokens: [], sum: 0 };
-          entry.tokens.push(tokenText);
-          entry.sum += amount;
-          mintGroups.set(mint, entry);
-        }
-
-        const preferredMint =
-          requestInfo.mintUrls
-            .map((mintUrl) => normalizeMintUrl(mintUrl))
-            .find((mintUrl) => Boolean(mintUrl)) ??
-          normalizeMintUrl(defaultMintUrl ?? "");
-        const candidates = buildCashuMintCandidates(mintGroups, preferredMint);
-        const candidate = selectSingleMintCandidateForAmount(
-          candidates,
-          requestInfo.amount,
-        );
-        if (!candidate) {
-          setStatus(t("payInsufficient"));
-          return true;
-        }
-
-        usedInputTokens = [...candidate.tokens];
-        const maxReservedFeeSat = getPaymentAmountReserveCap(
-          requestInfo.amount,
-          candidate.sum,
-        );
-        const attempts = buildPaymentAmountAttempts(
-          requestInfo.amount,
-          candidate.sum,
-        ).filter((attemptAmountSat) => {
-          return requestInfo.amount - attemptAmountSat <= maxReservedFeeSat;
-        });
-
-        for (let index = 0; index < attempts.length; index += 1) {
-          const attemptAmountSat = attempts[index];
-          const hasLowerAmountFallback = index < attempts.length - 1;
-
-          try {
-            const split = await createSendTokenWithTokensAtMint({
-              amount: attemptAmountSat,
-              mint: candidate.mint,
-              tokens: candidate.tokens,
-              unit: "sat",
-            });
-
-            if (!split.ok) {
-              lastError = split.error;
-              if (
-                hasLowerAmountFallback &&
-                isRetryablePaymentAmountFailure(String(split.error ?? ""))
-              ) {
-                continue;
-              }
-              break;
-            }
-
-            const spentRows = cashuTokensWithMeta.filter((row) => {
-              if (!isCashuTokenAcceptedState(row.state)) return false;
-              const tokenText = String(row.token ?? row.rawToken ?? "").trim();
-              return candidate.tokens.includes(tokenText);
-            });
-            for (const row of spentRows) {
-              const rowId = row.id;
-              if (!rowId) continue;
-              const deleted = updateCashuToken(
-                { id: rowId as CashuTokenId, isDeleted: Evolu.sqliteTrue },
-                resolveCashuRowStoredOwnerLane(row),
-              );
-              if (!deleted.ok) throw deleted.error;
-            }
-
-            if (split.remainingToken && split.remainingAmount > 0) {
-              gainedToken = split.remainingToken;
-              const inserted = insertCashuToken({
-                token: split.remainingToken,
-                mint: split.mint,
-                unit: split.unit ?? null,
-                amount: split.remainingAmount,
-                state: "accepted",
-              });
-              if (!inserted.ok) throw inserted.error;
-            }
-
-            sendToken = split.sendToken;
-            sendTokenAmount = split.sendAmount;
-            sendProofs = split.sendProofs;
-            sendTokenUnit = split.unit ?? null;
-            sentAmountSat = split.sendAmount;
-            usedMint = split.mint;
-            break;
-          } catch (error) {
-            lastError = error;
-            if (
-              hasLowerAmountFallback &&
-              isRetryablePaymentAmountFailure(
-                getUnknownErrorMessage(error, "unknown"),
-              )
-            ) {
-              continue;
-            }
-            break;
-          }
-        }
-
-        if (!sendToken) {
-          const errorMessage = getUnknownErrorMessage(
-            lastError,
-            "insufficient funds",
-          );
-          logPaymentEvent({
-            direction: "out",
-            status: "error",
-            amount: requestInfo.amount,
-            fee: null,
-            mint: usedMint,
-            unit: "sat",
-            error: errorMessage,
-            contactId: null,
-            method: "cashu_chat",
-            phase: "swap",
-          });
-          setStatus(`${t("payFailed")}: ${errorMessage}`);
-          return true;
-        }
-
-        const proofs = sendProofs.flatMap((proof) => {
-          const normalized = normalizeCashuProofPayload(proof);
-          return normalized ? [normalized] : [];
-        });
-        if (proofs.length === 0) throw new Error("empty payment proofs");
-
-        const body: Record<string, unknown> = {
-          mint: usedMint,
-          unit: sendTokenUnit ?? "sat",
-          proofs,
-        };
-        if (requestInfo.requestId) body.id = requestInfo.requestId;
-        if (requestInfo.description) body.memo = requestInfo.description;
-
-        const response = await fetch(postUrl.toString(), {
-          method: "POST",
-          cache: "no-store",
-          credentials: "omit",
-          headers: {
-            Accept: "application/json",
-            "Content-Type": "application/json",
-          },
-          mode: "cors",
-          body: JSON.stringify(body),
-        });
-
-        if (!response.ok) {
-          throw new Error(`Payment request POST ${response.status}`);
-        }
-
-        logPaymentEvent({
-          direction: "out",
-          status: "ok",
-          amount: sentAmountSat,
-          details: {
-            ...(gainedToken ? { gainedToken } : {}),
-            ...(requestInfo.requestId
-              ? { requestId: requestInfo.requestId }
-              : {}),
-            postUrl: postUrl.toString(),
-            usedInputTokens,
-          },
-          fee: null,
-          mint: usedMint,
-          unit: sendTokenUnit ?? "sat",
-          error: null,
-          contactId: null,
-          method: "cashu_chat",
-          phase: "complete",
-        });
-
-        const displayAmount = formatDisplayedAmountParts(sentAmountSat);
-        showPaidOverlay(
-          t("paidSentTo")
-            .replace(
-              "{amount}",
-              `${displayAmount.approxPrefix}${displayAmount.amountText}`,
-            )
-            .replace("{unit}", displayAmount.unitLabel)
-            .replace(
-              "{name}",
-              requestInfo.description || postUrl.hostname || t("appTitle"),
-            ),
-        );
-        safeLocalStorageSet(CONTACTS_ONBOARDING_HAS_PAID_STORAGE_KEY, "1");
-        setContactsOnboardingHasPaid(true);
-        return true;
-      } catch (error) {
-        if (sendToken) {
-          const inserted = insertCashuToken({
-            token: sendToken,
-            mint: usedMint,
-            unit: sendTokenUnit,
-            amount: sendTokenAmount,
-            state: "accepted",
-          });
-          if (!inserted.ok) {
-            console.warn("[linky][payment-request] recovery insert failed", {
-              error: String(inserted.error ?? ""),
-            });
-          }
-        }
-
-        const errorMessage = getUnknownErrorMessage(error, "unknown");
-        logPaymentEvent({
-          direction: "out",
-          status: "error",
-          amount: requestInfo.amount,
-          fee: null,
-          mint: usedMint,
-          unit: sendTokenUnit ?? "sat",
-          error: errorMessage,
-          contactId: null,
-          method: "cashu_chat",
-          phase: "publish",
-        });
-        setStatus(`${t("payFailed")}: ${errorMessage}`);
-        return true;
-      } finally {
-        setCashuIsBusy(false);
-      }
-    },
-    [
-      buildCashuMintCandidates,
-      cashuBalance,
-      cashuTokensWithMeta,
-      defaultMintUrl,
-      formatDisplayedAmountParts,
-      logPaymentEvent,
-      resolveOwnerIdForWrite,
-      setCashuIsBusy,
-      setContactsOnboardingHasPaid,
-      setStatus,
-      showPaidOverlay,
-      t,
-      update,
-      upsert,
-    ],
-  );
-
-  const payCashuPaymentRequest = React.useCallback(
-    async (requestInfo: CashuPaymentRequestMessageInfo) => {
-      if (cashuIsBusy) return;
-      if (requestInfo.amount > cashuBalance) {
-        const requestedMints = requestInfo.mintUrls.flatMap((mintUrl) => {
-          const normalizedMint = normalizeMintUrl(mintUrl);
-          return normalizedMint ? [normalizedMint] : [];
-        });
-        const targetMainMint = paymentMintMeltPlan?.toMint ?? "";
-        const mainMintIsAccepted =
-          requestedMints.length === 0 ||
-          (Boolean(targetMainMint) && requestedMints.includes(targetMainMint));
-        if (
-          !mainMintIsAccepted ||
-          !requestPaymentMintMelt(requestInfo.amount)
-        ) {
-          setStatus(t("payInsufficient"));
-        }
-        return;
-      }
-
-      const contact = ensureContactForCashuPaymentRequest(requestInfo);
-      if (!contact?.id) {
-        if (await payCashuPaymentRequestViaPost(requestInfo)) return;
-        setStatus(t("paymentRequestUnknownContact"));
-        return;
-      }
-
-      setCashuIsBusy(true);
-      try {
-        const previousRequestMessage = findPreviousCashuPaymentRequestMessage(
-          requestInfo,
-          String(contact.id ?? ""),
-        );
-        const previousRequestRumorId = String(
-          previousRequestMessage?.rumorId ?? "",
-        ).trim();
-
-        await payContactWithCashuMessage({
-          contact,
-          amountSat: requestInfo.amount,
-          paymentRequestId: requestInfo.requestId,
-          ...(previousRequestRumorId
-            ? {
-                replyContext: {
-                  replyToId: previousRequestRumorId,
-                  rootMessageId:
-                    String(
-                      previousRequestMessage?.rootMessageId ?? "",
-                    ).trim() || previousRequestRumorId,
-                  replyToContent:
-                    String(previousRequestMessage?.content ?? "").trim() ||
-                    null,
-                },
-              }
-            : {}),
-        });
-      } finally {
-        setCashuIsBusy(false);
-      }
-    },
-    [
-      cashuIsBusy,
-      cashuBalance,
-      ensureContactForCashuPaymentRequest,
-      findPreviousCashuPaymentRequestMessage,
-      payCashuPaymentRequestViaPost,
-      payContactWithCashuMessage,
-      paymentMintMeltPlan?.toMint,
-      requestPaymentMintMelt,
-      setCashuIsBusy,
-      setStatus,
-      t,
-    ],
-  );
-
-  const {
-    payLightningAddressWithCashu: payLightningAddressWithCashuBase,
-    payLightningInvoiceWithCashu: payLightningInvoiceWithCashuBase,
-  } = useLightningPaymentsDomain({
-    buildCashuMintCandidates,
-    canPayWithCashu,
-    cashuBalance,
-    cashuIsBusy,
-    cashuOwnerId,
-    cashuTokensAll,
-    cashuTokensWithMeta,
-    cashuVisibleOwnerIds,
-    contacts,
-    defaultMintUrl,
-    formatDisplayedAmountParts,
-    upsert,
-    logPaymentEvent,
-    normalizeMintUrl,
-    setCashuIsBusy,
-    setContactsOnboardingHasPaid,
-    setPostPaySaveContact,
-    setStatus,
-    showPaidOverlay,
-    t,
-    update,
-  });
-
-  const payLightningAddressWithCashu = React.useCallback(
-    async (lnAddress: string, amountSat: number): Promise<void> => {
-      if (amountSat > cashuBalance) {
-        if (!requestPaymentMintMelt(amountSat)) {
-          setStatus(t("payInsufficient"));
-        }
-        return;
-      }
-      const paid = await payLightningAddressWithCashuBase(lnAddress, amountSat);
-      if (paid) navigateTo({ route: "wallet" });
-    },
-    [
-      cashuBalance,
-      payLightningAddressWithCashuBase,
-      requestPaymentMintMelt,
-      setStatus,
-      t,
-    ],
-  );
-
-  const payLightningInvoiceWithCashu = React.useCallback(
-    async (invoice: string): Promise<boolean> => {
-      const amountSat = getLightningInvoicePreview(invoice)?.amountSat ?? null;
-      if (amountSat !== null && amountSat > cashuBalance) {
-        if (!requestPaymentMintMelt(amountSat)) {
-          setStatus(t("payInsufficient"));
-        }
-        return false;
-      }
-      const paid = await payLightningInvoiceWithCashuBase(invoice);
-      if (paid && route.kind === "manualPay") {
-        navigateTo({ route: "wallet" });
-      }
-      return paid;
-    },
-    [
-      cashuBalance,
-      payLightningInvoiceWithCashuBase,
-      requestPaymentMintMelt,
-      route.kind,
-      setStatus,
-      t,
-    ],
-  );
-
-  const closeLightningInvoiceConfirmation = React.useCallback(() => {
-    setPendingLightningInvoiceConfirmation(null);
-  }, []);
-
-  const confirmLightningInvoicePayment = React.useCallback(async () => {
-    const pending = pendingLightningInvoiceConfirmation;
-    if (!pending) return;
-
-    const ok = await payLightningInvoiceWithCashu(pending.invoice);
-    if (ok) setPendingLightningInvoiceConfirmation(null);
-  }, [payLightningInvoiceWithCashu, pendingLightningInvoiceConfirmation]);
-
-  const closeLnurlWithdrawConfirmation = React.useCallback(() => {
-    if (lnurlWithdrawIsBusy) return;
-    setPendingLnurlWithdrawConfirmation(null);
-  }, [lnurlWithdrawIsBusy]);
-
-  const confirmLnurlWithdraw = React.useCallback(async () => {
-    const pending = pendingLnurlWithdrawConfirmation;
-    if (!pending || lnurlWithdrawIsBusy) return;
-
-    const mintUrl = normalizeMintUrl(defaultMintUrl ?? MAIN_MINT_URL);
-    if (!mintUrl) {
-      setStatus(t("topupInvoiceFailed"));
-      return;
-    }
-
-    setLnurlWithdrawIsBusy(true);
-    try {
-      setStatus(t("lnurlWithdrawPreparing"));
-      const { invoice, quoteId } = await requestMintQuoteBolt11({
-        amountSat: pending.amountSat,
-        mintUrl,
-      });
-      await redeemLnurlWithdraw({
-        callback: pending.callback,
-        invoice,
-        k1: pending.k1,
-      });
-      setTopupMintQuote({
-        amount: pending.amountSat,
-        invoice,
-        mintUrl,
-        quote: quoteId,
-        unit: "sat",
-      });
-      setPendingLnurlWithdrawConfirmation(null);
-      setStatus(t("lnurlWithdrawPending"));
-    } catch (error) {
-      const message = getUnknownErrorMessage(error, t("lnurlWithdrawFailed"));
-      setStatus(`${t("errorPrefix")}: ${message}`);
-    } finally {
-      setLnurlWithdrawIsBusy(false);
-    }
-  }, [
-    defaultMintUrl,
-    lnurlWithdrawIsBusy,
-    pendingLnurlWithdrawConfirmation,
-    setStatus,
-    t,
-  ]);
 
   const scannedTextHandlerRef = React.useRef<
     (rawValue: string) => Promise<void>
@@ -3442,130 +1159,6 @@ export const useAppShellComposition = () => {
     stopContactsGuide,
     t,
   });
-
-  const [walletWarningDismissed, setWalletWarningDismissed] = React.useState(
-    () => safeLocalStorageGet(WALLET_WARNING_DISMISSED_STORAGE_KEY) === "1",
-  );
-
-  const walletWarningApplies =
-    cashuBalance > WALLET_WARNING_BALANCE_THRESHOLD_SAT;
-
-  const dismissWalletWarning = React.useCallback(() => {
-    safeLocalStorageSet(WALLET_WARNING_DISMISSED_STORAGE_KEY, "1");
-    setWalletWarningDismissed(true);
-  }, []);
-
-  const saveCashuFromText = useSaveCashuFromText({
-    enqueueCashuOp,
-    ensureCashuTokenPersisted,
-    formatDisplayedAmountParts,
-    upsert,
-    isCashuTokenStored,
-    isMintDeleted,
-    logPaymentEvent,
-    mintInfoByUrl,
-    refreshMintInfo,
-    resolveOwnerIdForWrite,
-    rememberCashuTokenKnown,
-    setCashuDraft,
-    setCashuIsBusy,
-    setStatus,
-    showPaidOverlay,
-    t,
-    touchMintInfo,
-  });
-
-  const {
-    checkAllCashuTokensAndDeleteInvalid,
-    checkAndRefreshCashuToken,
-    checkIssuedCashuTokensAndDeleteClaimed,
-    checkSingleIssuedCashuTokenIsClaimed,
-    requestDeleteCashuToken,
-  } = useCashuTokenChecks({
-    appOwnerId: cashuOwnerId,
-    cashuBulkCheckIsBusy,
-    cashuIsBusy,
-    cashuTokensAll: cashuTokensAllFiltered,
-    pendingCashuDeleteId,
-    pushToast,
-    setCashuBulkCheckIsBusy,
-    setCashuIsBusy,
-    setPendingCashuDeleteId,
-    setStatus,
-    t,
-    update,
-  });
-
-  // Background check for issued-token claims (issue #86). Runs once on
-  // mount and every 60s thereafter while we have any issued tokens —
-  // wallet.checkProofsStates is the passive NUT-07 query that doesn't
-  // consume proofs. The helper itself skips when cashuIsBusy /
-  // bulkCheckIsBusy is true, so concurrent send/melt operations aren't
-  // disturbed. Detection deletes the row, so the issued list cleans up
-  // even when the user isn't sitting on #wallet/tokens.
-  //
-  // The helper's callback identity changes every time cashuTokensAll
-  // updates (Evolu emits frequently). Stashing it in a ref keeps the
-  // 60s interval from being torn down + restarted on every churn — the
-  // earlier inline-deps version was firing the check roughly every
-  // second under load.
-  const hasAnyIssuedTokensForBackgroundCheck = cashuIssuedTokens.length > 0;
-  const checkIssuedCashuTokensRef = React.useRef(
-    checkIssuedCashuTokensAndDeleteClaimed,
-  );
-  React.useEffect(() => {
-    checkIssuedCashuTokensRef.current = checkIssuedCashuTokensAndDeleteClaimed;
-  }, [checkIssuedCashuTokensAndDeleteClaimed]);
-  const formatDisplayedAmountTextRef = React.useRef(formatDisplayedAmountText);
-  React.useEffect(() => {
-    formatDisplayedAmountTextRef.current = formatDisplayedAmountText;
-  }, [formatDisplayedAmountText]);
-  const pushToastRef = React.useRef(pushToast);
-  React.useEffect(() => {
-    pushToastRef.current = pushToast;
-  }, [pushToast]);
-  const claimToastTRef = React.useRef(t);
-  React.useEffect(() => {
-    claimToastTRef.current = t;
-  }, [t]);
-  React.useEffect(() => {
-    if (!hasAnyIssuedTokensForBackgroundCheck) return;
-    let cancelled = false;
-    const tick = async () => {
-      if (cancelled) return;
-      try {
-        const outcome = await checkIssuedCashuTokensRef.current();
-        if (cancelled) return;
-        if (outcome.claimed.length === 0) return;
-        // Background detection — surface a toast so the user knows the
-        // issued token was redeemed even when they aren't on the QR
-        // screen (the CashuTokenPage poll handles the in-page UX with a
-        // checkmark overlay).
-        const formatter = formatDisplayedAmountTextRef.current;
-        const tt = claimToastTRef.current;
-        for (const entry of outcome.claimed) {
-          const message =
-            entry.amount > 0
-              ? tt("cashuTokenClaimedWithAmount").replace(
-                  "{amount}",
-                  formatter(entry.amount),
-                )
-              : tt("cashuTokenClaimed");
-          pushToastRef.current(message);
-        }
-      } catch {
-        // ignore — the helper already swallows mint-side errors.
-      }
-    };
-    void tick();
-    const intervalId = window.setInterval(() => {
-      void tick();
-    }, 60_000);
-    return () => {
-      cancelled = true;
-      window.clearInterval(intervalId);
-    };
-  }, [hasAnyIssuedTokensForBackgroundCheck]);
 
   const closeShareOptions = React.useCallback(() => {
     setShareOptionsText(null);
@@ -3762,390 +1355,6 @@ export const useAppShellComposition = () => {
     [cashuOwnerId, pushToast, setStatus, t, update, writeNfcUriWithToast],
   );
 
-  const returnCashuTokenToWallet = React.useCallback(
-    async (id: CashuTokenId) => {
-      const ownerId = await resolveOwnerIdForWrite();
-      const payload = {
-        id,
-        state: "accepted" as typeof Evolu.NonEmptyString100.Type,
-        error: null,
-      };
-      const result = ownerId
-        ? update("cashuToken", payload, { ownerId })
-        : update("cashuToken", payload);
-
-      if (!result.ok) {
-        setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
-        return;
-      }
-
-      setStatus(t("cashuReturnedToWallet"));
-    },
-    [resolveOwnerIdForWrite, setStatus, t, update],
-  );
-
-  const pendingCashuContactSend = React.useMemo(() => {
-    if (!pendingCashuTokenContactPickId) return null;
-
-    const row = cashuTokensAllFiltered.find(
-      (candidate) =>
-        candidate.id === pendingCashuTokenContactPickId &&
-        !candidate.isDeleted &&
-        isCashuTokenIssuedState(candidate.state),
-    );
-    if (!row) return null;
-
-    const meta = extractCashuTokenMeta(row);
-    const amountSat = Number(meta.amount ?? row.amount ?? 0);
-    if (!Number.isFinite(amountSat) || amountSat <= 0) return null;
-
-    return {
-      amountSat: Math.floor(amountSat),
-      tokenId: pendingCashuTokenContactPickId,
-    };
-  }, [cashuTokensAllFiltered, pendingCashuTokenContactPickId]);
-
-  const cancelPendingCashuContactSend = React.useCallback(async () => {
-    const tokenId = pendingCashuContactSend?.tokenId ?? null;
-    setPendingCashuTokenContactPickId(null);
-    if (!tokenId) return;
-
-    await returnCashuTokenToWallet(tokenId);
-  }, [pendingCashuContactSend, returnCashuTokenToWallet]);
-
-  const reserveCashuToken = React.useCallback(
-    async (id: CashuTokenId) => {
-      const ownerId = await resolveOwnerIdForWrite();
-      const payload = {
-        id,
-        state:
-          CASHU_TOKEN_STATE_RESERVED as typeof Evolu.NonEmptyString100.Type,
-        error: null,
-      };
-      const result = ownerId
-        ? update("cashuToken", payload, { ownerId })
-        : update("cashuToken", payload);
-
-      if (!result.ok) {
-        setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
-        return;
-      }
-
-      setStatus(t("cashuReserved"));
-    },
-    [resolveOwnerIdForWrite, setStatus, t, update],
-  );
-
-  const markCashuTokenIssued = React.useCallback(
-    async (id: CashuTokenId): Promise<boolean> => {
-      const ownerId = await resolveOwnerIdForWrite();
-      const payload = {
-        id,
-        state: "issued" as typeof Evolu.NonEmptyString100.Type,
-        error: null,
-      };
-      const result = ownerId
-        ? update("cashuToken", payload, { ownerId })
-        : update("cashuToken", payload);
-
-      if (!result.ok) {
-        setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
-        return false;
-      }
-
-      return true;
-    },
-    [resolveOwnerIdForWrite, setStatus, t, update],
-  );
-
-  const deleteCashuToken = React.useCallback(
-    async (id: CashuTokenId): Promise<boolean> => {
-      const matchingAliases = new Set<string>();
-
-      for (const row of cashuTokensAll) {
-        if (row.isDeleted || row.id !== id) continue;
-        for (const alias of readCashuRowAliases(row)) {
-          matchingAliases.add(alias);
-        }
-      }
-
-      let aliasesExpanded = true;
-      while (aliasesExpanded) {
-        aliasesExpanded = false;
-
-        for (const row of cashuTokensAll) {
-          if (row.isDeleted) continue;
-          const rowAliases = readCashuRowAliases(row);
-          if (
-            rowAliases.length === 0 ||
-            !rowAliases.some((alias) => matchingAliases.has(alias))
-          ) {
-            continue;
-          }
-
-          for (const alias of rowAliases) {
-            if (matchingAliases.has(alias)) continue;
-            matchingAliases.add(alias);
-            aliasesExpanded = true;
-          }
-        }
-      }
-
-      const rowsToDelete =
-        matchingAliases.size > 0
-          ? cashuTokensAll.filter((row) => {
-              if (row.isDeleted) return false;
-              return readCashuRowAliases(row).some((alias) =>
-                matchingAliases.has(alias),
-              );
-            })
-          : [];
-
-      if (rowsToDelete.length > 0) {
-        for (const row of rowsToDelete) {
-          const rowOwnerId = readCashuRowOwnerId(row);
-          const payload = {
-            id: row.id,
-            isDeleted: Evolu.sqliteTrue,
-          };
-          const result = rowOwnerId
-            ? update("cashuToken", payload, { ownerId: row.ownerId })
-            : update("cashuToken", payload);
-
-          if (!result.ok) {
-            setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
-            return false;
-          }
-        }
-
-        return true;
-      }
-
-      const ownerId = await resolveOwnerIdForWrite();
-      const payload = {
-        id,
-        isDeleted: Evolu.sqliteTrue,
-      };
-      const result = ownerId
-        ? update("cashuToken", payload, { ownerId })
-        : update("cashuToken", payload);
-
-      if (!result.ok) {
-        setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
-        return false;
-      }
-
-      return true;
-    },
-    [
-      cashuTokensAll,
-      readCashuRowAliases,
-      readCashuRowOwnerId,
-      resolveOwnerIdForWrite,
-      setStatus,
-      t,
-      update,
-    ],
-  );
-
-  const startSendCashuTokenToContact = React.useCallback(
-    async (id: CashuTokenId) => {
-      setPendingCashuTokenContactPickId(id);
-      setStatus(t("cashuSelectContactToSend"));
-      navigateTo({ route: "contacts" });
-    },
-    [setStatus, t],
-  );
-
-  const sendCashuTokenToContact = React.useCallback(
-    async (contact: DisplayContact, tokenId: CashuTokenId) => {
-      setPendingCashuTokenContactPickId(null);
-
-      const row = cashuTokensAllFiltered.find(
-        (candidate) => candidate.id === tokenId && !candidate.isDeleted,
-      );
-      const tokenMeta = row ? extractCashuTokenMeta(row) : null;
-      const tokenText = String(tokenMeta?.tokenText ?? "").trim();
-
-      if (!row || !tokenText || !isCashuTokenIssuedState(row.state)) {
-        setStatus(t("cashuInvalid"));
-        return;
-      }
-
-      const contactId = String(contact.id ?? "").trim();
-      if (!contactId) {
-        setStatus(t("contactNotFound"));
-        return;
-      }
-
-      if (!currentNsec) {
-        setStatus(t("profileMissingNpub"));
-        return;
-      }
-
-      let contactPubHex = normalizePubkeyHex(contact.unknownPubkeyHex);
-      const contactNpub = normalizeNpubIdentifier(contact.npub);
-
-      if (!contactPubHex && contactNpub) {
-        let decodedContact: ReturnType<typeof nip19.decode> | null = null;
-        try {
-          decodedContact = nip19.decode(contactNpub);
-        } catch {
-          decodedContact = null;
-        }
-        if (
-          decodedContact &&
-          decodedContact.type === "npub" &&
-          typeof decodedContact.data === "string"
-        ) {
-          contactPubHex = decodedContact.data;
-        }
-      }
-
-      if (!contactPubHex) {
-        setStatus(t("chatMissingContactNpub"));
-        return;
-      }
-
-      const transactionNote =
-        String(contact.name ?? "").trim() ||
-        String(contact.lnAddress ?? "").trim() ||
-        null;
-      const logIssuedTokenSendTransaction = (phase: "complete" | "publish") => {
-        logPaymentEvent({
-          amount: tokenMeta?.amount ?? null,
-          contactId: contact.id as ContactId,
-          details: {
-            usedInputTokens: [tokenText],
-          },
-          direction: "out",
-          error: null,
-          fee: null,
-          method: "cashu_chat",
-          mint: tokenMeta?.mint ?? null,
-          note: transactionNote,
-          phase,
-          status: "ok",
-          unit: tokenMeta?.unit ?? null,
-        });
-      };
-
-      let activeClientId: string | null = null;
-
-      try {
-        const { getEventHash, getPublicKey } = await import("nostr-tools");
-
-        const decodedMe = nip19.decode(currentNsec);
-        if (
-          decodedMe.type !== "nsec" ||
-          !(decodedMe.data instanceof Uint8Array)
-        ) {
-          throw new Error("invalid nsec");
-        }
-
-        const privBytes = decodedMe.data;
-        const myPubHex = getPublicKey(privBytes);
-        const clientId = makeLocalId();
-        activeClientId = clientId;
-        activeNostrMessagePublishClientIdsRef.current.add(clientId);
-
-        const baseEvent = {
-          created_at: Math.ceil(Date.now() / 1e3),
-          kind: 14,
-          pubkey: myPubHex,
-          tags: [
-            ["p", contactPubHex],
-            ["p", myPubHex],
-            ["client", clientId],
-          ],
-          content: tokenText,
-        } satisfies UnsignedEvent;
-
-        const rumorId = getEventHash(baseEvent);
-        const pendingId = appendLocalNostrMessage({
-          contactId,
-          direction: "out",
-          content: tokenText,
-          wrapId: `pending:${clientId}`,
-          rumorId,
-          pubkey: myPubHex,
-          createdAtSec: baseEvent.created_at,
-          status: "pending",
-          clientId,
-        });
-
-        const deleted = await deleteCashuToken(tokenId);
-        if (!deleted) {
-          return;
-        }
-
-        navigateTo({ route: "chat", id: contactId });
-
-        const isOffline =
-          typeof navigator !== "undefined" && navigator.onLine === false;
-        if (isOffline) {
-          logIssuedTokenSendTransaction("publish");
-          setStatus(t("chatQueued"));
-          return;
-        }
-
-        const wrapForMe = wrapEventWithoutPushMarker(
-          baseEvent,
-          privBytes,
-          myPubHex,
-        );
-        const wrapForContact = wrapEventWithPushMarker(
-          baseEvent,
-          privBytes,
-          contactPubHex,
-        );
-
-        const pool = await getSharedAppNostrPool();
-        const publishOutcome = await publishWrappedWithRetry(
-          pool,
-          NOSTR_RELAYS,
-          wrapForMe,
-          wrapForContact,
-        );
-
-        if (!publishOutcome.anySuccess) {
-          logIssuedTokenSendTransaction("publish");
-          setStatus(t("chatQueued"));
-          return;
-        }
-
-        chatSeenWrapIdsRef.current.add(String(wrapForMe.id ?? ""));
-        if (pendingId) {
-          updateLocalNostrMessage(pendingId, {
-            status: "sent",
-            wrapId: String(wrapForMe.id ?? ""),
-            pubkey: myPubHex,
-            rumorId,
-          });
-        }
-
-        logIssuedTokenSendTransaction("complete");
-      } catch (error) {
-        setStatus(`${t("errorPrefix")}: ${String(error ?? "unknown")}`);
-      } finally {
-        if (activeClientId) {
-          activeNostrMessagePublishClientIdsRef.current.delete(activeClientId);
-        }
-      }
-    },
-    [
-      appendLocalNostrMessage,
-      cashuTokensAllFiltered,
-      currentNsec,
-      logPaymentEvent,
-      deleteCashuToken,
-      publishWrappedWithRetry,
-      setStatus,
-      t,
-      updateLocalNostrMessage,
-    ],
-  );
-
   const shareCashuTokenText = React.useCallback(
     async (id: CashuTokenId, text: string) => {
       const trimmed = String(text ?? "").trim();
@@ -4203,26 +1412,6 @@ export const useAppShellComposition = () => {
       pendingCashuTokenContactPickId,
       sendCashuTokenToContact,
     ],
-  );
-
-  const handleMintIconLoad = React.useCallback(
-    (origin: string, url: string | null) => {
-      setMintIconUrlByMint((prev) => ({
-        ...prev,
-        [origin]: url,
-      }));
-    },
-    [],
-  );
-
-  const handleMintIconError = React.useCallback(
-    (origin: string, url: string | null) => {
-      setMintIconUrlByMint((prev) => ({
-        ...prev,
-        [origin]: url,
-      }));
-    },
-    [],
   );
 
   const renderContactCard = React.useCallback(
@@ -4340,1108 +1529,6 @@ export const useAppShellComposition = () => {
       });
     };
 
-  const restoreMissingTokens = useRestoreMissingTokens({
-    cashuIsBusy,
-    cashuTokensAll: cashuTokensAllFiltered,
-    defaultMintUrl,
-    enqueueCashuOp,
-    upsert,
-    isMintDeleted,
-    logPaymentEvent,
-    mintInfoDeduped,
-    pushToast,
-    readSeenMintsFromStorage,
-    rememberSeenMint,
-    resolveOwnerIdForWrite,
-    setCashuIsBusy,
-    setTokensRestoreIsBusy,
-    t,
-    tokensRestoreIsBusy,
-  });
-
-  const mainMintForTokenList = React.useMemo(
-    () => normalizeMintUrl(defaultMintUrl ?? MAIN_MINT_URL),
-    [defaultMintUrl],
-  );
-
-  const largestForeignMintForTokenList = React.useMemo(() => {
-    if (!mainMintForTokenList) return null;
-
-    const groups = new Map<
-      string,
-      { mint: string; sum: number; tokens: string[] }
-    >();
-    for (const row of cashuTokensWithMeta) {
-      if (!isCashuTokenAcceptedState(row.state)) continue;
-
-      const mint = normalizeMintUrl(String(row.mint ?? "").trim());
-      if (!mint || mint === mainMintForTokenList) continue;
-
-      const tokenText = String(row.token ?? row.rawToken ?? "").trim();
-      if (!tokenText) continue;
-
-      const amount = Number(row.amount ?? 0);
-      const nextAmount = Number.isFinite(amount) && amount > 0 ? amount : 0;
-      const entry = groups.get(mint) ?? { mint, sum: 0, tokens: [] };
-      entry.sum += nextAmount;
-      entry.tokens.push(tokenText);
-      groups.set(mint, entry);
-    }
-
-    let selected: { mint: string; sum: number; tokens: string[] } | null = null;
-    for (const entry of groups.values()) {
-      if (!selected || entry.sum > selected.sum) {
-        selected = entry;
-      }
-    }
-
-    return selected;
-  }, [cashuTokensWithMeta, mainMintForTokenList]);
-
-  const formatMintButtonLabel = React.useCallback((mintUrl: string) => {
-    try {
-      return new URL(mintUrl).host || mintUrl.replace(/^https?:\/\//i, "");
-    } catch {
-      return mintUrl.replace(/^https?:\/\//i, "");
-    }
-  }, []);
-
-  const cashuMeltToMainMintButtonLabel =
-    mainMintForTokenList && largestForeignMintForTokenList
-      ? t("cashuMeltToMainMint").replace(
-          "{mint}",
-          formatMintButtonLabel(mainMintForTokenList),
-        )
-      : null;
-
-  const emitCashuToken = React.useCallback(async () => {
-    const amountSat = Number.parseInt(cashuEmitAmount.trim(), 10);
-    if (!Number.isFinite(amountSat) || amountSat <= 0) {
-      setStatus(t("payInvalidAmount"));
-      return;
-    }
-
-    if (cashuIsBusy) return;
-    if (cashuBalance < amountSat) {
-      setStatus(t("payInsufficient"));
-      return;
-    }
-
-    const insertCashuTokenRecord = async (args: {
-      amount?: number | null;
-      mint?: string | null;
-      state: "accepted" | "issued";
-      token: string;
-      unit?: string | null;
-    }) => {
-      const targetAliases = readCashuRowAliases({
-        rawToken: null,
-        token: args.token,
-      });
-      const targetId = String(createCashuTokenId(args.token));
-      const ownerId = await resolveOwnerIdForWrite();
-      const existingRow = cashuTokensAll.find((row) => {
-        return (
-          String(row.id ?? "") === targetId ||
-          readCashuRowAliases(row).some((alias) =>
-            targetAliases.includes(alias),
-          )
-        );
-      });
-
-      if (existingRow) {
-        return {
-          ownerId,
-          ok: true,
-          error: null,
-          rowId: existingRow.id,
-          skippedDuplicate: true,
-        };
-      }
-
-      const payload: {
-        id: CashuTokenId;
-        token: typeof Evolu.NonEmptyString.Type;
-        state: typeof Evolu.NonEmptyString100.Type;
-      } = {
-        id: createCashuTokenId(args.token),
-        token: args.token as typeof Evolu.NonEmptyString.Type,
-        state: args.state as typeof Evolu.NonEmptyString100.Type,
-      };
-
-      const result = ownerId
-        ? upsert("cashuToken", payload, { ownerId })
-        : upsert("cashuToken", payload);
-      return {
-        ownerId,
-        ok: result.ok,
-        error: result.ok
-          ? null
-          : getUnknownErrorMessage(result.error, "unknown"),
-        rowId: result.ok ? result.value.id : null,
-        skippedDuplicate: false,
-      };
-    };
-
-    const deleteCashuRows = async (
-      rows: readonly {
-        id?: CashuTokenId | string | null;
-        ownerId?: unknown;
-      }[],
-      fallbackOwnerId?: Evolu.OwnerId | null,
-    ) => {
-      for (const row of rows) {
-        if (!row.id) continue;
-        const payload = { id: row.id, isDeleted: Evolu.sqliteTrue };
-        const ownerId = resolveCashuRowStoredOwnerLane(row) ?? fallbackOwnerId;
-        const result = ownerId
-          ? update("cashuToken", payload, { ownerId })
-          : update("cashuToken", payload);
-        if (!result.ok) {
-          throw new Error(getUnknownErrorMessage(result.error, "unknown"));
-        }
-      }
-    };
-
-    setCashuIsBusy(true);
-    setStatus(t("cashuEmitting"));
-
-    try {
-      const mintGroups = new Map<string, { tokens: string[]; sum: number }>();
-      for (const row of cashuTokensWithMeta) {
-        if (!isCashuTokenAcceptedState(row.state)) continue;
-
-        const mint = String(row.mint ?? "").trim();
-        if (!mint) continue;
-
-        const tokenText = String(row.token ?? row.rawToken ?? "").trim();
-        if (!tokenText) continue;
-
-        const amount = Number(row.amount ?? 0) || 0;
-        const entry = mintGroups.get(mint) ?? { tokens: [], sum: 0 };
-        entry.tokens.push(tokenText);
-        entry.sum += amount;
-        mintGroups.set(mint, entry);
-      }
-
-      const preferredMint = normalizeMintUrl(defaultMintUrl ?? "");
-      const candidates = buildCashuMintCandidates(mintGroups, preferredMint);
-
-      if (candidates.length === 0) {
-        setStatus(t("payInsufficient"));
-        return;
-      }
-
-      const candidate = selectSingleMintCandidateForAmount(
-        candidates,
-        amountSat,
-      );
-      if (!candidate) {
-        setStatus(t("payInsufficient"));
-        return;
-      }
-
-      const maxReservedFeeSat = getPaymentAmountReserveCap(
-        amountSat,
-        candidate.sum,
-      );
-
-      let selectedTokenId: CashuTokenId | null = null;
-      let finalError: string | null = null;
-
-      const attempts = buildPaymentAmountAttempts(
-        amountSat,
-        candidate.sum,
-      ).filter((attemptAmountSat) => {
-        return amountSat - attemptAmountSat <= maxReservedFeeSat;
-      });
-
-      if (attempts.length === 0) {
-        setStatus(t("payInsufficient"));
-        return;
-      }
-
-      for (const attemptAmountSat of attempts) {
-        const split = await createSendTokenWithTokensAtMint({
-          amount: attemptAmountSat,
-          mint: candidate.mint,
-          tokens: candidate.tokens,
-          unit: "sat",
-        });
-
-        if (!split.ok) {
-          finalError = String(split.error ?? "unknown");
-
-          if (split.remainingToken && split.remainingAmount > 0) {
-            const recoveryInsert = await insertCashuTokenRecord({
-              token: split.remainingToken,
-              mint: split.mint,
-              unit: split.unit,
-              amount: split.remainingAmount,
-              state: "accepted",
-            });
-            if (!recoveryInsert.ok) {
-              throw new Error(String(recoveryInsert.error));
-            }
-
-            const spentRows = cashuTokensWithMeta.filter((row) => {
-              return (
-                isCashuTokenAcceptedState(row.state) &&
-                String(row.mint ?? "").trim() === candidate.mint
-              );
-            });
-            await deleteCashuRows(spentRows, recoveryInsert.ownerId);
-            break;
-          }
-
-          if (isRetryablePaymentAmountFailure(finalError)) {
-            continue;
-          }
-          break;
-        }
-
-        const spentRows = cashuTokensWithMeta.filter((row) => {
-          return (
-            isCashuTokenAcceptedState(row.state) &&
-            String(row.mint ?? "").trim() === candidate.mint
-          );
-        });
-        const spentOwnerId = await resolveOwnerIdForWrite();
-        await deleteCashuRows(spentRows, spentOwnerId);
-
-        if (split.remainingToken && split.remainingAmount > 0) {
-          const remainingInsert = await insertCashuTokenRecord({
-            token: split.remainingToken,
-            mint: split.mint,
-            unit: split.unit,
-            amount: split.remainingAmount,
-            state: "accepted",
-          });
-          if (!remainingInsert.ok) {
-            throw new Error(String(remainingInsert.error));
-          }
-        }
-
-        const issuedInsert = await insertCashuTokenRecord({
-          token: split.sendToken,
-          mint: split.mint,
-          unit: split.unit,
-          amount: split.sendAmount,
-          state: "issued",
-        });
-        if (!issuedInsert.ok || !issuedInsert.rowId) {
-          throw new Error(
-            String(issuedInsert.error ?? "missing issued token id"),
-          );
-        }
-
-        selectedTokenId = issuedInsert.rowId;
-        logPaymentEvent({
-          direction: "out",
-          status: "ok",
-          amount: split.sendAmount,
-          details: {
-            ...(split.remainingToken
-              ? { gainedToken: split.remainingToken }
-              : {}),
-            issuedToken: split.sendToken,
-            usedInputTokens: candidate.tokens,
-          },
-          fee: null,
-          mint: split.mint,
-          unit: split.unit,
-          error: null,
-          contactId: null,
-          method: "unknown",
-          phase: "swap",
-        });
-        break;
-      }
-
-      if (!selectedTokenId) {
-        const errorMessage = finalError ?? t("payInsufficient");
-        logPaymentEvent({
-          direction: "out",
-          status: "error",
-          amount: amountSat,
-          fee: null,
-          mint: null,
-          unit: "sat",
-          error: errorMessage,
-          contactId: null,
-          method: "unknown",
-          phase: "swap",
-        });
-        setStatus(`${t("payFailed")}: ${errorMessage}`);
-        return;
-      }
-
-      setCashuEmitAmount("");
-      navigateTo({ route: "cashuToken", id: selectedTokenId });
-    } catch (error) {
-      const errorMessage = getUnknownErrorMessage(error, "unknown");
-      logPaymentEvent({
-        direction: "out",
-        status: "error",
-        amount: amountSat,
-        fee: null,
-        mint: null,
-        unit: "sat",
-        error: errorMessage,
-        contactId: null,
-        method: "unknown",
-        phase: "swap",
-      });
-      setStatus(`${t("payFailed")}: ${errorMessage}`);
-    } finally {
-      setCashuIsBusy(false);
-    }
-  }, [
-    buildCashuMintCandidates,
-    cashuBalance,
-    cashuEmitAmount,
-    cashuIsBusy,
-    cashuTokensAll,
-    cashuTokensWithMeta,
-    defaultMintUrl,
-    logPaymentEvent,
-    readCashuRowAliases,
-    resolveOwnerIdForWrite,
-    setCashuEmitAmount,
-    setStatus,
-    t,
-    update,
-    upsert,
-  ]);
-
-  // Shared per-quote in-flight set so the inline claim trigger in the
-  // autoswap path and the 5s background tick can never both successfully
-  // call mintTopupProofs for the same quote. Without this, the second path
-  // would land in the NUT-09 restore branch, return proofs in a different
-  // order than the first, encode a different token string, miss the
-  // isCashuTokenKnownAny dedup, and insert a duplicate cashuToken row.
-  const autoswapClaimInFlightRef = React.useRef<Set<string>>(new Set());
-  // Cross-tick cache so the background claim effect doesn't reload the
-  // target-mint wallet (info+keysets+keys) every tick while a quote is
-  // still PENDING at the mint. Keyed by `mintUrl|unit`; entries cleared
-  // on logout (effect cleanup).
-  const autoswapClaimWalletCacheRef = React.useRef<
-    Map<string, LoadedCashuWallet>
-  >(new Map());
-
-  const meltLargestForeignMintToMainMint = React.useCallback(async () => {
-    if (cashuIsBusy) return;
-
-    const targetMint = normalizeMintUrl(defaultMintUrl ?? MAIN_MINT_URL);
-    if (!targetMint) {
-      setStatus(t("mintUrlInvalid"));
-      return;
-    }
-
-    const sourceGroups = new Map<string, { mint: string; sum: number }>();
-    for (const row of cashuTokensWithMeta) {
-      if (!isCashuTokenAcceptedState(row.state)) continue;
-
-      const mint = normalizeMintUrl(String(row.mint ?? "").trim());
-      if (!mint || mint === targetMint) continue;
-
-      const amount = Number(row.amount ?? 0);
-      const nextAmount = Number.isFinite(amount) && amount > 0 ? amount : 0;
-      const entry = sourceGroups.get(mint) ?? { mint, sum: 0 };
-      entry.sum += nextAmount;
-      sourceGroups.set(mint, entry);
-    }
-
-    let sourceMint: string | null = null;
-    let sourceBalance = 0;
-    for (const entry of sourceGroups.values()) {
-      if (!sourceMint || entry.sum > sourceBalance) {
-        sourceMint = entry.mint;
-        sourceBalance = entry.sum;
-      }
-    }
-
-    if (!sourceMint || sourceBalance <= 0) {
-      setStatus(t("cashuMeltToMainMintUnavailable"));
-      return;
-    }
-
-    const sourceRows = cashuTokensWithMeta.filter((row) => {
-      if (!isCashuTokenAcceptedState(row.state)) return false;
-      return normalizeMintUrl(String(row.mint ?? "").trim()) === sourceMint;
-    });
-    const sourceTokens = sourceRows
-      .map((row) => String(row.token ?? row.rawToken ?? "").trim())
-      .filter((tokenText) => tokenText.length > 0);
-
-    if (sourceTokens.length === 0) {
-      setStatus(t("cashuMeltToMainMintUnavailable"));
-      return;
-    }
-
-    interface AcceptedCashuTokenPayload {
-      id: CashuTokenId;
-      state: "accepted";
-      token: string;
-    }
-
-    const insertAcceptedToken = async (args: {
-      amount?: number | null;
-      mint?: string | null;
-      rawToken?: string | null;
-      token: string;
-      unit?: string | null;
-    }) => {
-      const targetAliases = readCashuRowAliases({
-        rawToken: args.rawToken ?? null,
-        token: args.token,
-      });
-      const targetId = String(createCashuTokenId(args.rawToken || args.token));
-      const ownerId = await resolveOwnerIdForWrite();
-      const existingRow = cashuTokensAll.find((row) => {
-        return (
-          String(row.id ?? "") === targetId ||
-          readCashuRowAliases(row).some((alias) =>
-            targetAliases.includes(alias),
-          )
-        );
-      });
-
-      if (existingRow) {
-        return {
-          ownerId,
-          ok: true,
-          error: null,
-          rowId: existingRow.id,
-          skippedDuplicate: true,
-        };
-      }
-
-      const payload: AcceptedCashuTokenPayload = {
-        id: createCashuTokenId(args.rawToken || args.token),
-        token: args.token,
-        state: "accepted",
-      };
-
-      const result = ownerId
-        ? upsert("cashuToken", payload, { ownerId })
-        : upsert("cashuToken", payload);
-      return {
-        ownerId,
-        ok: result.ok,
-        error: result.ok
-          ? null
-          : getUnknownErrorMessage(result.error, "unknown"),
-        rowId: result.ok ? result.value.id : null,
-        skippedDuplicate: false,
-      };
-    };
-
-    const markRowsDeleted = async (
-      rows: Array<{
-        id?: CashuTokenId | string | null;
-        ownerId?: unknown;
-      }>,
-      fallbackOwnerId?: Evolu.OwnerId | null,
-    ) => {
-      for (const row of rows) {
-        if (!row.id) continue;
-        const payload = { id: row.id, isDeleted: Evolu.sqliteTrue };
-        const ownerId = resolveCashuRowStoredOwnerLane(row) ?? fallbackOwnerId;
-        const result = ownerId
-          ? update("cashuToken", payload, { ownerId })
-          : update("cashuToken", payload);
-        if (!result.ok) {
-          throw new Error(getUnknownErrorMessage(result.error, "unknown"));
-        }
-      }
-    };
-
-    const initialAmountAttempts = buildPaymentAmountAttempts(
-      sourceBalance,
-      sourceBalance,
-    );
-    // Cap retries hard. Each iteration creates a fresh top-up quote at the
-    // target mint, and most mints rate-limit quote creation aggressively
-    // (we have hit 429 on `/v1/mint/quote/bolt11` and even `/v1/info` on
-    // mint.lnpay.cz). Eight matches buildPaymentAmountAttempts's natural
-    // stepping schedule [0,1,2,3,5,8,13,21] so we can reach a 21-sat drop
-    // off the source balance — enough headroom for percentage fee_reserve
-    // schedules (e.g. 1% with min) on borderline balances.
-    const MAX_AMOUNT_ATTEMPTS = 8;
-    const queuedAmountAttempts = [...initialAmountAttempts].slice(
-      0,
-      MAX_AMOUNT_ATTEMPTS,
-    );
-    const seenAmountAttempts = new Set(queuedAmountAttempts);
-    let finalError = t("cashuMeltToMainMintFailed");
-
-    setCashuIsBusy(true);
-    setStatus(t("cashuMeltToMainMintProcessing"));
-
-    try {
-      rememberSeenMint(targetMint);
-      // Skip refreshMintInfo here: the mint store already
-      // gates on a once-per-session ref (useMintInfoStore.ts) and the boot
-      // effect auto-refreshes the default mint at app startup. The wallet
-      // load below independently fetches info+keysets+keys via cashu-ts,
-      // which is what melt actually needs.
-
-      const { Mint, Wallet } = await getCashuLib();
-      const det = getCashuDeterministicSeedFromStorage();
-      const targetWallet = await createLoadedCashuWallet({
-        Mint,
-        Wallet,
-        mintUrl: targetMint,
-        unit: "sat",
-        ...(det ? { bip39seed: det.bip39seed } : {}),
-      });
-      const { meltInvoiceWithTokensAtMint, prepareMeltMintContext } =
-        await import("../cashuMelt");
-
-      // Pre-load source-mint context (info+keysets+keys+checkstate) once.
-      // Each retry only varies the amount; reusing the wallet handle and the
-      // already-state-checked spendable proofs across attempts cuts ~4
-      // mint round-trips per iteration. The melt-quote / swap / melt steps
-      // still run per-attempt because they bind to the per-attempt invoice.
-      let sourceMeltContext: Awaited<
-        ReturnType<typeof prepareMeltMintContext>
-      > | null = null;
-      try {
-        sourceMeltContext = await prepareMeltMintContext({
-          mint: sourceMint,
-          tokens: sourceTokens,
-          unit: "sat",
-        });
-      } catch (error) {
-        finalError = getUnknownErrorMessage(error, "unknown");
-      }
-
-      // Pre-flight fee discovery: ask source mint how much fee_reserve + input
-      // fee it will charge for a probe invoice of the full sourceBalance, then
-      // size the first target-mint invoice as
-      //   sourceAmount = sourceBalance - fee_reserve - input_fee
-      // so the first real melt attempt has the right headroom instead of
-      // burning the entire retry ladder hitting Insufficient.
-      if (sourceMeltContext) {
-        try {
-          const probe = await requestMintQuoteBolt11({
-            amountSat: sourceBalance,
-            mintUrl: targetMint,
-          });
-          const probeMeltQuote =
-            await sourceMeltContext.wallet.createMeltQuoteBolt11(probe.invoice);
-          const probeFeeReserve = cashuAmountToNumber(
-            probeMeltQuote.fee_reserve,
-          );
-          const probeInputFee = cashuAmountToNumber(
-            sourceMeltContext.wallet.getFeesForProofs(
-              sourceMeltContext.spendableProofs,
-            ),
-          );
-          const sizedAmount = Math.max(
-            1,
-            sourceBalance - probeFeeReserve - probeInputFee,
-          );
-          if (
-            Number.isFinite(sizedAmount) &&
-            sizedAmount >= 1 &&
-            sizedAmount < sourceBalance
-          ) {
-            // Drop the no-fee-reserve attempts that we now know will fail and
-            // promote the discovered sized amount to the front of the queue.
-            const tail = queuedAmountAttempts.filter(
-              (candidate) => candidate < sizedAmount,
-            );
-            queuedAmountAttempts.length = 0;
-            queuedAmountAttempts.push(sizedAmount, ...tail);
-            seenAmountAttempts.clear();
-            for (const candidate of queuedAmountAttempts) {
-              seenAmountAttempts.add(candidate);
-            }
-          }
-        } catch {
-          // Probe failed (rate-limited mint, network error, etc.). Fall
-          // through to the original retry strategy starting from sourceBalance.
-        }
-      }
-
-      let activeSourceRows: Array<{ id?: CashuTokenId | string | null }> =
-        sourceRows;
-      let activeSourceOwnerId = cashuOwnerId;
-      let activeSourceTokens = sourceTokens;
-
-      for (
-        let attemptIndex = 0;
-        attemptIndex < queuedAmountAttempts.length;
-        attemptIndex += 1
-      ) {
-        const amountSat = queuedAmountAttempts[attemptIndex];
-        let quoteId = "";
-        let invoice = "";
-
-        try {
-          const requestedQuote = await requestMintQuoteBolt11({
-            amountSat,
-            mintUrl: targetMint,
-          });
-          quoteId = requestedQuote.quoteId;
-          invoice = requestedQuote.invoice;
-
-          const meltResult = await meltInvoiceWithTokensAtMint({
-            invoice,
-            mint: sourceMint,
-            tokens: activeSourceTokens,
-            unit: "sat",
-            ...(sourceMeltContext ? { context: sourceMeltContext } : {}),
-          });
-
-          if (!meltResult.ok) {
-            const errorMessage = String(meltResult.error ?? "unknown");
-
-            if (meltResult.remainingToken && meltResult.remainingAmount > 0) {
-              const retryable = isRetryablePaymentAmountFailure(errorMessage);
-
-              if (retryable) {
-                const recoveryInsert = await insertAcceptedToken({
-                  token: meltResult.remainingToken,
-                  mint: meltResult.mint,
-                  unit: meltResult.unit,
-                  amount: meltResult.remainingAmount,
-                });
-                if (!recoveryInsert.ok || !recoveryInsert.rowId) {
-                  throw new Error(
-                    String(recoveryInsert.error ?? "missing recovery token id"),
-                  );
-                }
-
-                await markRowsDeleted(activeSourceRows, activeSourceOwnerId);
-
-                activeSourceRows = [
-                  {
-                    id: recoveryInsert.rowId,
-                  },
-                ];
-                activeSourceOwnerId = recoveryInsert.ownerId;
-                activeSourceTokens = [meltResult.remainingToken];
-
-                finalError = errorMessage;
-                break;
-              }
-
-              const recoveryInsert = await insertAcceptedToken({
-                token: meltResult.remainingToken,
-                mint: meltResult.mint,
-                unit: meltResult.unit,
-                amount: meltResult.remainingAmount,
-              });
-              if (!recoveryInsert.ok) {
-                throw new Error(String(recoveryInsert.error));
-              }
-              await markRowsDeleted(activeSourceRows, activeSourceOwnerId);
-              finalError = errorMessage;
-              break;
-            }
-
-            if (
-              isRetryablePaymentAmountFailure(errorMessage) &&
-              queuedAmountAttempts.length < MAX_AMOUNT_ATTEMPTS
-            ) {
-              // Prefer stepping by the exact shortage the mint reported
-              // (`need X, have Y`), then fall back through the fee ladder.
-              // For tiny balances this matters: 2 sats with a 1-sat input
-              // fee should retry 1 sat, not drop straight to 0.
-              const candidates = buildPaymentFailureAmountAttempts(
-                amountSat,
-                errorMessage,
-              );
-              for (const retryAmount of candidates) {
-                if (seenAmountAttempts.has(retryAmount)) continue;
-                seenAmountAttempts.add(retryAmount);
-                queuedAmountAttempts.push(retryAmount);
-                if (queuedAmountAttempts.length >= MAX_AMOUNT_ATTEMPTS) break;
-              }
-              // Brief pause before re-hitting the mint quote endpoint —
-              // back-to-back POSTs trigger 429 on most public mints.
-              await new Promise<void>((resolve) => {
-                window.setTimeout(resolve, 800);
-              });
-            }
-
-            finalError = errorMessage;
-            continue;
-          }
-
-          if (meltResult.remainingToken && meltResult.remainingAmount > 0) {
-            const remainingInsert = await insertAcceptedToken({
-              token: meltResult.remainingToken,
-              mint: meltResult.mint,
-              unit: meltResult.unit,
-              amount: meltResult.remainingAmount,
-            });
-            if (!remainingInsert.ok) {
-              throw new Error(String(remainingInsert.error));
-            }
-          }
-
-          const mintedUnit = targetWallet.unit ?? "sat";
-
-          // Persist the pending claim BEFORE deleting the source rows so
-          // the background autoswap-claim effect can recover after a crash.
-          // The actual mintProofs + insert is shared with that effect via
-          // claimAutoswapPendingEntry + a per-quote in-flight set, so we
-          // can fire it inline here for instant UX without any duplicate
-          // risk: if the 5s tick happens to overlap, the second caller
-          // sees in_flight and bails.
-          const pendingClaimOwnerKey = String(appOwnerId ?? "anon");
-          const pendingClaimsKey =
-            makePendingAutoswapClaimsKey(pendingClaimOwnerKey);
-          const pendingClaim: AutoswapPendingClaim = {
-            amount: amountSat,
-            createdAtMs: Date.now(),
-            invoice,
-            mintUrl: targetMint,
-            quote: quoteId,
-            unit: mintedUnit,
-          };
-          appendPendingAutoswapClaim(pendingClaimsKey, pendingClaim);
-
-          await markRowsDeleted(activeSourceRows, activeSourceOwnerId);
-
-          void (async () => {
-            // Best-effort instant claim. Failures (mint quote not yet
-            // claimable, network error, 429) are picked up by the
-            // background tick on its next 5s pass.
-            const outcome = await claimAutoswapPendingEntry({
-              claim: pendingClaim,
-              claimOwnerKey: pendingClaimOwnerKey,
-              claimsKey: pendingClaimsKey,
-              ctx: {
-                upsert,
-                isCashuTokenKnownAny,
-                resolveOwnerIdForWrite,
-              },
-              inFlightSet: autoswapClaimInFlightRef.current,
-              walletCache: autoswapClaimWalletCacheRef.current,
-            });
-            if (outcome.kind === "claimed") {
-              const okAmount = formatDisplayedAmountParts(amountSat);
-              setStatus(
-                t("cashuMeltToMainMintDone")
-                  .replace(
-                    "{amount}",
-                    `${okAmount.approxPrefix}${okAmount.amountText}`,
-                  )
-                  .replace("{unit}", okAmount.unitLabel)
-                  .replace("{mint}", formatMintButtonLabel(targetMint)),
-              );
-            }
-          })();
-
-          const displayAmount = formatDisplayedAmountParts(amountSat);
-          setStatus(
-            t("cashuMeltToMainMintPending")
-              .replace(
-                "{amount}",
-                `${displayAmount.approxPrefix}${displayAmount.amountText}`,
-              )
-              .replace("{unit}", displayAmount.unitLabel),
-          );
-          return;
-        } catch (error) {
-          finalError = getUnknownErrorMessage(error, "unknown");
-          if (!isRetryablePaymentAmountFailure(finalError)) {
-            break;
-          }
-        }
-      }
-
-      setStatus(`${t("cashuMeltToMainMintFailed")}: ${finalError}`);
-    } finally {
-      setCashuIsBusy(false);
-    }
-  }, [
-    cashuIsBusy,
-    cashuOwnerId,
-    cashuTokensAll,
-    cashuTokensWithMeta,
-    defaultMintUrl,
-    appOwnerId,
-    formatDisplayedAmountParts,
-    formatMintButtonLabel,
-    upsert,
-    isCashuTokenKnownAny,
-    readCashuRowAliases,
-    rememberSeenMint,
-    resolveOwnerIdForWrite,
-    setCashuIsBusy,
-    setStatus,
-    t,
-    update,
-  ]);
-
-  const autoswapAttemptedSignatureRef = React.useRef<string | null>(null);
-  const autoswapInFlightRef = React.useRef(false);
-  React.useEffect(() => {
-    meltLargestForeignMintToMainMintRef.current =
-      meltLargestForeignMintToMainMint;
-  }, [meltLargestForeignMintToMainMint]);
-
-  const closePaymentMintMeltConfirmation = React.useCallback(() => {
-    if (cashuIsBusy) return;
-    setPendingPaymentMintMeltConfirmation(null);
-  }, [cashuIsBusy]);
-
-  const confirmPaymentMintMelt = React.useCallback(async () => {
-    if (cashuIsBusy) return;
-    setPendingPaymentMintMeltConfirmation(null);
-    await meltLargestForeignMintToMainMintRef.current();
-  }, [cashuIsBusy]);
-
-  // Below this threshold the melt fee_reserve typically dominates the
-  // foreign-mint balance, so the swap fails with "Insufficient funds" and
-  // we end up with stranded dust at both the source and target mints. The
-  // user can still trigger the manual `Melt to <main mint>` button for any
-  // amount.
-  const autoswapSignature = React.useMemo(() => {
-    if (!largestForeignMintForTokenList) return null;
-    if (largestForeignMintForTokenList.sum < CASHU_AUTOSWAP_MIN_SOURCE_SUM) {
-      return null;
-    }
-    return `${largestForeignMintForTokenList.mint}|${largestForeignMintForTokenList.sum}|${largestForeignMintForTokenList.tokens.length}`;
-  }, [largestForeignMintForTokenList]);
-
-  React.useEffect(() => {
-    if (!cashuAutoswapEnabled) return;
-    if (cashuIsBusy) return;
-    if (autoswapInFlightRef.current) return;
-    if (!autoswapSignature) {
-      autoswapAttemptedSignatureRef.current = null;
-      return;
-    }
-    if (autoswapAttemptedSignatureRef.current === autoswapSignature) return;
-
-    const timeoutId = window.setTimeout(() => {
-      autoswapAttemptedSignatureRef.current = autoswapSignature;
-      autoswapInFlightRef.current = true;
-      void (async () => {
-        try {
-          await meltLargestForeignMintToMainMintRef.current();
-        } finally {
-          autoswapInFlightRef.current = false;
-        }
-      })();
-    }, 3000);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [autoswapSignature, cashuAutoswapEnabled, cashuIsBusy]);
-
-  const appOwnerIdValue = appOwnerId;
-  React.useEffect(() => {
-    const ownerKey = String(appOwnerIdValue ?? "anon");
-    const claimSources = [
-      {
-        claimsKey: makePendingAutoswapClaimsKey(ownerKey),
-        ownerKey,
-      },
-    ];
-    if (ownerKey !== "anon") {
-      claimSources.push({
-        claimsKey: makePendingAutoswapClaimsKey("anon"),
-        ownerKey: "anon",
-      });
-    }
-    const inFlightSet = autoswapClaimInFlightRef.current;
-    const walletCache = autoswapClaimWalletCacheRef.current;
-
-    let cancelled = false;
-    let tickInFlight = false;
-    let lastWarnedKey = "";
-
-    const tick = async () => {
-      if (cancelled || tickInFlight) return;
-      const pendingSources = claimSources
-        .map((source) => ({
-          ...source,
-          pending: readPendingAutoswapClaims(source.claimsKey),
-        }))
-        .filter((source) => source.pending.length > 0);
-      if (pendingSources.length === 0) return;
-      tickInFlight = true;
-      try {
-        for (const source of pendingSources) {
-          for (const claim of source.pending) {
-            if (cancelled) break;
-            const outcome = await claimAutoswapPendingEntry({
-              claim,
-              claimOwnerKey: source.ownerKey,
-              claimsKey: source.claimsKey,
-              ctx: {
-                upsert,
-                isCashuTokenKnownAny,
-                resolveOwnerIdForWrite,
-              },
-              inFlightSet,
-              walletCache,
-            });
-            if (outcome.kind === "failed") {
-              const warnKey = `${claim.mintUrl}:${claim.quote}:${outcome.reason}`;
-              if (warnKey !== lastWarnedKey) {
-                lastWarnedKey = warnKey;
-                console.warn("[linky][autoswap] background claim failed", {
-                  error: outcome.reason,
-                  mintUrl: claim.mintUrl,
-                  quote: claim.quote,
-                });
-              }
-            }
-          }
-        }
-      } finally {
-        tickInFlight = false;
-      }
-    };
-
-    void tick();
-    const intervalId = window.setInterval(() => {
-      void tick();
-    }, 5_000);
-
-    return () => {
-      cancelled = true;
-      window.clearInterval(intervalId);
-      walletCache.clear();
-    };
-  }, [appOwnerIdValue, isCashuTokenKnownAny, resolveOwnerIdForWrite, upsert]);
-
-  const requestSelectedContact = React.useCallback(async () => {
-    if (route.kind !== "contactPay") return;
-    if (!selectedContact) return;
-
-    const amountSat = Number.parseInt(String(payAmount ?? "").trim(), 10);
-    if (!Number.isFinite(amountSat) || amountSat <= 0) {
-      setStatus(t("payInvalidAmount"));
-      return;
-    }
-
-    const normalizedNpub = normalizeNpubIdentifier(selectedContact.npub);
-    if (!normalizedNpub) {
-      setStatus(t("chatMissingContactNpub"));
-      return;
-    }
-
-    let recipientPubkeyHex: string | null = null;
-    try {
-      const decoded = nip19.decode(currentNpub ?? "");
-      if (decoded.type === "npub" && typeof decoded.data === "string") {
-        recipientPubkeyHex = decoded.data;
-      }
-    } catch {
-      recipientPubkeyHex = null;
-    }
-
-    if (!recipientPubkeyHex) {
-      setStatus(t("profileMissingNpub"));
-      return;
-    }
-
-    const recipientNprofile = nip19.nprofileEncode({
-      pubkey: recipientPubkeyHex,
-      relays: NOSTR_RELAYS,
-    });
-    const preferredMint =
-      normalizeMintUrl(defaultMintUrl ?? MAIN_MINT_URL) ?? MAIN_MINT_URL;
-    const requestId = makeLocalId();
-    const requestText = buildCashuPaymentRequestMessage({
-      amount: amountSat,
-      mintUrls: [preferredMint],
-      recipientNprofile,
-      requestId,
-    });
-
-    await sendChatMessage({
-      clearDraft: false,
-      text: requestText,
-    });
-
-    logPaymentEvent({
-      amount: amountSat,
-      contactId: selectedContact.id,
-      details: {
-        mintUrls: [preferredMint],
-        recipientNprofile,
-        requestId,
-        requestText,
-      },
-      direction: "in",
-      method: "cashu_chat",
-      mint: preferredMint,
-      note: t("requestPaymentLabel"),
-      status: "ok",
-      unit: "sat",
-    });
-
-    if (
-      String(contactPayBackToChatRef.current ?? "") ===
-      String(selectedContact.id)
-    ) {
-      navigateTo({ route: "chat", id: selectedContact.id });
-      return;
-    }
-
-    navigateTo({ route: "contact", id: selectedContact.id });
-  }, [
-    currentNpub,
-    defaultMintUrl,
-    payAmount,
-    route.kind,
-    selectedContact,
-    sendChatMessage,
-    logPaymentEvent,
-    setStatus,
-    t,
-  ]);
-
-  const onPayChatPaymentRequest = React.useCallback(
-    async (
-      message: LocalNostrMessage,
-      requestInfo: CashuPaymentRequestMessageInfo,
-    ) => {
-      if (cashuIsBusy) return;
-      if (!selectedChatContact || selectedChatContact.isUnknownContact) return;
-      if (!selectedContact) return;
-
-      const requestRumorId = String(message.rumorId ?? "").trim();
-      if (!requestRumorId) return;
-
-      setCashuIsBusy(true);
-      try {
-        await payContactWithCashuMessage({
-          contact: selectedContact,
-          amountSat: requestInfo.amount,
-          paymentRequestId: requestInfo.requestId,
-          replyContext: {
-            replyToId: requestRumorId,
-            rootMessageId:
-              String(message.rootMessageId ?? "").trim() || requestRumorId,
-            replyToContent: String(message.content ?? "").trim() || null,
-          },
-        });
-      } finally {
-        setCashuIsBusy(false);
-      }
-    },
-    [
-      cashuIsBusy,
-      payContactWithCashuMessage,
-      selectedChatContact,
-      selectedContact,
-      setCashuIsBusy,
-    ],
-  );
-
   const contactPayBackToChatId = contactPayBackToChatRef.current;
   const topbar = React.useMemo(
     () =>
@@ -5496,12 +1583,6 @@ export const useAppShellComposition = () => {
           }
         : null,
     [route.kind, selectedChatContact, selectedContact?.id],
-  );
-
-  const getCashuTokenMessageInfo = React.useCallback(
-    (text: string) =>
-      getCashuTokenMessageInfoBase(text, cashuTokensAllFiltered),
-    [cashuTokensAllFiltered],
   );
 
   const openNotificationChat = React.useCallback(
@@ -6313,27 +2394,6 @@ export const useAppShellComposition = () => {
     saveCashuFromText,
     selectedContact: selectedChatContact,
   });
-  const knownLnAddressPayContact = React.useMemo(() => {
-    if (route.kind !== "lnAddressPay") return null;
-
-    const inferredLnAddress = inferLightningAddressFromLnurlTarget(
-      route.lnAddress,
-    );
-    if (!inferredLnAddress) return null;
-
-    return (
-      contacts.find(
-        (contact) =>
-          String(contact.lnAddress ?? "")
-            .trim()
-            .toLowerCase() === inferredLnAddress.toLowerCase(),
-      ) ?? null
-    );
-  }, [contacts, route]);
-  const knownLnAddressPayContactPictureUrl = React.useMemo(() => {
-    const npub = normalizeNpubIdentifier(knownLnAddressPayContact?.npub);
-    return npub ? (nostrPictureByNpub[npub] ?? null) : null;
-  }, [knownLnAddressPayContact, nostrPictureByNpub]);
 
   const { moneyRouteProps } = usePaymentMoneyComposition({
     moneyRouteBuilderInput: {

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -1,7 +1,7 @@
 import { Share } from "@capacitor/share";
 import type { Proof } from "@cashu/cashu-ts";
 import * as Evolu from "@evolu/common";
-import { useOwner, useQuery } from "@evolu/react";
+import { useQuery } from "@evolu/react";
 import {
   nip19,
   type Event as NostrToolsEvent,
@@ -23,7 +23,6 @@ import {
   useEvoluDatabaseInfoState,
   useEvoluLastError,
   useEvoluServersManager,
-  useEvoluSyncOwner,
   wipeEvoluStorage as wipeEvoluStorageImpl,
   type CashuTokenId,
   type ContactId,
@@ -58,10 +57,6 @@ import {
   parseStatusFilterValue,
 } from "../nostrStatus";
 import { writeClipboardText } from "../platform/clipboard";
-import {
-  persistSyncedActiveNostrIdentity,
-  readStoredNostrNsec,
-} from "../platform/identitySecrets";
 import {
   cancelNativeNfcWrite,
   consumePendingIosNativeDeepLinkUrl,
@@ -131,18 +126,11 @@ import { parseNpubCashProfileInfo } from "../utils/npubCashInfo";
 import { resolveNpubCashServerBaseUrl } from "../utils/npubCashServer";
 import { setStoredPushContactNames } from "../utils/pushContactNamesStorage";
 import {
-  clearStoredPushNsec,
-  setStoredPushNsec,
-} from "../utils/pushNsecStorage";
-import {
   getInitialAllowedDisplayCurrencies,
   getInitialBankPaymentOfferRecipientCount,
   getInitialCashuAutoswapEnabled,
   getInitialDisplayCurrency,
   getInitialLightningInvoiceAutoPayLimit,
-  getInitialNostrIdentitySource,
-  getInitialNostrIdentitySwitchedAtSec,
-  getInitialNostrNsec,
   getInitialPayWithCashuEnabled,
   getInitialShowProfileQrOnTiltEnabled,
   safeLocalStorageGet,
@@ -158,17 +146,13 @@ import { useCashuTokenChecks } from "./hooks/cashu/useCashuTokenChecks";
 import { useNpubCashClaim } from "./hooks/cashu/useNpubCashClaim";
 import { useRestoreMissingTokens } from "./hooks/cashu/useRestoreMissingTokens";
 import { useSaveCashuFromText } from "./hooks/cashu/useSaveCashuFromText";
+import { useIdentityOwnersComposition } from "./hooks/composition/useIdentityOwnersComposition";
 import { usePaymentMoneyComposition } from "./hooks/composition/usePaymentMoneyComposition";
-import { useProfileAuthComposition } from "./hooks/composition/useProfileAuthComposition";
 import { useProfilePeopleComposition } from "./hooks/composition/useProfilePeopleComposition";
 import { useRoutingViewComposition } from "./hooks/composition/useRoutingViewComposition";
 import { useSystemSettingsComposition } from "./hooks/composition/useSystemSettingsComposition";
 import { useContactEditor } from "./hooks/contacts/useContactEditor";
 import { useVisibleContacts } from "./hooks/contacts/useVisibleContacts";
-import {
-  ACTIVE_NOSTR_IDENTITY_ROW_ID,
-  resolveSyncedNostrIdentity,
-} from "./lib/nostrIdentitySync";
 import { useContactsOnboardingProgress } from "./hooks/guide/useContactsOnboardingProgress";
 import { useMainMenuState } from "./hooks/layout/useMainMenuState";
 import { useMainSwipeNavigation } from "./hooks/layout/useMainSwipeNavigation";
@@ -225,7 +209,6 @@ import { useCashuDomain } from "./hooks/useCashuDomain";
 import { useContactsDomain } from "./hooks/useContactsDomain";
 import { useContactsNostrPrefetchEffects } from "./hooks/useContactsNostrPrefetchEffects";
 import { useEvoluNostrBootstrapReady } from "./hooks/useEvoluNostrBootstrapReady";
-import { useEvoluContactsOwnerRotation } from "./hooks/useEvoluContactsOwnerRotation";
 import { useFeedbackContact } from "./hooks/useFeedbackContact";
 import { useFiatRates } from "./hooks/useFiatRates";
 import { useGuideScannerDomain } from "./hooks/useGuideScannerDomain";
@@ -282,7 +265,6 @@ import {
 import {
   buildIdentityChangeMessageContent,
   buildIdentityChangeMessageWrapId,
-  type IdentityChangeMessageSource,
 } from "./lib/identityChangeMessage";
 import {
   consumeNotificationOpenDetailFromHash,
@@ -479,13 +461,101 @@ export const useAppShellComposition = () => {
 
   const hasMintOverrideRef = React.useRef(false);
 
-  const appOwnerIdRef = React.useRef<Evolu.OwnerId | null>(null);
-  const cashuOwnerIdRef = React.useRef<Evolu.OwnerId | null>(null);
-  const messagesOwnerIdRef = React.useRef<Evolu.OwnerId | null>(null);
-  const transactionsOwnerIdRef = React.useRef<Evolu.OwnerId | null>(null);
-  const recordTransactionsOwnerWriteRef = React.useRef<
-    ((count?: number) => void) | null
-  >(null);
+  const route = useRouting();
+  const { dismissToast, toasts, pushToast } = useToasts();
+  const [lang, setLang] = useState<Lang>(() => getInitialLang());
+  const t = React.useCallback(
+    (key: string) => (hasTranslationKey(key) ? translations[lang][key] : key),
+    [lang],
+  );
+  const {
+    activeNostrIdentitySource,
+    activeSyncedNostrIdentity,
+    appOwnerId,
+    appOwnerIdRef,
+    appendIdentityChangeNoticesRef,
+    cashuOwnerEditsUntilRotation,
+    cashuOwnerId,
+    cashuOwnerIdRef,
+    cashuOwnerIndex,
+    cashuVisibleOwnerIds,
+    confirmPendingOnboardingProfile,
+    contactsOwnerEditCount,
+    contactsOwnerEditsUntilRotation,
+    contactsOwnerId,
+    contactsOwnerIndex,
+    contactsOwnerNewContactsCount,
+    contactsOwnerPointer,
+    contactsVisibleOwnerIds,
+    createNewAccount,
+    currentNpub,
+    currentNsec,
+    historicalOwnerSetsReady,
+    identityOwnerId,
+    isSeedLogin,
+    legacyIdentitiesOwnerId,
+    legacyMessagesIdentityOwnerId,
+    logoutArmed,
+    messagesBackupOwnerId,
+    messagesOwnerEditsUntilRotation,
+    messagesOwnerId,
+    messagesOwnerIdRef,
+    messagesOwnerIndex,
+    messagesVisibleOwnerIds,
+    metaOwnerId,
+    nostrIdentityRows,
+    onboardingIsBusy,
+    onboardingPhotoInputRef,
+    onboardingStep,
+    openReturningOnboarding,
+    onPendingOnboardingPhotoError,
+    onPendingOnboardingPhotoSelected,
+    pasteReturningSlip39FromClipboard,
+    pickPendingOnboardingPhoto,
+    recordContactsOwnerWrite,
+    recordMessagesOwnerWrite,
+    recordTransactionsOwnerWrite,
+    recordTransactionsOwnerWriteRef,
+    requestDeriveNostrKeys,
+    requestLogout,
+    requestManualRotateCashuOwner,
+    requestManualRotateContactsOwner,
+    requestManualRotateMessagesOwner,
+    requestManualRotateTransactionsOwner,
+    requestPasteNostrKeys,
+    rotateCashuOwnerIsBusy,
+    rotateContactsOwnerIsBusy,
+    rotateMessagesOwnerIsBusy,
+    rotateTransactionsOwnerIsBusy,
+    savePendingOnboardingBackupToPasswordManager,
+    seedMnemonic,
+    cyclePendingOnboardingAvatarControl,
+    selectReturningSlip39Suggestion,
+    setOnboardingStep,
+    setPendingOnboardingName,
+    setReturningSlip39Input,
+    slip39Seed,
+    submitReturningSlip39,
+    syncedNostrIdentityMatchesLocal,
+    syncedNostrIdentityResolution,
+    syncOwner,
+    transactionsBackupOwnerId,
+    transactionsBootstrapSnapshot,
+    transactionsOwnerEditsUntilRotation,
+    transactionsOwnerId,
+    transactionsOwnerIdRef,
+    transactionsOwnerIndex,
+    transactionsOwnerPointer,
+    transactionsVisibleOwnerIds,
+  } = useIdentityOwnersComposition({
+    evolu,
+    lang,
+    navigation: globalThis.location,
+    pushToast,
+    t,
+    upsert,
+  });
+
   const {
     logPaymentEvent,
     makeLocalStorageKey,
@@ -498,9 +568,6 @@ export const useAppShellComposition = () => {
     recordTransactionsOwnerWriteRef,
     transactionsOwnerIdRef,
   });
-
-  const route = useRouting();
-  const { dismissToast, toasts, pushToast } = useToasts();
 
   const evoluServers = useEvoluServersManager();
   const evoluServerUrls = evoluServers.configuredUrls;
@@ -557,7 +624,6 @@ export const useAppShellComposition = () => {
   const [contactAttentionById, setContactAttentionById] = useState<
     Record<string, number>
   >(() => ({}));
-  const [lang, setLang] = useState<Lang>(() => getInitialLang());
   const [allowedDisplayCurrencies, setAllowedDisplayCurrencies] = useState<
     DisplayCurrency[]
   >(() => getInitialAllowedDisplayCurrencies());
@@ -663,33 +729,7 @@ export const useAppShellComposition = () => {
     [displayCurrency, fiatRates, lang],
   );
 
-  const [currentNsec, setCurrentNsec] = useState<string | null>(() =>
-    getInitialNostrNsec(),
-  );
   const [chatOwnPubkeyHex, setChatOwnPubkeyHex] = useState<string | null>(null);
-
-  React.useEffect(() => {
-    let cancelled = false;
-
-    void (async () => {
-      const storedNsec = await readStoredNostrNsec();
-      if (cancelled) return;
-      setCurrentNsec((current) =>
-        current === storedNsec ? current : storedNsec,
-      );
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  // Evolu is local-first; to get automatic cross-device/browser sync you must
-  // "use" an owner (which starts syncing over configured transports).
-  // We only enable it after the user has an nsec (our identity gate).
-  const syncOwner = useEvoluSyncOwner(Boolean(currentNsec));
-
-  useOwner(syncOwner);
 
   const evoluLastError = useEvoluLastError({ logToConsole: true });
   const evoluHasError = Boolean(evoluLastError);
@@ -719,20 +759,6 @@ export const useAppShellComposition = () => {
     return () => {
       cancelled = true;
     };
-  }, [currentNsec]);
-
-  React.useEffect(() => {
-    void (async () => {
-      try {
-        if (currentNsec) {
-          await setStoredPushNsec(currentNsec);
-        } else {
-          await clearStoredPushNsec();
-        }
-      } catch {
-        // ignore
-      }
-    })();
   }, [currentNsec]);
 
   React.useEffect(() => {
@@ -774,7 +800,6 @@ export const useAppShellComposition = () => {
     return "disconnected" as const;
   }, [evoluActiveServerUrls, evoluHasError, evoluServerStatusByUrl, syncOwner]);
 
-  const appOwnerId = syncOwner?.id ?? null;
   const pendingTopupStorageKey = `${LOCAL_PENDING_TOPUP_QUOTE_STORAGE_KEY_PREFIX}.${String(appOwnerId ?? "anon")}`;
 
   useAnonymousPaymentTelemetry({
@@ -819,7 +844,7 @@ export const useAppShellComposition = () => {
       }
       hasMintOverrideRef.current = false;
     }
-  }, [appOwnerId, makeLocalStorageKey]);
+  }, [appOwnerId, appOwnerIdRef, makeLocalStorageKey]);
 
   // Evolu error subscription handled by useEvoluLastError.
 
@@ -1048,13 +1073,6 @@ export const useAppShellComposition = () => {
   const [lnurlWithdrawIsBusy, setLnurlWithdrawIsBusy] = useState(false);
 
   const chatMessagesRef = React.useRef<HTMLDivElement | null>(null);
-  const appendIdentityChangeNoticesRef = React.useRef<
-    | ((args: {
-        changedAtSec: number;
-        identitySource: IdentityChangeMessageSource;
-      }) => void)
-    | null
-  >(null);
   const chatMessageElByIdRef = React.useRef<Map<string, HTMLDivElement>>(
     new Map(),
   );
@@ -1241,11 +1259,6 @@ export const useAppShellComposition = () => {
     targetNpub: string;
   } | null>(null);
 
-  const t = React.useCallback(
-    (key: string) => (hasTranslationKey(key) ? translations[lang][key] : key),
-    [lang],
-  );
-
   const {
     paidOverlayIsOpen,
     paidOverlayTitle,
@@ -1330,125 +1343,6 @@ export const useAppShellComposition = () => {
       topupPaidNavTimerRef,
     ],
   );
-
-  const {
-    activeNostrIdentitySource,
-    confirmPendingOnboardingProfile,
-    createNewAccount,
-    currentNpub,
-    isSeedLogin,
-    logoutArmed,
-    onboardingIsBusy,
-    onboardingPhotoInputRef,
-    onboardingStep,
-    openReturningOnboarding,
-    onPendingOnboardingPhotoError,
-    onPendingOnboardingPhotoSelected,
-    pasteReturningSlip39FromClipboard,
-    pickPendingOnboardingPhoto,
-    requestDeriveNostrKeys,
-    requestPasteNostrKeys,
-    requestLogout,
-    savePendingOnboardingBackupToPasswordManager,
-    seedMnemonic,
-    cyclePendingOnboardingAvatarControl,
-    selectReturningSlip39Suggestion,
-    slip39Seed,
-    setReturningSlip39Input,
-    setOnboardingStep,
-    setPendingOnboardingName,
-    submitReturningSlip39,
-  } = useProfileAuthComposition({
-    appendIdentityChangeNoticesRef,
-    currentNsec,
-    lang,
-    pushToast,
-    t,
-    upsert,
-  });
-
-  const {
-    cashuOwnerId,
-    cashuOwnerEditsUntilRotation,
-    cashuOwnerIndex,
-    cashuSyncOwner,
-    cashuVisibleOwnerIds,
-    contactsSyncOwner,
-    contactsOwnerEditCount,
-    contactsOwnerEditsUntilRotation,
-    contactsOwnerId,
-    contactsOwnerIndex,
-    contactsOwnerNewContactsCount,
-    contactsOwnerPointer,
-    contactsVisibleOwnerIds,
-    identityOwnerId,
-    identitySyncOwner,
-    historicalBootstrapSyncOwners,
-    legacyIdentitiesOwnerId,
-    legacyMessagesIdentityOwnerId,
-    metaOwnerId,
-    metaSyncOwner,
-    messagesBackupOwnerId,
-    messagesOwnerId,
-    messagesOwnerEditsUntilRotation,
-    messagesOwnerIndex,
-    messagesSyncOwner,
-    messagesVisibleOwnerIds,
-    recordContactsOwnerWrite,
-    recordMessagesOwnerWrite,
-    recordTransactionsOwnerWrite,
-    requestManualRotateCashuOwner,
-    requestManualRotateContactsOwner,
-    requestManualRotateMessagesOwner,
-    requestManualRotateTransactionsOwner,
-    rotateCashuOwnerIsBusy,
-    rotateContactsOwnerIsBusy,
-    rotateMessagesOwnerIsBusy,
-    rotateTransactionsOwnerIsBusy,
-    transactionsBackupOwnerId,
-    transactionsBootstrapSnapshot,
-    transactionsOwnerEditsUntilRotation,
-    transactionsOwnerId,
-    transactionsOwnerIndex,
-    transactionsOwnerPointer,
-    transactionsSyncOwner,
-    transactionsVisibleOwnerIds,
-  } = useEvoluContactsOwnerRotation({
-    appOwnerId,
-    isSeedLogin,
-    pushToast,
-    slip39Seed,
-    t,
-    upsert,
-  });
-
-  useOwner(contactsSyncOwner);
-  useOwner(cashuSyncOwner);
-  useOwner(messagesSyncOwner);
-  useOwner(transactionsSyncOwner);
-  useOwner(metaSyncOwner);
-  useOwner(identitySyncOwner);
-
-  const historicalOwnerSetsReady = isSeedLogin
-    ? cashuVisibleOwnerIds.length === cashuOwnerIndex + 1 &&
-      contactsVisibleOwnerIds.length === contactsOwnerIndex + 1 &&
-      messagesVisibleOwnerIds.length === messagesOwnerIndex + 1 &&
-      transactionsVisibleOwnerIds.length === transactionsOwnerIndex + 1
-    : true;
-  React.useEffect(() => {
-    if (!isSeedLogin || !historicalOwnerSetsReady) return;
-
-    // Evolu does not expose an initial-sync-complete signal. Keep historical
-    // lanes subscribed for the whole authenticated session instead of
-    // guessing completion from a quiet timer and disconnecting them while
-    // their stored messages may still be arriving.
-    const stopUsingOwners = historicalBootstrapSyncOwners.map((owner) =>
-      evolu.useOwner(owner),
-    );
-    return () => {
-      for (const stopUsingOwner of stopUsingOwners) stopUsingOwner();
-    };
-  }, [historicalBootstrapSyncOwners, historicalOwnerSetsReady, isSeedLogin]);
 
   // Default mint cross-tab + cross-device sync via Evolu `ownerMeta`.
   //
@@ -1582,10 +1476,6 @@ export const useAppShellComposition = () => {
     upsertDefaultMintToOwnerMetaRef.current = upsertDefaultMintToOwnerMeta;
   }, [upsertDefaultMintToOwnerMeta]);
 
-  React.useEffect(() => {
-    cashuOwnerIdRef.current = cashuOwnerId;
-  }, [cashuOwnerId]);
-
   const resolveOwnerIdForWrite = React.useCallback(async () => {
     if (cashuOwnerIdRef.current) return cashuOwnerIdRef.current;
     if (isSeedLogin) return null;
@@ -1595,19 +1485,7 @@ export const useAppShellComposition = () => {
     } catch {
       return null;
     }
-  }, [isSeedLogin]);
-
-  React.useEffect(() => {
-    messagesOwnerIdRef.current = messagesOwnerId;
-  }, [messagesOwnerId]);
-
-  React.useEffect(() => {
-    transactionsOwnerIdRef.current = transactionsOwnerId;
-  }, [transactionsOwnerId]);
-
-  React.useEffect(() => {
-    recordTransactionsOwnerWriteRef.current = recordTransactionsOwnerWrite;
-  }, [recordTransactionsOwnerWrite]);
+  }, [cashuOwnerIdRef, isSeedLogin]);
 
   React.useEffect(() => {
     if (!appOwnerId) return;
@@ -1826,115 +1704,6 @@ export const useAppShellComposition = () => {
     [],
   );
   const cashuTokensAll = useQuery(cashuTokensAllQuery);
-
-  const nostrIdentityQuery = useMemo(
-    () =>
-      evolu.createQuery((db) =>
-        db
-          .selectFrom("nostrIdentity")
-          .selectAll()
-          .where("isDeleted", "is not", Evolu.sqliteTrue)
-          .orderBy("createdAt", "desc"),
-      ),
-    [],
-  );
-  const nostrIdentityRows = useQuery(nostrIdentityQuery);
-
-  const activeIdentityOwnerId = String(identityOwnerId ?? "").trim();
-  const legacyNostrIdentityOwnerIds = React.useMemo(
-    () =>
-      new Set(
-        [
-          ...messagesVisibleOwnerIds,
-          legacyIdentitiesOwnerId,
-          legacyMessagesIdentityOwnerId,
-          metaOwnerId,
-        ]
-          .map((ownerId) => String(ownerId ?? "").trim())
-          .filter(Boolean),
-      ),
-    [
-      legacyIdentitiesOwnerId,
-      legacyMessagesIdentityOwnerId,
-      messagesVisibleOwnerIds,
-      metaOwnerId,
-    ],
-  );
-  const syncedNostrIdentityResolution = React.useMemo(
-    () =>
-      resolveSyncedNostrIdentity(
-        nostrIdentityRows,
-        activeIdentityOwnerId,
-        legacyNostrIdentityOwnerIds,
-      ),
-    [activeIdentityOwnerId, legacyNostrIdentityOwnerIds, nostrIdentityRows],
-  );
-  const activeSyncedNostrIdentity = syncedNostrIdentityResolution.identity;
-  const syncedNostrIdentityMatchesLocal = React.useMemo(() => {
-    if (!activeSyncedNostrIdentity) return true;
-
-    const localSource = getInitialNostrIdentitySource();
-    const localSwitchedAtSec = getInitialNostrIdentitySwitchedAtSec();
-    const localNsec = String(currentNsec ?? "").trim();
-    const syncedSwitchedAtSec = activeSyncedNostrIdentity.switchedAtSec;
-    const switchedAtMatches =
-      localSwitchedAtSec === syncedSwitchedAtSec ||
-      (!localSwitchedAtSec && !syncedSwitchedAtSec);
-
-    return (
-      localNsec === activeSyncedNostrIdentity.nsec &&
-      localSource === activeSyncedNostrIdentity.source &&
-      switchedAtMatches
-    );
-  }, [activeSyncedNostrIdentity, currentNsec]);
-
-  React.useEffect(() => {
-    if (!syncedNostrIdentityResolution.shouldMigrateLegacyIdentity) return;
-    if (!activeSyncedNostrIdentity || !identityOwnerId) return;
-
-    upsert(
-      "nostrIdentity",
-      {
-        id: ACTIVE_NOSTR_IDENTITY_ROW_ID,
-        nsec: activeSyncedNostrIdentity.nsec,
-        source: activeSyncedNostrIdentity.source,
-        ...(activeSyncedNostrIdentity.npub
-          ? { npub: activeSyncedNostrIdentity.npub }
-          : {}),
-        ...(activeSyncedNostrIdentity.switchedAtSec
-          ? { switchedAtSec: activeSyncedNostrIdentity.switchedAtSec }
-          : {}),
-      },
-      { ownerId: identityOwnerId },
-    );
-  }, [
-    activeSyncedNostrIdentity,
-    identityOwnerId,
-    syncedNostrIdentityResolution.shouldMigrateLegacyIdentity,
-    upsert,
-  ]);
-
-  React.useEffect(() => {
-    if (!activeSyncedNostrIdentity) return;
-    if (syncedNostrIdentityMatchesLocal) return;
-
-    void persistSyncedActiveNostrIdentity({
-      identitySource: activeSyncedNostrIdentity.source,
-      nsec: activeSyncedNostrIdentity.nsec,
-      switchedAtSec: activeSyncedNostrIdentity.switchedAtSec,
-    }).then(() => {
-      setCurrentNsec((current) =>
-        current === activeSyncedNostrIdentity.nsec
-          ? current
-          : activeSyncedNostrIdentity.nsec,
-      );
-      globalThis.location.reload();
-    });
-  }, [
-    activeSyncedNostrIdentity,
-    syncedNostrIdentityMatchesLocal,
-    setCurrentNsec,
-  ]);
 
   const activeCashuOwnerId = String(cashuOwnerId ?? "").trim();
   const visibleCashuOwnerIds = React.useMemo(
@@ -2688,7 +2457,11 @@ export const useAppShellComposition = () => {
     return () => {
       appendIdentityChangeNoticesRef.current = null;
     };
-  }, [appendLocalNostrMessage, lastMessageByContactId]);
+  }, [
+    appendIdentityChangeNoticesRef,
+    appendLocalNostrMessage,
+    lastMessageByContactId,
+  ]);
 
   React.useEffect(() => {
     const pendingTokens = cashuTokensAllFiltered.filter((row) => {


### PR DESCRIPTION
Closes #177.

Splits the ~10k-line `useAppShellComposition` god hook into five per-domain composition hooks, leaving the shell as a thin wiring layer (**10,136 → 1,881 lines**). One commit per domain for reviewable history:

- `useIdentityOwnersComposition` — identity/owner-lane state and rotation wiring
- `useProfileComposition` — profile editing/metadata state and effects
- `useContactsMessagingComposition` — contacts + messaging state, effects, callbacks (~3.2k lines)
- `useCashuWalletComposition` — cashu/wallet state, effects, callbacks (~4.5k lines)
- `useScanNativeComposition` — scan + native-bridge flows

All hooks follow the existing `hooks/composition/` slice idiom: one params interface in, plain object out, called from the shell at the same relative position so React hook call order is preserved.

Per the issue, the context transport (`AppShellContextsProvider` / `useAppShellCore` / `useAppShellActions` / `useAppShellRouteContext`) is untouched — the diff is confined to `useAppShellComposition.tsx` plus the five new hooks (and an AGENTS.md architecture note).

The issue suggested one domain per PR; this lands all five in one PR but keeps one commit per domain, so it can be reviewed (or cherry-picked) domain by domain.

## Behavior preservation

This is a pure mechanical move:

- Hook-call counts exactly preserved across the split (55 `useEffect`, 121 `useCallback`, 59 `useMemo`, 59 `useRef`, 3 `useQuery`); every removed shell line is accounted for as a move
- Dependency arrays unchanged apart from prefix renames/stable-ref additions; no stale-closure risks introduced
- `bun run check-code` passes on the recreated branch
- The recreated branch tree is byte-for-byte identical to #192
- The Playwright `appshell-parity` E2E suite was not run here (needs a dev server)
