### PR TITLE
Normalize horizontal screen gutters

### DIFF
--- a/apps/web-app/src/App.css
+++ b/apps/web-app/src/App.css
@@ -3,7 +3,7 @@
   margin: 0 auto;
   height: 100dvh;
   min-height: 0;
-  padding: calc(var(--topbar-height) + 8px) 20px 72px;
+  padding: calc(var(--topbar-height) + 8px) var(--page-gutter) 72px;
   background: var(--app-flat-bg);
   overflow-y: auto;
   overscroll-behavior-y: contain;
@@ -29,6 +29,10 @@
   overflow: hidden;
   overscroll-behavior: none;
   max-width: none;
+}
+
+.page.authenticated-page > .panel {
+  padding-inline: 0;
 }
 
 .pwa-update-banner {
@@ -251,7 +255,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: calc(var(--safe-area-top) + 8px) 12px 8px;
+  padding: calc(var(--safe-area-top) + 8px) var(--page-gutter) 8px;
   background: rgba(15, 23, 42, 0.9);
   border-bottom: none;
   backdrop-filter: blur(8px);
@@ -1934,7 +1938,8 @@ button.settings-sensitive-action.is-armed {
 
 .chat-messages {
   margin-top: 14px;
-  padding: 18px 10px calc(12px + var(--chat-compose-height, 116px));
+  padding: 18px var(--page-gutter)
+    calc(12px + var(--chat-compose-height, 116px));
   border-radius: 12px;
   border: none;
   background: transparent;
@@ -2526,7 +2531,7 @@ button.settings-sensitive-action.is-armed {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 12px;
+  padding: 12px var(--page-gutter);
   padding-bottom: calc(12px + var(--floating-safe-area-bottom));
   background: rgba(15, 23, 42, 0.95);
   border-radius: 0;
@@ -4637,14 +4642,15 @@ button.icon {
   right: 0;
   bottom: 0;
   z-index: 20;
-  padding: 0 20px calc(20px + var(--floating-safe-area-bottom));
+  padding: 0 var(--page-gutter)
+    calc(var(--page-gutter) + var(--floating-safe-area-bottom));
   background: transparent;
   backdrop-filter: none;
 }
 
 .contacts-fab {
   position: fixed;
-  right: 20px;
+  right: var(--page-gutter);
   bottom: calc(96px + var(--floating-safe-area-bottom));
   z-index: 30;
   width: 56px;
@@ -4794,11 +4800,11 @@ button.icon {
 
 @media (max-width: 640px) {
   .page.main-swipe-active .main-swipe {
-    margin-inline: -20px;
+    margin-inline: calc(-1 * var(--page-gutter));
   }
 
   .page.main-swipe-active .main-swipe-page {
-    padding-inline: 20px;
+    padding-inline: var(--page-gutter);
   }
 }
 

--- a/apps/web-app/src/App.css
+++ b/apps/web-app/src/App.css
@@ -504,6 +504,14 @@
   color: #e2e8f0;
 }
 
+.topbar-left .topbar-btn {
+  justify-content: flex-start;
+}
+
+.topbar > .topbar-btn {
+  justify-content: flex-end;
+}
+
 .topbar-profile-btn {
   width: 34px;
   height: 34px;
@@ -5257,7 +5265,7 @@ button.icon {
 @media (max-width: 640px) {
   .chat-compose {
     gap: 4px;
-    padding: 0 12px;
+    padding: 0 var(--page-gutter);
     padding-bottom: calc(6px + var(--floating-safe-area-bottom));
     background: transparent;
     box-shadow: none;

--- a/apps/web-app/src/app/AppShell.tsx
+++ b/apps/web-app/src/app/AppShell.tsx
@@ -78,7 +78,11 @@ const AppShell = () => {
   );
 
   return (
-    <div className={currentNsec ? pageClassNameWithSwipe : "page"}>
+    <div
+      className={
+        currentNsec ? `${pageClassNameWithSwipe} authenticated-page` : "page"
+      }
+    >
       <PwaUpdateBanner t={t} />
       <CashuContactSendBanner
         amountText={

--- a/apps/web-app/src/index.css
+++ b/apps/web-app/src/index.css
@@ -12,6 +12,7 @@
   --native-keyboard-inset: 0px;
   --chat-compose-height: 116px;
   --floating-safe-area-bottom: min(var(--safe-area-bottom), 24px);
+  --page-gutter: 20px;
   --topbar-content-height: 48px;
   --topbar-height: calc(var(--topbar-content-height) + var(--safe-area-top));
   font-family:

--- a/apps/web-app/tests/appshell-parity.spec.ts
+++ b/apps/web-app/tests/appshell-parity.spec.ts
@@ -88,6 +88,32 @@ const createContactAndOpenChat = async (page: Page): Promise<string> => {
   return decodeURIComponent(contactMatch[1]);
 };
 
+test("keeps authenticated screen gutters aligned", async ({ page }) => {
+  await setAuthenticatedStorage(page);
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  for (const route of [
+    "/#settings",
+    "/#wallet/transactions",
+    "/#wallet/topup",
+    "/#contact/new",
+  ]) {
+    await page.goto(route);
+
+    const shell = page.locator(".page.authenticated-page");
+    await expect(shell).toBeVisible();
+    await expect(shell).toHaveCSS("padding-left", "20px");
+    await expect(shell).toHaveCSS("padding-right", "20px");
+    await expect(page.locator(".topbar")).toHaveCSS("padding-left", "20px");
+    await expect(page.locator(".topbar")).toHaveCSS("padding-right", "20px");
+
+    const rootPanel = page.locator(".page.authenticated-page > .panel");
+    await expect(rootPanel).toHaveCount(1);
+    await expect(rootPanel).toHaveCSS("padding-left", "0px");
+    await expect(rootPanel).toHaveCSS("padding-right", "0px");
+  }
+});
+
 test("keeps unauthenticated auth gating without render loops", async ({
   page,
 }) => {

--- a/apps/web-app/tests/appshell-parity.spec.ts
+++ b/apps/web-app/tests/appshell-parity.spec.ts
@@ -112,6 +112,16 @@ test("keeps authenticated screen gutters aligned", async ({ page }) => {
     await expect(rootPanel).toHaveCSS("padding-left", "0px");
     await expect(rootPanel).toHaveCSS("padding-right", "0px");
   }
+
+  await page.goto("/#profile");
+  await expect(page.locator(".topbar-left .topbar-btn")).toHaveCSS(
+    "justify-content",
+    "flex-start",
+  );
+  await expect(page.locator(".topbar > .topbar-btn")).toHaveCSS(
+    "justify-content",
+    "flex-end",
+  );
 });
 
 test("keeps unauthenticated auth gating without render loops", async ({


### PR DESCRIPTION
## Summary

- introduce one shared 20px page gutter for authenticated screens
- remove the extra horizontal padding applied by root route panels
- align top bars, chat content/composer, swipe screens, bottom actions, and the contacts FAB to the same gutter
- add a mobile-width Playwright regression test across representative route families

## Why

Secondary screens were combining the 20px app-shell padding with an additional 22px panel padding, while primary, chat, and fixed UI surfaces used several unrelated values. This made content begin at different horizontal positions across routes.

## Impact

Authenticated screens now share one predictable horizontal content boundary without changing intentional padding inside controls and nested cards.

## Validation

- `bun run check-code`
- `bun run --filter @linky/web-app build`
- audited authenticated production routes at a 390×844 viewport

The focused Playwright test is included but could not be executed locally because the configured Chromium binary is not installed in this environment.