### PR TITLE
Fix mobile contacts scrolling

### DIFF
--- a/apps/web-app/src/App.css
+++ b/apps/web-app/src/App.css
@@ -4635,6 +4635,11 @@ button.icon {
   gap: 10px;
   overflow-x: auto;
   padding-bottom: 4px;
+  scrollbar-width: none;
+}
+
+.group-filter-inner::-webkit-scrollbar {
+  display: none;
 }
 
 .contacts-qr-bar {
@@ -4780,10 +4785,16 @@ button.icon {
   flex: 0 0 100%;
   min-width: 100%;
   min-height: 0;
+  padding-bottom: calc(96px + var(--floating-safe-area-bottom));
   overflow-y: auto;
   overscroll-behavior-y: contain;
   scroll-snap-align: start;
+  scrollbar-width: none;
   background: var(--app-flat-bg);
+}
+
+.main-swipe-page::-webkit-scrollbar {
+  display: none;
 }
 
 .desktop-main-pane-title {
@@ -4799,6 +4810,7 @@ button.icon {
   flex-direction: column;
   height: 100dvh;
   min-height: 0;
+  padding-bottom: 0;
   overflow: hidden;
   -webkit-overflow-scrolling: auto;
 }


### PR DESCRIPTION
## What changed

- Let the mobile contacts and wallet swipe pages scroll behind the floating bottom tab bar.
- Move bottom clearance into the scrollable content so the final contacts can be scrolled fully above the tabs.
- Hide the horizontal contact-filter scrollbar and vertical page scrollbar without disabling scrolling.

## Why

The contacts page reserved bottom space on the outer page shell, which shortened the scroll viewport and left a persistent empty gap above the tab bar. Native-looking mobile scrolling should continue behind the floating controls, with clearance only at the end of the scroll content.

## User impact

The contacts list now uses the full mobile viewport, remains fully scrollable, and no longer shows distracting scrollbar tracks.

## Validation

- Verified locally at a 320 × 568 viewport with existing contact data.
- Confirmed the list scrolls behind the tabs and the final contact clears the overlay.
- Confirmed both scrollbar tracks are hidden while scrolling remains functional.
- `bun run check-code` (passes; 11 existing React hook warnings, 0 errors).
