### PR TITLE
Fix react-hooks/exhaustive-deps warnings in composition hooks

### DIFF
--- a/apps/web-app/src/app/hooks/composition/useCashuWalletComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useCashuWalletComposition.ts
@@ -3218,8 +3218,10 @@ export const useCashuWalletComposition = ({
       }
     },
     [
+      activeNostrMessagePublishClientIdsRef,
       appendLocalNostrMessage,
       cashuTokensAllFiltered,
+      chatSeenWrapIdsRef,
       currentNsec,
       logPaymentEvent,
       deleteCashuToken,
@@ -3237,7 +3239,7 @@ export const useCashuWalletComposition = ({
         [origin]: url,
       }));
     },
-    [],
+    [setMintIconUrlByMint],
   );
 
   const handleMintIconError = React.useCallback(
@@ -3247,7 +3249,7 @@ export const useCashuWalletComposition = ({
         [origin]: url,
       }));
     },
-    [],
+    [setMintIconUrlByMint],
   );
 
   const restoreMissingTokens = useRestoreMissingTokens({
@@ -4303,6 +4305,7 @@ export const useCashuWalletComposition = ({
 
     navigateTo({ route: "contact", id: selectedContact.id });
   }, [
+    contactPayBackToChatRef,
     currentNpub,
     defaultMintUrl,
     payAmount,

--- a/apps/web-app/src/app/hooks/composition/useContactsMessagingComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useContactsMessagingComposition.ts
@@ -1624,6 +1624,7 @@ export const useContactsMessagingComposition = ({
     pushToast,
     setContactNewPrefill,
     setForm,
+    setPayAmount,
     t,
   ]);
 
@@ -2627,7 +2628,7 @@ export const useContactsMessagingComposition = ({
       setContactPaymentIntent(intent);
       navigateTo({ route: "contactPay", id: knownContact.id });
     },
-    [contacts],
+    [contactPayBackToChatRef, contacts, setContactPaymentIntent],
   );
 
   const openContactDetail = React.useCallback(
@@ -2664,7 +2665,7 @@ export const useContactsMessagingComposition = ({
       }
       navigateTo({ route: "chat", id: String(knownContact.id) });
     },
-    [clearContactAttention, contacts, openContactPay],
+    [clearContactAttention, contactPayBackToChatRef, contacts, openContactPay],
   );
 
   const addUnknownContactFromChat = React.useCallback(async () => {
@@ -2780,8 +2781,6 @@ export const useContactsMessagingComposition = ({
     clearContactAttention,
     removeLocalNostrMessagesByContactId,
     route.kind,
-    selectedChatContact?.npub,
-    selectedChatContact?.unknownPubkeyHex,
     selectedChatContact,
     setStatus,
     t,

--- a/apps/web-app/src/app/hooks/composition/useScanNativeComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useScanNativeComposition.ts
@@ -984,6 +984,7 @@ export const useScanNativeComposition = ({
     [
       appendLocalNostrMessage,
       bankPaymentOfferMessages,
+      contactsLatestRef,
       currentNsec,
       knownNostrMessageIdentityIndex,
       nostrFetchRelays,

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -965,7 +965,7 @@ export const useAppShellComposition = () => {
 
   const clearPendingDeleteOnMenuChange = React.useCallback(() => {
     setPendingDeleteId(null);
-  }, []);
+  }, [setPendingDeleteId]);
 
   const { closeMenu, menuIsOpen, navigateToMainReturn, toggleMenu } =
     useMainMenuState({
@@ -1110,6 +1110,7 @@ export const useAppShellComposition = () => {
     },
     [
       contactAttentionById,
+      getCashuTokenMessageInfo,
       getMintIconUrl,
       getNpubMessageContactInfo,
       handleMintIconError,


### PR DESCRIPTION
Fixes all 11 `react-hooks/exhaustive-deps` warnings introduced by the AppShell composition split. `bun run check-code` is now warning-free.

## Changes

- **Stable refs/setters added to dependency arrays (9 warnings):** the composition split moved code into hooks that receive refs (`contactPayBackToChatRef`, `activeNostrMessagePublishClientIdsRef`, `chatSeenWrapIdsRef`, `contactsLatestRef`) and `useState` setters (`setMintIconUrlByMint`, `setPayAmount`, `setContactPaymentIntent`, `setPendingDeleteId`) as parameters. ESLint can't prove their stability across the hook boundary, so they must be listed. All are stable in practice — no behavior change.
- **Redundant deps removed (1 warning):** `blockUnknownContactFromChat` listed both `selectedChatContact` and two of its sub-properties; the sub-property entries are gone.
- **Real staleness fix (1 warning):** `renderContactCard` in `useAppShellComposition.tsx` closed over `getCashuTokenMessageInfo` (which depends on the filtered cashu token list) without listing it, so contact cards could show stale token status when a token was marked spent/accepted without concurrent message churn. Now listed, so cards re-render when the token list changes.

## Verification

- `bun run check-code`: 0 errors, 0 warnings
- `vitest run`: 368 passed; the 7 failures (`cashuWallet.test.ts`, `usePayContactWithCashuMessage.test.tsx`, `useInboxNotificationsSync.test.tsx`) reproduce identically on clean main and are unrelated to this change