### PR TITLE
Fix rotten unit tests and wire vitest into scripts and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run unit tests
+        run: bun run test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ bun run native:ios:add     # Generate the Capacitor iOS project once
 bun run push:dev           # Start the Bun push notification service in watch mode
 bun run push:start         # Start the Bun push notification service once
 bun run check-code         # Run ALL checks: typecheck → eslint --fix → prettier --write
+bun run test               # Run Vitest unit tests in all workspaces
 bun run typecheck          # TypeScript type checking only
 bun run eslint             # Lint + autofix all workspaces
 bun run prettier           # Format + autofix all workspaces
@@ -151,7 +152,8 @@ Native Android builds require Java 17. `apps/native-shell/scripts/with-java17.sh
 ## Testing
 
 - **Playwright** E2E tests in `apps/web-app/tests/`
-- **Vitest** unit tests (jsdom environment, Worker polyfill in `vitest.setup.ts`)
+- **Vitest** unit tests (jsdom environment, Worker polyfill in `vitest.setup.ts`); run via `bun run test`, also enforced on PRs and `main` pushes by `.github/workflows/tests.yml`
+- Vitest excludes `tests/**/*.spec.ts` — those are Playwright E2E suites run separately
 - Dev server for E2E: `http://127.0.0.1:5174`
 
 ## Gotchas

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -10,6 +10,7 @@
     "eslint": "eslint --fix .",
     "prettier": "prettier --write .",
     "typecheck": "tsc -b",
+    "test": "vitest run",
     "preview": "vite preview",
     "prev": "vite preview"
   },

--- a/apps/web-app/src/app/hooks/composition/useCashuWalletComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useCashuWalletComposition.ts
@@ -3215,8 +3215,10 @@ export const useCashuWalletComposition = ({
       }
     },
     [
+      activeNostrMessagePublishClientIdsRef,
       appendLocalNostrMessage,
       cashuTokensAllFiltered,
+      chatSeenWrapIdsRef,
       currentNsec,
       logPaymentEvent,
       deleteCashuToken,
@@ -3234,7 +3236,7 @@ export const useCashuWalletComposition = ({
         [origin]: url,
       }));
     },
-    [],
+    [setMintIconUrlByMint],
   );
 
   const handleMintIconError = React.useCallback(
@@ -3244,7 +3246,7 @@ export const useCashuWalletComposition = ({
         [origin]: url,
       }));
     },
-    [],
+    [setMintIconUrlByMint],
   );
 
   const restoreMissingTokens = useRestoreMissingTokens({
@@ -4300,6 +4302,7 @@ export const useCashuWalletComposition = ({
 
     navigateTo({ route: "contact", id: selectedContact.id });
   }, [
+    contactPayBackToChatRef,
     currentNpub,
     defaultMintUrl,
     payAmount,

--- a/apps/web-app/src/app/hooks/composition/useContactsMessagingComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useContactsMessagingComposition.ts
@@ -1624,6 +1624,7 @@ export const useContactsMessagingComposition = ({
     pushToast,
     setContactNewPrefill,
     setForm,
+    setPayAmount,
     t,
   ]);
 
@@ -2627,7 +2628,7 @@ export const useContactsMessagingComposition = ({
       setContactPaymentIntent(intent);
       navigateTo({ route: "contactPay", id: knownContact.id });
     },
-    [contacts],
+    [contactPayBackToChatRef, contacts, setContactPaymentIntent],
   );
 
   const openContactDetail = React.useCallback(
@@ -2664,7 +2665,7 @@ export const useContactsMessagingComposition = ({
       }
       navigateTo({ route: "chat", id: String(knownContact.id) });
     },
-    [clearContactAttention, contacts, openContactPay],
+    [clearContactAttention, contactPayBackToChatRef, contacts, openContactPay],
   );
 
   const addUnknownContactFromChat = React.useCallback(async () => {
@@ -2780,8 +2781,6 @@ export const useContactsMessagingComposition = ({
     clearContactAttention,
     removeLocalNostrMessagesByContactId,
     route.kind,
-    selectedChatContact?.npub,
-    selectedChatContact?.unknownPubkeyHex,
     selectedChatContact,
     setStatus,
     t,

--- a/apps/web-app/src/app/hooks/composition/useScanNativeComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useScanNativeComposition.ts
@@ -984,6 +984,7 @@ export const useScanNativeComposition = ({
     [
       appendLocalNostrMessage,
       bankPaymentOfferMessages,
+      contactsLatestRef,
       currentNsec,
       knownNostrMessageIdentityIndex,
       nostrFetchRelays,

--- a/apps/web-app/src/app/lib/cashuOwnerLane.test.ts
+++ b/apps/web-app/src/app/lib/cashuOwnerLane.test.ts
@@ -7,9 +7,9 @@ import {
   resolveCashuTokenStoredOwnerLaneById,
 } from "./cashuOwnerLane";
 
-const owner0 = Evolu.OwnerId.orThrow("aaaaaaaaaaaaaaaaaaaaaa");
-const owner1 = Evolu.OwnerId.orThrow("bbbbbbbbbbbbbbbbbbbbbb");
-const owner2 = Evolu.OwnerId.orThrow("cccccccccccccccccccccc");
+const owner0 = Evolu.OwnerId.orThrow("AAAAAAAAAAAAAAAAAAAAAA");
+const owner1 = Evolu.OwnerId.orThrow("AQEBAQEBAQEBAQEBAQEBAQ");
+const owner2 = Evolu.OwnerId.orThrow("AgICAgICAgICAgICAgICAg");
 
 describe("cashu owner lane helpers", () => {
   it("reads an owner id from an aggregated row", () => {

--- a/apps/web-app/src/app/useAppShellComposition.tsx
+++ b/apps/web-app/src/app/useAppShellComposition.tsx
@@ -953,7 +953,7 @@ export const useAppShellComposition = () => {
 
   const clearPendingDeleteOnMenuChange = React.useCallback(() => {
     setPendingDeleteId(null);
-  }, []);
+  }, [setPendingDeleteId]);
 
   const { closeMenu, menuIsOpen, navigateToMainReturn, toggleMenu } =
     useMainMenuState({
@@ -1098,6 +1098,7 @@ export const useAppShellComposition = () => {
     },
     [
       contactAttentionById,
+      getCashuTokenMessageInfo,
       getMintIconUrl,
       getNpubMessageContactInfo,
       handleMintIconError,

--- a/apps/web-app/src/pages/TopupInvoicePage.test.tsx
+++ b/apps/web-app/src/pages/TopupInvoicePage.test.tsx
@@ -40,12 +40,23 @@ const translate = (key: string): string => {
   }
 };
 
-const waitForQrRender = async (): Promise<void> => {
-  await Promise.resolve();
-  await Promise.resolve();
-  await new Promise<void>((resolve) => {
-    window.setTimeout(resolve, 0);
-  });
+// The QR src updates asynchronously (qrcode.toDataURL + setState), so poll
+// until the assertion holds instead of racing it with a fixed delay.
+const waitFor = async (assertion: () => void): Promise<void> => {
+  const deadline = Date.now() + 2000;
+  for (;;) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      if (Date.now() > deadline) throw error;
+      await act(async () => {
+        await new Promise<void>((resolve) => {
+          window.setTimeout(resolve, 10);
+        });
+      });
+    }
+  }
 };
 
 describe("TopupInvoicePage", () => {
@@ -124,12 +135,12 @@ describe("TopupInvoicePage", () => {
 
     await act(async () => {
       cashuTab?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      await waitForQrRender();
     });
-
-    expect(
-      container.querySelector(".topup-invoice-qr")?.getAttribute("src"),
-    ).toBe("qr:creqArequest");
+    await waitFor(() => {
+      expect(
+        container.querySelector(".topup-invoice-qr")?.getAttribute("src"),
+      ).toBe("qr:creqArequest");
+    });
 
     await act(async () => {
       container
@@ -144,12 +155,12 @@ describe("TopupInvoicePage", () => {
 
     await act(async () => {
       lightningTab?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      await waitForQrRender();
     });
-
-    expect(
-      container.querySelector(".topup-invoice-qr")?.getAttribute("src"),
-    ).toBe("qr:lnbc-invoice");
+    await waitFor(() => {
+      expect(
+        container.querySelector(".topup-invoice-qr")?.getAttribute("src"),
+      ).toBe("qr:lnbc-invoice");
+    });
 
     await act(async () => {
       container

--- a/apps/web-app/src/utils/cashuWallet.test.ts
+++ b/apps/web-app/src/utils/cashuWallet.test.ts
@@ -98,24 +98,24 @@ describe("createLoadedCashuWallet", () => {
     const activeKeys = { "1": "02aa", "2": "02bb" };
     const legacyKeys = { "128": "03cc" };
     const mintGetKeys = vi.fn(async (id?: string) => {
-      if (id === "01active") {
+      if (id === "01884a74bb2fc5ee") {
         return {
           keysets: [
             {
               active: true,
-              id: "01active",
+              id: "01884a74bb2fc5ee",
               keys: activeKeys,
               unit: "sat",
             },
           ],
         };
       }
-      if (id === "01legacy") {
+      if (id === "009a1f293253e41e") {
         return {
           keysets: [
             {
               active: false,
-              id: "01legacy",
+              id: "009a1f293253e41e",
               keys: legacyKeys,
               unit: "sat",
             },
@@ -138,13 +138,13 @@ describe("createLoadedCashuWallet", () => {
         keysets: [
           {
             active: true,
-            id: "01active",
+            id: "01884a74bb2fc5ee",
             input_fee_ppk: 10,
             unit: "sat",
           },
           {
             active: false,
-            id: "01legacy",
+            id: "009a1f293253e41e",
             input_fee_ppk: 10,
             unit: "sat",
           },
@@ -185,27 +185,27 @@ describe("createLoadedCashuWallet", () => {
       unit: "sat",
     });
 
-    expect(mintGetKeys).toHaveBeenCalledWith("01active");
-    expect(mintGetKeys).toHaveBeenCalledWith("01legacy");
+    expect(mintGetKeys).toHaveBeenCalledWith("01884a74bb2fc5ee");
+    expect(mintGetKeys).toHaveBeenCalledWith("009a1f293253e41e");
     expect(loadMintFromCache).toHaveBeenCalledWith(mintInfo, {
       mintUrl: "https://mint.example",
       keysets: [
         {
           active: true,
-          id: "01active",
+          id: "01884a74bb2fc5ee",
           input_fee_ppk: 10,
           keys: activeKeys,
           unit: "sat",
         },
         {
           active: false,
-          id: "01legacy",
+          id: "009a1f293253e41e",
           input_fee_ppk: 10,
           keys: legacyKeys,
           unit: "sat",
         },
       ],
     });
-    expect(bindKeyset).toHaveBeenCalledWith("01active");
+    expect(bindKeyset).toHaveBeenCalledWith("01884a74bb2fc5ee");
   });
 });

--- a/apps/web-app/tests/useInboxNotificationsSync.test.tsx
+++ b/apps/web-app/tests/useInboxNotificationsSync.test.tsx
@@ -274,11 +274,21 @@ describe("useInboxNotificationsSync", () => {
       value: "visible",
     });
 
+    // Only live subscription events surface toasts; bootstrap querySync
+    // results are stored silently, so deliver the wrap through onevent.
     const wrapEvent = { id: "wrap-known-1" };
-    querySyncMock.mockResolvedValue([wrapEvent]);
-    subscribeMock.mockReturnValue({
-      close: vi.fn(async () => {}),
-    });
+    const liveEventHandlers: Array<(event: typeof wrapEvent) => void> = [];
+    querySyncMock.mockResolvedValue([]);
+    subscribeMock.mockImplementation(
+      (
+        _relays: unknown,
+        _filter: unknown,
+        handlers: { onevent: (event: typeof wrapEvent) => void },
+      ) => {
+        liveEventHandlers.push(handlers.onevent);
+        return { close: vi.fn(async () => {}) };
+      },
+    );
     unwrapEventMock.mockReturnValue({
       kind: 14,
       id: "rumor-known-1",
@@ -345,6 +355,9 @@ describe("useInboxNotificationsSync", () => {
     };
 
     const root = await renderHarness("contact-alice");
+    await act(async () => {
+      liveEventHandlers[0]?.(wrapEvent);
+    });
 
     expect(pushToast).toHaveBeenCalledWith(
       "Bob: hi from Bob",
@@ -358,14 +371,10 @@ describe("useInboxNotificationsSync", () => {
     });
 
     querySyncMock.mockReset();
-    subscribeMock.mockReset();
     unwrapEventMock.mockReset();
     pushToast.mockReset();
 
-    querySyncMock.mockResolvedValue([wrapEvent]);
-    subscribeMock.mockReturnValue({
-      close: vi.fn(async () => {}),
-    });
+    querySyncMock.mockResolvedValue([]);
     unwrapEventMock.mockReturnValue({
       kind: 14,
       id: "rumor-known-2",
@@ -376,6 +385,9 @@ describe("useInboxNotificationsSync", () => {
     });
 
     const activeRoot = await renderHarness("contact-bob");
+    await act(async () => {
+      liveEventHandlers.at(-1)?.({ id: "wrap-known-2" });
+    });
 
     expect(pushToast).not.toHaveBeenCalled();
 
@@ -795,10 +807,18 @@ describe("useInboxNotificationsSync", () => {
 
   it("routes incoming messages to a known contact when the peer is only identifiable from p tags", async () => {
     const wrapEvent = { id: "wrap-known-via-ptag-1" };
-    querySyncMock.mockResolvedValue([wrapEvent]);
-    subscribeMock.mockReturnValue({
-      close: vi.fn(async () => {}),
-    });
+    const liveEventHandlers: Array<(event: typeof wrapEvent) => void> = [];
+    querySyncMock.mockResolvedValue([]);
+    subscribeMock.mockImplementation(
+      (
+        _relays: unknown,
+        _filter: unknown,
+        handlers: { onevent: (event: typeof wrapEvent) => void },
+      ) => {
+        liveEventHandlers.push(handlers.onevent);
+        return { close: vi.fn(async () => {}) };
+      },
+    );
     unwrapEventMock.mockReturnValue({
       kind: 14,
       id: "rumor-known-via-ptag-1",
@@ -866,6 +886,9 @@ describe("useInboxNotificationsSync", () => {
     });
     await flushEffects();
     await flushEffects();
+    await act(async () => {
+      liveEventHandlers[0]?.(wrapEvent);
+    });
 
     expect(appendLocalNostrMessage).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1220,10 +1243,18 @@ describe("useInboxNotificationsSync", () => {
     });
 
     const wrapEvent = { id: "wrap-payment-notice-1" };
-    querySyncMock.mockResolvedValue([wrapEvent]);
-    subscribeMock.mockReturnValue({
-      close: vi.fn(async () => {}),
-    });
+    const liveEventHandlers: Array<(event: typeof wrapEvent) => void> = [];
+    querySyncMock.mockResolvedValue([]);
+    subscribeMock.mockImplementation(
+      (
+        _relays: unknown,
+        _filter: unknown,
+        handlers: { onevent: (event: typeof wrapEvent) => void },
+      ) => {
+        liveEventHandlers.push(handlers.onevent);
+        return { close: vi.fn(async () => {}) };
+      },
+    );
     unwrapEventMock.mockReturnValue({
       kind: 24133,
       id: "rumor-payment-notice-1",
@@ -1294,6 +1325,9 @@ describe("useInboxNotificationsSync", () => {
     });
     await flushEffects();
     await flushEffects();
+    await act(async () => {
+      liveEventHandlers[0]?.(wrapEvent);
+    });
 
     expect(pushToast).toHaveBeenCalledWith("Bob: You received money");
     expect(maybeShowPwaNotification).toHaveBeenCalledWith(
@@ -1315,10 +1349,18 @@ describe("useInboxNotificationsSync", () => {
     });
 
     const wrapEvent = { id: "wrap-payment-notice-repeat-1" };
-    querySyncMock.mockResolvedValue([wrapEvent]);
-    subscribeMock.mockReturnValue({
-      close: vi.fn(async () => {}),
-    });
+    const liveEventHandlers: Array<(event: typeof wrapEvent) => void> = [];
+    querySyncMock.mockResolvedValue([]);
+    subscribeMock.mockImplementation(
+      (
+        _relays: unknown,
+        _filter: unknown,
+        handlers: { onevent: (event: typeof wrapEvent) => void },
+      ) => {
+        liveEventHandlers.push(handlers.onevent);
+        return { close: vi.fn(async () => {}) };
+      },
+    );
     unwrapEventMock.mockReturnValue({
       kind: 24133,
       id: "payment-notice-repeat-1",
@@ -1393,18 +1435,29 @@ describe("useInboxNotificationsSync", () => {
     });
     await flushEffects();
     await flushEffects();
+    await act(async () => {
+      liveEventHandlers[0]?.(wrapEvent);
+    });
 
     await act(async () => {
       root.render(<Harness routeKind="wallet" />);
     });
     await flushEffects();
     await flushEffects();
+    // The route change re-runs the inbox effect and resubscribes; the same
+    // wrap arriving again must be deduped by the seen-wrap-id set.
+    await act(async () => {
+      liveEventHandlers.at(-1)?.(wrapEvent);
+    });
 
     await act(async () => {
       root.render(<Harness routeKind="contacts" />);
     });
     await flushEffects();
     await flushEffects();
+    await act(async () => {
+      liveEventHandlers.at(-1)?.(wrapEvent);
+    });
 
     expect(pushToast).toHaveBeenCalledTimes(1);
     expect(pushToast).toHaveBeenCalledWith("Bob: You received money");
@@ -1427,9 +1480,17 @@ describe("useInboxNotificationsSync", () => {
     });
 
     const wrapEvent = { id: "wrap-payment-notice-restart-1" };
-    subscribeMock.mockReturnValue({
-      close: vi.fn(async () => {}),
-    });
+    const liveEventHandlers: Array<(event: typeof wrapEvent) => void> = [];
+    subscribeMock.mockImplementation(
+      (
+        _relays: unknown,
+        _filter: unknown,
+        handlers: { onevent: (event: typeof wrapEvent) => void },
+      ) => {
+        liveEventHandlers.push(handlers.onevent);
+        return { close: vi.fn(async () => {}) };
+      },
+    );
     unwrapEventMock.mockReturnValue({
       kind: 24133,
       id: "payment-notice-restart-1",
@@ -1492,13 +1553,16 @@ describe("useInboxNotificationsSync", () => {
       return null;
     };
 
-    querySyncMock.mockResolvedValue([wrapEvent]);
+    querySyncMock.mockResolvedValue([]);
     const firstRoot = createRoot(document.createElement("div"));
     await act(async () => {
       firstRoot.render(<Harness />);
     });
     await flushEffects();
     await flushEffects();
+    await act(async () => {
+      liveEventHandlers[0]?.(wrapEvent);
+    });
 
     expect(pushToast).toHaveBeenCalledTimes(1);
     expect(maybeShowPwaNotification).toHaveBeenCalledTimes(1);
@@ -1507,6 +1571,8 @@ describe("useInboxNotificationsSync", () => {
       firstRoot.unmount();
     });
 
+    // After a restart the same wrap comes back through bootstrap catch-up;
+    // the persisted seen-wrap-id set must keep it silent.
     querySyncMock.mockResolvedValue([wrapEvent]);
     const secondRoot = createRoot(document.createElement("div"));
     await act(async () => {

--- a/apps/web-app/tests/usePayContactWithCashuMessage.test.tsx
+++ b/apps/web-app/tests/usePayContactWithCashuMessage.test.tsx
@@ -56,6 +56,12 @@ import { usePayContactWithCashuMessage } from "../src/app/hooks/payments/usePayC
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
+// Evolu OwnerIds must be canonical 22-char base64url ids; arbitrary strings
+// fail validation in resolveCashuRowStoredOwnerLane and silently fall back to
+// the active write lane, which is exactly the bug this test guards against.
+const LANE_OLD = "AAAAAAAAAAAAAAAAAAAAAA";
+const LANE_ACTIVE = "AQEBAQEBAQEBAQEBAQEBAQ";
+
 const flushEffects = async () => {
   await act(async () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -102,7 +108,7 @@ describe("usePayContactWithCashuMessage", () => {
     wrapEventWithPushMarkerMock.mockReturnValue({ id: "wrap-payment-notice" });
 
     const operations: string[] = [];
-    const insert = vi.fn(
+    const upsert = vi.fn(
       (table: string, payload: { state?: string; token?: string }) => {
         if (table === "cashuToken") {
           operations.push(
@@ -152,7 +158,7 @@ describe("usePayContactWithCashuMessage", () => {
         cashuTokensWithMeta: [
           {
             id: "old-token-1",
-            ownerId: "lane-old",
+            ownerId: LANE_OLD,
             state: "accepted",
             mint: "https://mint.example",
             token: "cashu-old-token",
@@ -161,7 +167,7 @@ describe("usePayContactWithCashuMessage", () => {
           },
         ],
         // Active write lane differs from the lane that holds the spent token.
-        cashuVisibleOwnerIds: ["lane-old", "lane-active"],
+        cashuVisibleOwnerIds: [LANE_OLD, LANE_ACTIVE],
         chatSeenWrapIdsRef: { current: new Set<string>() },
         currentNpub: "npub-test",
         currentNsec: "nsec-test",
@@ -172,12 +178,11 @@ describe("usePayContactWithCashuMessage", () => {
           amountText: "600",
           unitLabel: "sat",
         }),
-        insert,
         logPayStep: vi.fn(),
         logPaymentEvent: vi.fn(),
         nostrMessagesLocal: [],
         payWithCashuEnabled: true,
-        resolveOwnerIdForWrite: vi.fn(async () => "lane-active"),
+        resolveOwnerIdForWrite: vi.fn(async () => LANE_ACTIVE),
         publishSingleWrappedWithRetry: vi.fn(async () => ({
           anySuccess: true,
           error: null,
@@ -193,6 +198,7 @@ describe("usePayContactWithCashuMessage", () => {
         t: (key: string) => key,
         update,
         updateLocalNostrMessage: vi.fn(),
+        upsert,
       });
 
       React.useEffect(() => {
@@ -226,10 +232,10 @@ describe("usePayContactWithCashuMessage", () => {
     // The spent token is soft-deleted in ITS OWN lane (lane-old), not the
     // active write lane (lane-active) — otherwise Evolu's (ownerId, id) keying
     // makes the delete a no-op and the token stays spendable.
-    expect(operations).toContain("update:old-token-1:lane-old");
-    expect(operations).not.toContain("update:old-token-1:lane-active");
+    expect(operations).toContain(`update:old-token-1:${LANE_OLD}`);
+    expect(operations).not.toContain(`update:old-token-1:${LANE_ACTIVE}`);
     expect(operations).toContain("insert:cashu-change-token:accepted");
-    expect(operations.indexOf("update:old-token-1:lane-old")).toBeLessThan(
+    expect(operations.indexOf(`update:old-token-1:${LANE_OLD}`)).toBeLessThan(
       operations.indexOf("insert:cashu-change-token:accepted"),
     );
 

--- a/apps/web-app/vitest.config.ts
+++ b/apps/web-app/vitest.config.ts
@@ -1,5 +1,5 @@
 import react from "@vitejs/plugin-react-swc";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [react()],
@@ -8,5 +8,7 @@ export default defineConfig({
     globals: true,
     setupFiles: "./vitest.setup.ts",
     css: true,
+    // *.spec.ts files in tests/ are Playwright E2E suites, not vitest tests.
+    exclude: [...configDefaults.exclude, "tests/**/*.spec.ts"],
   },
 });

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint": "bun run --workspaces --if-present eslint",
     "prettier": "bun run --workspaces --if-present prettier",
     "typecheck": "bun run --workspaces --if-present typecheck",
+    "test": "bun run --workspaces --if-present test",
     "check-code": "bun run typecheck && bun run eslint && bun run prettier"
   }
 }


### PR DESCRIPTION
The unit test suite had 7 failing tests, 1 flaky test, and 4 suites failing at collection — all rotten silently because nothing ran vitest automatically (no `test` script, no CI job). Investigation showed **every failure was a test problem, not a product bug**. This PR also includes the `react-hooks/exhaustive-deps` fixes originally opened as #198, so it is self-contained: full suite green (`377 + 22` tests), `check-code` clean with zero warnings, and tests run in CI.

## Test fixes

- **`cashuOwnerLane.test.ts` / `usePayContactWithCashuMessage.test.tsx` — invalid Evolu OwnerId fixtures.** Evolu ids must be canonical 22-char base64url (last char restricted to `A/Q/g/w`); fixtures like `"a"×22` and `"lane-old"` fail validation, so `resolveCashuRowStoredOwnerLane` rightly rejected them and the lane-delete test asserted against its own broken fixture. With valid ids the documented invariant (soft-deletes target the row's own lane) is confirmed intact in production. The pay test also passed the removed `insert` dependency; it now passes `upsert`.
- **`useInboxNotificationsSync.test.tsx` — stale since the catch-up/live gating change (`4284d02`).** Bootstrap `querySync` results are intentionally silent; only live subscription events surface toasts. The 5 tests now deliver wraps through the live `onevent` handler (same pattern as the passing declined-offer test), and the replay tests re-deliver the same wrap across resubscribes/restarts to exercise the seen-wrap-id dedupe for real.
- **`cashuWallet.test.ts` — non-hex keyset ids.** Keyset ids are hex per NUT-02 and the production filter correctly rejects non-hex; fixture ids `01active`/`01legacy` are now realistic hex ids.
- **`TopupInvoicePage.test.tsx` — flake.** The async QR src was raced with a fixed 0ms delay; now polled with a bounded `waitFor`.

## Hook dependency fixes (from #198)

All 11 `react-hooks/exhaustive-deps` warnings resolved: stable refs/setters passed as hook parameters added to dependency arrays (9× — lint can't prove stability across the extraction boundary; no behavior change), redundant `selectedChatContact` sub-property deps removed (1×), and `getCashuTokenMessageInfo` added to `renderContactCard` deps (1× — real staleness fix: contact cards now refresh token status when the wallet token list changes).

## Infrastructure

- `vitest.config.ts` excludes `tests/**/*.spec.ts` — those are Playwright suites that previously failed collection under a bare `vitest run`.
- New `test` scripts: root (`--workspaces --if-present`) and `@linky/web-app` (`vitest run`); `@linky/core` already had one.
- New `.github/workflows/tests.yml` runs `bun run test` on PRs and pushes to `main`.
- AGENTS.md updated accordingly.

## Verification

- `bun run test`: web-app 377/377 across 87 files, core 22/22
- Full web-app suite run 3× consecutively — no flakes
- `bun run check-code`: 0 errors, 0 warnings