### PR TITLE
Fix Android QR scanner layout on small screens

### DIFF
--- a/apps/native-shell/android/app/src/main/java/fit/linky/app/MainActivity.java
+++ b/apps/native-shell/android/app/src/main/java/fit/linky/app/MainActivity.java
@@ -447,23 +447,30 @@ public class MainActivity extends BridgeActivity {
 			return;
 		}
 
-		nativeQrScannerOverlay.post(() -> {
-			int overlayWidth = nativeQrScannerOverlay.getWidth();
-			int overlayHeight = nativeQrScannerOverlay.getHeight();
-			if (overlayWidth <= 0 || overlayHeight <= 0) {
-				return;
+		int overlayWidth = nativeQrScannerOverlay.getWidth();
+		int overlayHeight = nativeQrScannerOverlay.getHeight();
+		WebView webView = getBridgeWebView();
+		if (webView != null) {
+			if (overlayWidth <= 0) {
+				overlayWidth = webView.getWidth();
 			}
+			if (overlayHeight <= 0) {
+				overlayHeight = webView.getHeight();
+			}
+		}
+		if (overlayWidth <= 0 || overlayHeight <= 0) {
+			return;
+		}
 
-			double scaleX = overlayWidth / viewportWidthCssPx;
-			double scaleY = overlayHeight / viewportHeightCssPx;
-			FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(
-				Math.max(1, (int) Math.round(widthCssPx * scaleX)),
-				Math.max(1, (int) Math.round(heightCssPx * scaleY))
-			);
-			layoutParams.leftMargin = Math.max(0, (int) Math.round(leftCssPx * scaleX));
-			layoutParams.topMargin = Math.max(0, (int) Math.round(topCssPx * scaleY));
-			nativeQrScannerView.setLayoutParams(layoutParams);
-		});
+		double scaleX = overlayWidth / viewportWidthCssPx;
+		double scaleY = overlayHeight / viewportHeightCssPx;
+		FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(
+			Math.max(1, (int) Math.round(widthCssPx * scaleX)),
+			Math.max(1, (int) Math.round(heightCssPx * scaleY))
+		);
+		layoutParams.leftMargin = Math.max(0, (int) Math.round(leftCssPx * scaleX));
+		layoutParams.topMargin = Math.max(0, (int) Math.round(topCssPx * scaleY));
+		nativeQrScannerView.setLayoutParams(layoutParams);
 	}
 
 	private void startNativeQrScannerPreview() {

--- a/apps/web-app/src/platform/nativeBridge.test.ts
+++ b/apps/web-app/src/platform/nativeBridge.test.ts
@@ -78,4 +78,21 @@ describe("startNativeQrScanStream", () => {
     handle?.stop();
     expect(stopScan).toHaveBeenCalledOnce();
   });
+
+  it("starts a full-screen preview when the viewport never becomes available", () => {
+    const onResult = vi.fn();
+    const getViewport = vi.fn(() => null);
+
+    const handle = startNativeQrScanStream(onResult, getViewport);
+
+    expect(handle).not.toBeNull();
+    while (callbacks.length > 0) {
+      callbacks.shift()?.(0);
+    }
+
+    expect(getViewport).toHaveBeenCalledTimes(30);
+    expect(setScanViewport).not.toHaveBeenCalled();
+    expect(startScan).toHaveBeenCalledOnce();
+    expect(onResult).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web-app/src/platform/nativeBridge.test.ts
+++ b/apps/web-app/src/platform/nativeBridge.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { startNativeQrScanStream } from "./nativeBridge";
+
+const runtimeMocks = vi.hoisted(() => ({
+  getPlatformTarget: vi.fn(() => "android"),
+  isNativePlatform: vi.fn(() => true),
+}));
+
+vi.mock("./runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./runtime")>();
+  return {
+    ...actual,
+    getPlatformTarget: runtimeMocks.getPlatformTarget,
+    isNativePlatform: runtimeMocks.isNativePlatform,
+  };
+});
+
+describe("startNativeQrScanStream", () => {
+  const callbacks: FrameRequestCallback[] = [];
+  const setScanViewport = vi.fn();
+  const startScan = vi.fn();
+  const stopScan = vi.fn();
+
+  beforeEach(() => {
+    callbacks.length = 0;
+    setScanViewport.mockReset();
+    startScan.mockReset();
+    stopScan.mockReset();
+
+    vi.stubGlobal("LinkyNativeScanner", {
+      setScanViewport,
+      startScan,
+      stopScan,
+    });
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        callbacks.push(callback);
+        return callbacks.length;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("waits for the scanner controls to lay out before starting Android camera preview", () => {
+    const viewport = {
+      height: 462,
+      left: 0,
+      top: 84,
+      viewportHeight: 640,
+      viewportWidth: 360,
+      width: 360,
+    };
+    const getViewport = vi
+      .fn()
+      .mockReturnValueOnce(null)
+      .mockReturnValue(viewport);
+
+    const handle = startNativeQrScanStream(vi.fn(), getViewport);
+
+    expect(handle).not.toBeNull();
+    expect(startScan).not.toHaveBeenCalled();
+
+    callbacks.shift()?.(0);
+
+    expect(startScan).not.toHaveBeenCalled();
+    expect(callbacks).toHaveLength(1);
+
+    callbacks.shift()?.(16);
+
+    expect(setScanViewport).toHaveBeenCalledWith(0, 84, 360, 462, 360, 640);
+    expect(startScan).toHaveBeenCalledOnce();
+
+    handle?.stop();
+    expect(stopScan).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web-app/src/platform/nativeBridge.ts
+++ b/apps/web-app/src/platform/nativeBridge.ts
@@ -105,6 +105,8 @@ export interface NativeScanViewport {
   width: number;
 }
 
+const NATIVE_SCAN_VIEWPORT_MAX_FRAMES = 30;
+
 interface AndroidNotificationsBridge {
   areSupported?: () => boolean;
   getPermissionState?: () => string;
@@ -499,32 +501,45 @@ export const startNativeQrScanStream = (
 
   window.addEventListener(eventName, onResultEvent);
 
-  animationFrameId = window.requestAnimationFrame(() => {
-    animationFrameId = null;
+  const startWhenViewportIsReady = (framesRemaining: number) => {
+    animationFrameId = window.requestAnimationFrame(() => {
+      animationFrameId = null;
 
-    try {
-      const viewport = getViewport?.() ?? null;
-      if (viewport && bridge.setScanViewport) {
-        bridge.setScanViewport(
-          viewport.left,
-          viewport.top,
-          viewport.width,
-          viewport.height,
-          viewport.viewportWidth,
-          viewport.viewportHeight,
-        );
+      try {
+        const viewport = getViewport?.() ?? null;
+        if (getViewport && bridge.setScanViewport && !viewport) {
+          if (framesRemaining > 1) {
+            startWhenViewportIsReady(framesRemaining - 1);
+            return;
+          }
+
+          throw new Error("Native scanner viewport unavailable");
+        }
+
+        if (viewport && bridge.setScanViewport) {
+          bridge.setScanViewport(
+            viewport.left,
+            viewport.top,
+            viewport.width,
+            viewport.height,
+            viewport.viewportWidth,
+            viewport.viewportHeight,
+          );
+        }
+        bridge.startScan?.();
+        started = true;
+      } catch (error) {
+        cleanup();
+        onResult({
+          cancelled: false,
+          message: String(error ?? "Native scanner failed"),
+          value: null,
+        });
       }
-      bridge.startScan?.();
-      started = true;
-    } catch (error) {
-      cleanup();
-      onResult({
-        cancelled: false,
-        message: String(error ?? "Native scanner failed"),
-        value: null,
-      });
-    }
-  });
+    });
+  };
+
+  startWhenViewportIsReady(NATIVE_SCAN_VIEWPORT_MAX_FRAMES);
 
   return {
     stop: () => {

--- a/apps/web-app/src/platform/nativeBridge.ts
+++ b/apps/web-app/src/platform/nativeBridge.ts
@@ -507,15 +507,18 @@ export const startNativeQrScanStream = (
 
       try {
         const viewport = getViewport?.() ?? null;
-        if (getViewport && bridge.setScanViewport && !viewport) {
-          if (framesRemaining > 1) {
-            startWhenViewportIsReady(framesRemaining - 1);
-            return;
-          }
-
-          throw new Error("Native scanner viewport unavailable");
+        if (
+          !viewport &&
+          getViewport &&
+          bridge.setScanViewport &&
+          framesRemaining > 1
+        ) {
+          startWhenViewportIsReady(framesRemaining - 1);
+          return;
         }
 
+        // Viewport still unavailable after the frame budget: start anyway so a
+        // slow layout degrades to a full-screen preview instead of no scanner.
         if (viewport && bridge.setScanViewport) {
           bridge.setScanViewport(
             viewport.left,


### PR DESCRIPTION
## Summary

- wait for the web scanner header and footer to finish layout before starting the Android camera preview
- size the native scanner against the measured WebView when its hidden overlay has no dimensions yet
- add regression coverage for delayed scanner viewport measurement

## Root cause

The native viewport was configured while the Android scanner overlay was still `GONE`. On smaller/slower devices, the React controls could also still be laying out. The missing or zero-sized viewport was discarded, leaving the native camera surface at its full-screen default and covering the header and footer.

## User impact

The Add contact QR scanner now keeps the title/close header and Type/Paste footer visible on both small and medium Android screens.

## Verification

- `bun run check-code`
- `bun run test` — 590 tests passed
- `bun run native:apk:debug`
- installed and visually verified the scanner on Android emulators at 720×1280 and 1080×2400
