### PR TITLE
Fix incognito profile creation loading loop

### DIFF
--- a/apps/web-app/index.html
+++ b/apps/web-app/index.html
@@ -73,9 +73,11 @@
 
         const markRecoveryAttempt = () => {
           try {
-            sessionStorage.setItem(recoveryKey, String(Date.now()));
+            const value = String(Date.now());
+            sessionStorage.setItem(recoveryKey, value);
+            return sessionStorage.getItem(recoveryKey) === value;
           } catch {
-            // A reload can still recover when sessionStorage is unavailable.
+            return false;
           }
         };
 
@@ -105,8 +107,12 @@
           }
         };
 
-        const recoverAndReload = async () => {
-          markRecoveryAttempt();
+        const recoverAndReload = async (requireRecoveryMarker = false) => {
+          const recoveryWasMarked = markRecoveryAttempt();
+          if (requireRecoveryMarker && !recoveryWasMarked) {
+            renderBootFailure();
+            return;
+          }
           await Promise.race([
             clearAppCaches().catch(() => undefined),
             new Promise((resolve) => window.setTimeout(resolve, 2_500)),
@@ -163,7 +169,7 @@
           const recoveryWasRecent =
             Date.now() - readLastRecoveryAt() < retryCooldownMs;
           if (navigator.onLine !== false && !recoveryWasRecent) {
-            void recoverAndReload();
+            void recoverAndReload(true);
             return;
           }
           renderBootFailure();

--- a/apps/web-app/public/password-save.html
+++ b/apps/web-app/public/password-save.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="robots" content="noindex" />
+    <title>Linky</title>
+  </head>
+  <body></body>
+</html>

--- a/apps/web-app/src/components/BootCommitSignal.tsx
+++ b/apps/web-app/src/components/BootCommitSignal.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+interface BootCommitSignalProps {
+  onCommit: () => void;
+}
+
+export const BootCommitSignal = ({ onCommit }: BootCommitSignalProps) => {
+  React.useEffect(() => {
+    onCommit();
+  }, [onCommit]);
+
+  return null;
+};

--- a/apps/web-app/src/components/PasswordManagerSaveForm.test.tsx
+++ b/apps/web-app/src/components/PasswordManagerSaveForm.test.tsx
@@ -1,0 +1,36 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { PasswordManagerSaveForm } from "./PasswordManagerSaveForm";
+
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+  configurable: true,
+  value: true,
+  writable: true,
+});
+
+describe("PasswordManagerSaveForm", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("submits to the lightweight password-save page", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <PasswordManagerSaveForm password="example backup" username="Alice" />,
+      );
+    });
+
+    const form = container.querySelector("form");
+    expect(form).toBeInstanceOf(HTMLFormElement);
+    expect(form?.method).toBe("post");
+    expect(form?.getAttribute("action")).toBe("/password-save.html");
+    expect(form?.target).toBe("linky-password-manager-save-target");
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web-app/src/components/PasswordManagerSaveForm.tsx
+++ b/apps/web-app/src/components/PasswordManagerSaveForm.tsx
@@ -10,6 +10,7 @@ interface PasswordManagerSaveFormProps {
 }
 
 const PASSWORD_MANAGER_SAVE_TARGET = "linky-password-manager-save-target";
+const PASSWORD_MANAGER_SAVE_ACTION = "/password-save.html";
 
 export const PasswordManagerSaveForm = React.forwardRef<
   PasswordManagerSaveFormHandle,
@@ -52,7 +53,7 @@ export const PasswordManagerSaveForm = React.forwardRef<
         ref={formRef}
         className="onboarding-password-save-form"
         method="post"
-        action="/"
+        action={PASSWORD_MANAGER_SAVE_ACTION}
         target={PASSWORD_MANAGER_SAVE_TARGET}
         autoComplete="on"
         aria-hidden="true"

--- a/apps/web-app/src/main.tsx
+++ b/apps/web-app/src/main.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { registerSW } from "virtual:pwa-register";
+import { BootCommitSignal } from "./components/BootCommitSignal";
 import "./index.css";
 import type {
   BroadcastChannelLike,
@@ -581,6 +582,7 @@ const renderBootError = (error: unknown) => {
 
 const bootstrap = async () => {
   let stage = "init";
+  let appCommitRecorded = false;
   // Surface a stuck-loading state with the last completed boot stage so we
   // can tell whether bootstrap froze in dynamic imports, polyfills, or the
   // first render. Mostly catches iOS Safari private-mode quirks where a
@@ -605,24 +607,30 @@ const bootstrap = async () => {
     const { evolu, EvoluProvider } = await import("./evolu.ts");
     console.log("[linky][boot] evolu loaded");
 
-    stage = "render";
+    stage = "await-render-commit";
     const root = createRoot(document.getElementById("root")!);
+    const recordAppCommit = () => {
+      if (appCommitRecorded) return;
+      appCommitRecorded = true;
+      stage = "mounted";
+      window.clearTimeout(stuckTimer);
+      appHasMounted = true;
+      window.dispatchEvent(new Event("linky-app-mounted"));
+      clearDynamicImportFetchRetry();
+    };
     flushSync(() => {
       root.render(
         <StrictMode>
           <EvoluProvider value={evolu}>
             <ErrorBoundary>
+              <BootCommitSignal onCommit={recordAppCommit} />
               <App />
             </ErrorBoundary>
           </EvoluProvider>
         </StrictMode>,
       );
     });
-    console.log("[linky][boot] rendered");
-    window.clearTimeout(stuckTimer);
-    appHasMounted = true;
-    window.dispatchEvent(new Event("linky-app-mounted"));
-    clearDynamicImportFetchRetry();
+    console.log("[linky][boot] render scheduled");
   } catch (error) {
     window.clearTimeout(stuckTimer);
     console.error(`Boot failed at stage ${stage}:`, error);

--- a/apps/web-app/src/sw.ts
+++ b/apps/web-app/src/sw.ts
@@ -523,7 +523,11 @@ registerRoute(
   async ({ url }) => createSpaydResponse(url),
 );
 
-registerRoute(new NavigationRoute(createHandlerBoundToURL("index.html")));
+registerRoute(
+  new NavigationRoute(createHandlerBoundToURL("index.html"), {
+    denylist: [/^\/password-save\.html$/],
+  }),
+);
 
 self.addEventListener("install", (event) => {
   event.waitUntil(logSw("service worker install", { build: SW_BUILD_TAG }));

--- a/apps/web-app/tests/boot-recovery.spec.ts
+++ b/apps/web-app/tests/boot-recovery.spec.ts
@@ -1,4 +1,7 @@
 import { expect, test } from "@playwright/test";
+import { generateMnemonic } from "@scure/bip39";
+import { wordlist } from "@scure/bip39/wordlists/english";
+import { generateSecretKey, nip19 } from "nostr-tools";
 
 test("recovers once when the main bundle cannot start", async ({ page }) => {
   let mainBundleRequests = 0;
@@ -29,4 +32,71 @@ test("recovers once when the main bundle cannot start", async ({ page }) => {
   await expect(
     page.getByRole("button", { name: "Clear cache and reload" }),
   ).toBeVisible();
+});
+
+test("does not reload forever when session storage is unavailable", async ({
+  page,
+}) => {
+  let mainBundleRequests = 0;
+
+  await page.addInitScript(() => {
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      get() {
+        throw new DOMException("Storage unavailable", "SecurityError");
+      },
+    });
+    Object.defineProperty(window, "__linkyBootWatchdogMs", {
+      configurable: true,
+      value: 50,
+    });
+  });
+  await page.route("**/src/main.tsx*", async (route) => {
+    mainBundleRequests += 1;
+    await route.abort();
+  });
+
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", { name: "The app failed to start" }),
+  ).toBeVisible({ timeout: 10_000 });
+  await page.waitForTimeout(250);
+  expect(mainBundleRequests).toBe(1);
+});
+
+test("recovers when the authenticated app never commits", async ({ page }) => {
+  const nsec = nip19.nsecEncode(generateSecretKey());
+  const mnemonic = generateMnemonic(wordlist, 128);
+  let databaseWorkerRequests = 0;
+
+  await page.addInitScript(
+    ([nextNsec, nextMnemonic]) => {
+      const initializedKey = "linky.test.commit-recovery-initialized";
+      if (sessionStorage.getItem(initializedKey) !== "1") {
+        localStorage.clear();
+        sessionStorage.clear();
+        sessionStorage.setItem(initializedKey, "1");
+      }
+      localStorage.setItem("linky.lang", "en");
+      localStorage.setItem("linky.nostr_nsec", nextNsec);
+      localStorage.setItem("linky.initialMnemonic", nextMnemonic);
+      Object.defineProperty(window, "__linkyBootWatchdogMs", {
+        configurable: true,
+        value: 2_000,
+      });
+    },
+    [nsec, mnemonic],
+  );
+  await page.route("**/*Db.worker*", async (route) => {
+    databaseWorkerRequests += 1;
+    await route.abort();
+  });
+
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("heading", { name: "The app failed to start" }),
+  ).toBeVisible({ timeout: 15_000 });
+  expect(databaseWorkerRequests).toBeGreaterThanOrEqual(1);
 });

--- a/apps/web-app/tests/password-manager-save.spec.ts
+++ b/apps/web-app/tests/password-manager-save.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+
+test("password save does not boot a nested app instance", async ({ page }) => {
+  let mainBundleRequests = 0;
+  let passwordSaveMethod = "";
+
+  await page.addInitScript(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    localStorage.setItem("linky.lang", "en");
+  });
+  page.on("request", (request) => {
+    if (request.url().includes("/src/main.tsx")) {
+      mainBundleRequests += 1;
+    }
+  });
+  await page.route("**/password-save.html", async (route) => {
+    passwordSaveMethod = route.request().method();
+    await route.fulfill({
+      body: "<!doctype html><html><body>Password saved</body></html>",
+      contentType: "text/html",
+      status: 200,
+    });
+  });
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "I'm getting started" }).click();
+  await expect(
+    page.getByRole("button", { name: "Confirm profile" }),
+  ).toBeVisible({ timeout: 20_000 });
+
+  const mainBundleRequestsBeforeSave = mainBundleRequests;
+  const saveForm = page.locator(".onboarding-password-save-form");
+  await expect(saveForm).toHaveCount(1);
+  await saveForm.evaluate((element) => {
+    if (!(element instanceof HTMLFormElement)) {
+      throw new Error("Expected password-save form");
+    }
+    element.requestSubmit();
+  });
+
+  await expect.poll(() => passwordSaveMethod, { timeout: 10_000 }).toBe("POST");
+  await expect(
+    page
+      .frameLocator('iframe[name="linky-password-manager-save-target"]')
+      .getByText("Password saved"),
+  ).toHaveCount(1);
+  expect(mainBundleRequests).toBe(mainBundleRequestsBeforeSave);
+});


### PR DESCRIPTION
## Summary

- keep password-manager save submission on a lightweight same-origin page so it cannot boot a competing Linky/Evolu instance
- only mark boot complete after React's first real commit
- stop the recovery watchdog from endlessly reloading when session storage is unavailable
- add unit and browser regression coverage

## Root cause

The hidden password-manager form posted to `/`, loading the full app in its iframe during new-profile setup. That temporary Evolu instance could own the shared database worker just as the top-level page reloaded. When the iframe disappeared, initialization messages could be lost, leaving authenticated React queries suspended behind the static loading shell. The boot code also reported success before React committed, disabling recovery, and the shell recovery marker could not persist in some private-mode storage environments.

## Validation

- `bun run check-code`
- `bun run test` (592 tests)
- `bun run build`
- `cd apps/web-app && bunx playwright test tests/boot-recovery.spec.ts tests/password-manager-save.spec.ts` (4 tests)
