### PR TITLE
Add full local dev environment with docker-compose service stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+apps/push/data
 dist-ssr
 dev-dist
 test-results

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ IMPORTANT: When you make or change an architectural decision, document it in `do
 ## Local dev environment
 
 - `bun run dev` starts the local service stack (`docker-compose.dev.yml`: Nostr relay :7777, Evolu relay :4001, FakeWallet mint :3338) detached, then the web app (:5173) and push service (:8787) against it; requires Docker
-- `bun run dev:preview` runs the web app on :5175 against production services (no local stack needed)
+- `bun run dev:prod` runs the web app on :5175 against production services (no local stack needed)
 - `bun run dev:services` runs just the docker stack attached (Ctrl-C stops it)
 - See the "Local dev environment" section in `docs/architecture.md` for how env overrides and vite modes work
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,13 @@ IMPORTANT: When you make or change an architectural decision, document it in `do
 - Prefer sparse Evolu mutation payloads: omit optional fields when empty instead of writing explicit `null` (especially `cashuToken` optional columns like `rawToken`, `mint`, `unit`, `amount`, `error`)
 - Plain CSS in `App.css` - no CSS-in-JS or utility framework
 
+## Local dev environment
+
+- `bun run dev` starts the local service stack (`docker-compose.dev.yml`: Nostr relay :7777, Evolu relay :4001, FakeWallet mint :3338) detached, then the web app (:5173) and push service (:8787) against it; requires Docker
+- `bun run dev:preview` runs the web app on :5175 against production services (no local stack needed)
+- `bun run dev:services` runs just the docker stack attached (Ctrl-C stops it)
+- See the "Local dev environment" section in `docs/architecture.md` for how env overrides and vite modes work
+
 ## Gotchas
 
 - Evolu requires a Worker polyfill in test environments (jsdom + polyfill live in `vitest.setup.ts`)
@@ -35,6 +42,8 @@ IMPORTANT: When you make or change an architectural decision, document it in `do
 - SQLite WASM files served from `public/sqlite-wasm/` with `cache-control: no-store` in dev
 - Play upload bundles require release signing via `apps/native-shell/android/keystore.properties` or `LINKY_UPLOAD_STORE_FILE` / `LINKY_UPLOAD_STORE_PASSWORD` / `LINKY_UPLOAD_KEY_ALIAS` / `LINKY_UPLOAD_KEY_PASSWORD`; `bun run native:aab:release` fails fast when those credentials are missing
 - Dev mode now keeps the registered PWA service worker alive for push testing; use `#advanced/push-debug` to inspect persistent client/SW push logs and manually reset service workers/caches when needed
+- The pinned versions in `docker/evolu-relay/package.json` must stay protocol-compatible with the web app's `@evolu/common` — check upstream `apps/relay/CHANGELOG.md` when bumping Evolu packages
+- `apps/push/.env.development` and `apps/web-app/.env.development` are intentionally committed (localhost-only config; the VAPID keypair in there is dev-only, never reuse it in production)
 
 ## Maintaining This File
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,15 @@ The repo also contains a separate public website in `apps/site/` intended for `l
 
 ## Development
 
-Requirements: Bun
+Requirements: Bun; Docker for the local dev service stack
 
 For Android native builds: Java 17
+
+### Local dev vs prod services
+
+- `bun run dev` — full local environment: starts `docker-compose.dev.yml` (local Nostr relay :7777, Evolu sync relay :4001, Cashu Nutshell **FakeWallet** mint :3338 that auto-settles invoices with fake sats), then runs the web app (:5173) and push service (:8787) against it via the committed `.env.development` files. npub.cash flows are disabled locally (#219); the mint has no real Lightning backend (#220).
+- `bun run dev:preview` — web app only, on :5175, against production services. The separate port keeps browser storage isolated from local-dev sessions.
+- `bun run dev:services` — just the docker stack, attached.
 
 Android shell currently adds:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For Android native builds: Java 17
 ### Local dev vs prod services
 
 - `bun run dev` — full local environment: starts `docker-compose.dev.yml` (local Nostr relay :7777, Evolu sync relay :4001, Cashu Nutshell **FakeWallet** mint :3338 that auto-settles invoices with fake sats), then runs the web app (:5173) and push service (:8787) against it via the committed `.env.development` files. npub.cash flows are disabled locally (#219); the mint has no real Lightning backend (#220).
-- `bun run dev:preview` — web app only, on :5175, against production services. The separate port keeps browser storage isolated from local-dev sessions.
+- `bun run dev:prod` — web app only, on :5175, against production services. The separate port keeps browser storage isolated from local-dev sessions.
 - `bun run dev:services` — just the docker stack, attached.
 
 Android shell currently adds:

--- a/apps/push/.env.development
+++ b/apps/push/.env.development
@@ -1,0 +1,10 @@
+# Local dev config, auto-loaded by Bun when NODE_ENV is unset/development.
+# The VAPID keypair below is dev-only and used exclusively against localhost;
+# it is intentionally committed and must never be reused in production.
+PUSH_PORT=8787
+PUSH_STORAGE_PATH=./data/linky-push-dev.sqlite
+PUSH_VAPID_SUBJECT=mailto:dev@linky.fit
+PUSH_VAPID_PUBLIC_KEY=BML2PNVwsrHDgzeLt836OFeZkHw3RVhXPqQdDBFS4hoCbMUSNB-Ae_ybZOI97q3iSWMGRLbrCa26h1TAplJX1KI
+PUSH_VAPID_PRIVATE_KEY=LNC17GCpcc3lXj1uiyOdUaafOJqqK07S_eSHa9wSYKY
+PUSH_DEFAULT_RELAYS=ws://localhost:7777
+PUSH_CORS_ORIGIN=*

--- a/apps/web-app/.env.development
+++ b/apps/web-app/.env.development
@@ -1,0 +1,11 @@
+# Local dev services from docker-compose.dev.yml (repo root).
+# `bun run dev` (vite development mode) loads this file; `bun run dev:preview`
+# runs vite in "preview" mode, skips this file, and falls back to the
+# production endpoints hardcoded in src.
+VITE_NOSTR_RELAYS=ws://localhost:7777
+VITE_EVOLU_SERVER_URLS=ws://localhost:4001
+VITE_MAIN_MINT_URL=http://localhost:3338
+VITE_PUSH_SERVER_URL=http://localhost:8787
+# No npub.cash-compatible server runs locally; hosted lightning-address
+# flows are skipped in dev (see issue about running npubcash-server locally).
+VITE_NPUB_CASH_DISABLED=true

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:preview": "vite --mode preview --port 5175",
+    "dev:prod": "vite --mode prod-services --port 5175",
     "build": "tsc -b && vite build",
     "eslint": "eslint --fix .",
     "prettier": "prettier --write .",

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:preview": "vite --mode preview --port 5175",
     "build": "tsc -b && vite build",
     "eslint": "eslint --fix .",
     "prettier": "prettier --write .",

--- a/apps/web-app/playwright.config.ts
+++ b/apps/web-app/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     headless: true,
   },
   webServer: {
-    command: "bun run dev -- --mode preview --host 127.0.0.1 --port 5174",
+    command: "bun run dev -- --mode prod-services --host 127.0.0.1 --port 5174",
     url: "http://127.0.0.1:5174",
     reuseExistingServer: true,
     timeout: 120000,

--- a/apps/web-app/playwright.config.ts
+++ b/apps/web-app/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     headless: true,
   },
   webServer: {
-    command: "bun run dev -- --host 127.0.0.1 --port 5174",
+    command: "bun run dev -- --mode preview --host 127.0.0.1 --port 5174",
     url: "http://127.0.0.1:5174",
     reuseExistingServer: true,
     timeout: 120000,

--- a/apps/web-app/src/app/hooks/cashu/useNpubCashClaim.ts
+++ b/apps/web-app/src/app/hooks/cashu/useNpubCashClaim.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../utils/constants";
 import type { DisplayAmountParts } from "../../../utils/displayAmounts";
 import { extractUniqueClaimTokens } from "../../../utils/npubCashClaimResponse";
+import { isNpubCashDisabled } from "../../../utils/npubCashServer";
 import type { Route } from "../../../types/route";
 import {
   safeLocalStorageGet,
@@ -289,6 +290,7 @@ export const useNpubCashClaim = ({
   const claimNpubCashOnce = React.useCallback(async () => {
     // Don't claim while we are paying/accepting, otherwise we risk consuming
     // the claim response and then skipping token processing.
+    if (isNpubCashDisabled()) return;
     if (cashuIsBusy) return;
     if (!currentNpub) return;
     if (!currentNsec) return;

--- a/apps/web-app/src/app/hooks/composition/useCashuWalletComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useCashuWalletComposition.ts
@@ -35,6 +35,7 @@ import {
   WALLET_WARNING_DISMISSED_STORAGE_KEY,
 } from "../../../utils/constants";
 import { formatDisplayAmountParts } from "../../../utils/displayAmounts";
+import { isNpubCashDisabled } from "../../../utils/npubCashServer";
 import {
   getLightningInvoicePreview,
   type LightningInvoicePreview,
@@ -1626,7 +1627,7 @@ export const useCashuWalletComposition = ({
   );
 
   React.useEffect(() => {
-    if (!currentNpub || !currentNsec) {
+    if (isNpubCashDisabled() || !currentNpub || !currentNsec) {
       setOwnedProfileLightningAddresses([]);
       setOwnedProfileLightningAddressesLoading(false);
       return;

--- a/apps/web-app/src/app/hooks/mint/useNpubCashMintSelection.ts
+++ b/apps/web-app/src/app/hooks/mint/useNpubCashMintSelection.ts
@@ -5,6 +5,7 @@ import {
   isTestMintUrl,
   normalizeMintUrl,
 } from "../../../utils/mint";
+import { isNpubCashDisabled } from "../../../utils/npubCashServer";
 import { safeLocalStorageSet } from "../../../utils/storage";
 
 interface MintSelectionAutoswapPlanArgs {
@@ -153,6 +154,7 @@ export const useNpubCashMintSelection = ({
 
   const updateNpubCashMint = React.useCallback(
     async (mintUrl: string): Promise<void> => {
+      if (isNpubCashDisabled()) return;
       if (!currentNpub) throw new Error("Missing npub");
       if (!currentNsec) throw new Error("Missing nsec");
       const cleaned = normalizeMintUrl(mintUrl);

--- a/apps/web-app/src/app/hooks/useProfileNpubCashEffects.ts
+++ b/apps/web-app/src/app/hooks/useProfileNpubCashEffects.ts
@@ -1,6 +1,7 @@
 import React from "react";
 import type { JsonValue } from "../../types/json";
 import { normalizeMintUrl } from "../../utils/mint";
+import { isNpubCashDisabled } from "../../utils/npubCashServer";
 import { optimizeCaseInsensitiveQrPayload } from "../../utils/qrPayload";
 import { asRecord } from "../../utils/validation";
 
@@ -120,6 +121,7 @@ export const useProfileNpubCashEffects = ({
     // - read default mint (preferred mint) for the user
     // - auto-claim pending payments and store them as Cashu tokens
     // Uses the server bound to the current lightning-address domain.
+    if (isNpubCashDisabled()) return;
     if (!networkEnabled) return;
     if (!currentNpub) return;
     if (!currentNsec) return;

--- a/apps/web-app/src/evolu.ts
+++ b/apps/web-app/src/evolu.ts
@@ -42,10 +42,15 @@ export type EvoluDatabaseInfo = {
   updatedAtMs: number | null;
 };
 
-export const DEFAULT_EVOLU_SERVER_URLS: ReadonlyArray<string> = [
-  "wss://evolu.linky.fit",
-  "wss://free.evoluhq.com",
-];
+const envEvoluServerUrls = (import.meta.env.VITE_EVOLU_SERVER_URLS ?? "")
+  .split(",")
+  .map((url) => url.trim())
+  .filter((url) => url.startsWith("ws://") || url.startsWith("wss://"));
+
+export const DEFAULT_EVOLU_SERVER_URLS: ReadonlyArray<string> =
+  envEvoluServerUrls.length > 0
+    ? envEvoluServerUrls
+    : ["wss://evolu.linky.fit", "wss://free.evoluhq.com"];
 
 // Generate a valid SimpleName (1-42 chars, alphanumeric + dash) from mnemonic
 // Each user gets their own SQLite database file

--- a/apps/web-app/src/utils/mint.ts
+++ b/apps/web-app/src/utils/mint.ts
@@ -1,12 +1,18 @@
-export const MAIN_MINT_URL = "https://cashu.cz";
+const envMainMintUrl = (import.meta.env.VITE_MAIN_MINT_URL ?? "").trim();
 
-export const PRESET_MINTS = [
-  "https://cashu.cz",
-  "https://testnut.cashu.space",
-  "https://mint.minibits.cash/Bitcoin",
-  "https://kashu.me",
-  "https://cashu.21m.lol",
-];
+export const MAIN_MINT_URL = envMainMintUrl || "https://cashu.cz";
+
+// With a local dev mint configured, keep only test mints in the presets so
+// dev mode never fetches metadata from (or offers) production mints.
+export const PRESET_MINTS = envMainMintUrl
+  ? [envMainMintUrl, "https://testnut.cashu.space"]
+  : [
+      "https://cashu.cz",
+      "https://testnut.cashu.space",
+      "https://mint.minibits.cash/Bitcoin",
+      "https://kashu.me",
+      "https://cashu.21m.lol",
+    ];
 
 export const TEST_MINTS = ["https://testnut.cashu.space"];
 
@@ -110,6 +116,11 @@ export const getMintOriginAndHost = (
 export const isTestMintUrl = (mint: MintStringInput): boolean => {
   const normalizedMint = normalizeMintUrl(mint).toLowerCase();
   if (!normalizedMint) return false;
+
+  // Local dev mints (docker-compose FakeWallet) behave like test mints.
+  const { host } = getMintOriginAndHost(normalizedMint);
+  const hostname = (host ?? "").replace(/:\d+$/, "");
+  if (hostname === "localhost" || hostname === "127.0.0.1") return true;
 
   return TEST_MINTS.some(
     (testMint) => normalizeMintUrl(testMint).toLowerCase() === normalizedMint,

--- a/apps/web-app/src/utils/nostrRelays.ts
+++ b/apps/web-app/src/utils/nostrRelays.ts
@@ -1,9 +1,3 @@
-export const NOSTR_RELAYS = [
-  "wss://relay.damus.io",
-  "wss://nos.lol",
-  "wss://relay.0xchat.com",
-];
-
 export const normalizeRelayUrls = (urls: readonly string[]): string[] => {
   const seen = new Set<string>();
   const normalized: string[] = [];
@@ -18,3 +12,16 @@ export const normalizeRelayUrls = (urls: readonly string[]): string[] => {
 
   return normalized;
 };
+
+const DEFAULT_NOSTR_RELAYS = [
+  "wss://relay.damus.io",
+  "wss://nos.lol",
+  "wss://relay.0xchat.com",
+];
+
+const envRelays = normalizeRelayUrls(
+  (import.meta.env.VITE_NOSTR_RELAYS ?? "").split(","),
+);
+
+export const NOSTR_RELAYS =
+  envRelays.length > 0 ? envRelays : DEFAULT_NOSTR_RELAYS;

--- a/apps/web-app/src/utils/npubCashServer.ts
+++ b/apps/web-app/src/utils/npubCashServer.ts
@@ -1,3 +1,8 @@
+// Local dev has no npub.cash-compatible server; hosted lightning-address
+// flows (info/claim/mint sync) are skipped entirely when disabled.
+export const isNpubCashDisabled = (): boolean =>
+  import.meta.env.VITE_NPUB_CASH_DISABLED === "true";
+
 const DEFAULT_NPUB_CASH_SERVER_BASE_URL = "https://npub.cash";
 
 const HOSTED_NPUB_CASH_SERVER_BASE_URLS: Readonly<Record<string, string>> = {

--- a/apps/web-app/src/vite-env.d.ts
+++ b/apps/web-app/src/vite-env.d.ts
@@ -3,3 +3,12 @@
 
 declare const __APP_VERSION__: string;
 declare const __APP_COMMIT_SHA__: string;
+
+interface ImportMetaEnv {
+  readonly VITE_NOSTR_RELAYS?: string;
+  readonly VITE_EVOLU_SERVER_URLS?: string;
+  readonly VITE_MAIN_MINT_URL?: string;
+  readonly VITE_NPUB_CASH_DISABLED?: string;
+  readonly VITE_PUSH_SERVER_URL?: string;
+  readonly VITE_NOTIFICATION_SERVER_URL?: string;
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@
 # Run attached in a separate terminal with `bun run dev:services`.
 services:
   nostr-relay:
-    image: scsibug/nostr-rs-relay:latest
+    image: scsibug/nostr-rs-relay:0.10.0
     ports:
       - "7777:8080"
     volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,64 @@
+# Local dev services for `bun run dev` (see apps/web-app/.env.development).
+# Run attached in a separate terminal with `bun run dev:services`.
+services:
+  nostr-relay:
+    image: scsibug/nostr-rs-relay:latest
+    ports:
+      - "7777:8080"
+    volumes:
+      - nostr-relay-data:/usr/src/app/db
+
+  evolu-relay:
+    build: docker/evolu-relay
+    ports:
+      - "4001:4000"
+    volumes:
+      - evolu-relay-data:/app/data
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "const s=require('net').connect(4000,'127.0.0.1');s.on('connect',()=>process.exit(0));s.on('error',()=>process.exit(1))",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  cashu-mint:
+    image: cashubtc/nutshell:0.20.3
+    command: ["poetry", "run", "mint"]
+    ports:
+      - "3338:3338"
+    volumes:
+      - cashu-mint-data:/app/data
+    environment:
+      MINT_BACKEND_BOLT11_SAT: FakeWallet
+      MINT_LISTEN_HOST: "0.0.0.0"
+      MINT_LISTEN_PORT: "3338"
+      MINT_PRIVATE_KEY: LOCAL_DEV_ONLY_PRIVATE_KEY
+      MINT_DATABASE: data/mint
+      # FakeWallet simulation knobs for payment-timing tests (defaults shown).
+      # FAKEWALLET_BRR: "true"                  # auto-settle created invoices
+      # FAKEWALLET_DELAY_INCOMING_PAYMENT: "3"  # seconds before a top-up invoice settles
+      # FAKEWALLET_DELAY_OUTGOING_PAYMENT: "3"  # seconds before melt/pay returns
+      # FAKEWALLET_PAY_INVOICE_STATE: SETTLED   # or FAILED | PENDING | UNKNOWN
+      # FAKEWALLET_PAYMENT_STATE: SETTLED       # poll result: SETTLED | FAILED | PENDING | UNKNOWN
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python3",
+          "-c",
+          "import urllib.request,sys;sys.exit(0 if urllib.request.urlopen('http://localhost:3338/v1/info').status==200 else 1)",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+volumes:
+  nostr-relay-data:
+  evolu-relay-data:
+  cashu-mint-data:

--- a/docker/evolu-relay/Dockerfile
+++ b/docker/evolu-relay/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:22-alpine
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=dev
+COPY index.js ./
+RUN mkdir -p data
+EXPOSE 4000
+VOLUME ["/app/data"]
+CMD ["node", "index.js"]

--- a/docker/evolu-relay/index.js
+++ b/docker/evolu-relay/index.js
@@ -19,5 +19,9 @@ if (!relay.ok) {
   console.error(relay.error);
   process.exit(1);
 }
-process.once("SIGINT", relay.value[Symbol.dispose]);
-process.once("SIGTERM", relay.value[Symbol.dispose]);
+const shutdown = () => {
+  relay.value[Symbol.dispose]();
+  process.exit(0);
+};
+process.once("SIGINT", shutdown);
+process.once("SIGTERM", shutdown);

--- a/docker/evolu-relay/index.js
+++ b/docker/evolu-relay/index.js
@@ -1,0 +1,23 @@
+// Local-dev Evolu relay. We run our own instead of the official
+// evoluhq/relay image because that image hardcodes a 1MB-per-owner quota;
+// pinned deps must stay protocol-compatible with the web app's
+// @evolu/common version (see apps/web-app/package.json).
+import { createConsole } from "@evolu/common";
+import { createNodeJsRelay } from "@evolu/nodejs";
+import { mkdirSync } from "node:fs";
+
+mkdirSync("data", { recursive: true });
+process.chdir("data");
+
+const relay = await createNodeJsRelay({ console: createConsole() })({
+  port: 4000,
+  enableLogging: true,
+  isOwnerWithinQuota: () => true,
+});
+
+if (!relay.ok) {
+  console.error(relay.error);
+  process.exit(1);
+}
+process.once("SIGINT", relay.value[Symbol.dispose]);
+process.once("SIGTERM", relay.value[Symbol.dispose]);

--- a/docker/evolu-relay/package.json
+++ b/docker/evolu-relay/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "evolu-relay-dev",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@evolu/common": "7.4.1",
+    "@evolu/nodejs": "2.4.0"
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,12 +17,12 @@ Architectural decisions and behavioral constraints for Linky. Keep this file up 
 ## Local dev environment
 
 - All external service endpoints are env-overridable with hardcoded production fallbacks: `VITE_NOSTR_RELAYS`, `VITE_EVOLU_SERVER_URLS` (comma-separated), `VITE_MAIN_MINT_URL`, `VITE_PUSH_SERVER_URL`, `VITE_NPUB_CASH_DISABLED` (declared in `apps/web-app/src/vite-env.d.ts`)
-- Vite mode selects the environment: `development` mode loads the checked-in `apps/web-app/.env.development` pointing at the `docker-compose.dev.yml` stack (Nostr relay :7777, Evolu relay :4001, Nutshell FakeWallet mint :3338, push :8787); `preview` mode (`bun run dev:preview`, port 5175) loads no overrides and hits production. Distinct ports keep localStorage/OPFS/service-worker state origin-isolated between the two modes, so a local-dev identity can never bleed into a prod session
+- Vite mode selects the environment: `development` mode loads the checked-in `apps/web-app/.env.development` pointing at the `docker-compose.dev.yml` stack (Nostr relay :7777, Evolu relay :4001, Nutshell FakeWallet mint :3338, push :8787); `prod-services` mode (`bun run dev:prod`, port 5175) loads no overrides and hits production. Distinct ports keep localStorage/OPFS/service-worker state origin-isolated between the two modes, so a local-dev identity can never bleed into a prod session
 - Relay and Evolu server lists are user-persisted settings; env vars only change the *defaults* for a fresh origin
 - The local Evolu relay image (`docker/evolu-relay/`) pins `@evolu/nodejs` + `@evolu/common` versions that must stay protocol-compatible with the web app's `@evolu/common` — verify the pairing via the upstream `apps/relay/CHANGELOG.md` before bumping either side (the official `evoluhq/relay` image is not used because it hardcodes a 1MB-per-owner quota)
 - `isTestMintUrl` treats any `localhost`/`127.0.0.1` mint as a test mint (disables autoswap etc.); the FakeWallet mint auto-settles invoices after ~3s and exposes deterministic failure/delay knobs via `FAKEWALLET_*` env vars in `docker-compose.dev.yml` — there is no working stochastic-failure option in Nutshell
 - npub.cash-compatible flows are skipped entirely in local dev (`VITE_NPUB_CASH_DISABLED=true` guards the info/claim/mint-sync entry points via `isNpubCashDisabled()`); running npubcash-server locally is issue #219, a real Lightning backend for the local mint is issue #220
-- Playwright E2E's web server runs `vite --mode preview` so tests keep hitting production endpoints regardless of the local stack
+- Playwright E2E's web server runs `vite --mode prod-services` so tests keep hitting production endpoints regardless of the local stack
 
 ## Web app (`apps/web-app/`)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,16 @@ Architectural decisions and behavioral constraints for Linky. Keep this file up 
 - Vercel rewrites `/.well-known/lnurlp/:user` and `/.well-known/nostr.json` into `apps/site/api/` serverless handlers so apex `linky.fit` can expose LNURL/NIP-05 while forwarding to `NPUBCASH_BASE_URL` (default `https://npub.linky.fit`); LNURL responses rewrite the returned callback back to the apex host
 - The `/cashu` entry page can ingest a token from manual paste, query string, or preferably URL hash, inspect the token client-side, present `Vyzvednout v Linky` / primary Linky-open CTA first, reveal QR-copy plus Lightning-address redeem flow behind a secondary `Další možnosti` toggle, and redeem to a Lightning address; redeem sends the maximum LN-address amount the mint+LNURL flow allows, queues anonymous payment telemetry to the same collector/feed used by the app, and forwards any leftover token value as a private Nostr gift wrap to the configured collector `npub` from a one-time sender identity instead of returning change
 
+## Local dev environment
+
+- All external service endpoints are env-overridable with hardcoded production fallbacks: `VITE_NOSTR_RELAYS`, `VITE_EVOLU_SERVER_URLS` (comma-separated), `VITE_MAIN_MINT_URL`, `VITE_PUSH_SERVER_URL`, `VITE_NPUB_CASH_DISABLED` (declared in `apps/web-app/src/vite-env.d.ts`)
+- Vite mode selects the environment: `development` mode loads the checked-in `apps/web-app/.env.development` pointing at the `docker-compose.dev.yml` stack (Nostr relay :7777, Evolu relay :4001, Nutshell FakeWallet mint :3338, push :8787); `preview` mode (`bun run dev:preview`, port 5175) loads no overrides and hits production. Distinct ports keep localStorage/OPFS/service-worker state origin-isolated between the two modes, so a local-dev identity can never bleed into a prod session
+- Relay and Evolu server lists are user-persisted settings; env vars only change the *defaults* for a fresh origin
+- The local Evolu relay image (`docker/evolu-relay/`) pins `@evolu/nodejs` + `@evolu/common` versions that must stay protocol-compatible with the web app's `@evolu/common` — verify the pairing via the upstream `apps/relay/CHANGELOG.md` before bumping either side (the official `evoluhq/relay` image is not used because it hardcodes a 1MB-per-owner quota)
+- `isTestMintUrl` treats any `localhost`/`127.0.0.1` mint as a test mint (disables autoswap etc.); the FakeWallet mint auto-settles invoices after ~3s and exposes deterministic failure/delay knobs via `FAKEWALLET_*` env vars in `docker-compose.dev.yml` — there is no working stochastic-failure option in Nutshell
+- npub.cash-compatible flows are skipped entirely in local dev (`VITE_NPUB_CASH_DISABLED=true` guards the info/claim/mint-sync entry points via `isNpubCashDisabled()`); running npubcash-server locally is issue #219, a real Lightning backend for the local mint is issue #220
+- Playwright E2E's web server runs `vite --mode preview` so tests keep hitting production endpoints regardless of the local stack
+
 ## Web app (`apps/web-app/`)
 
 ### Routing and shell

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "bun run --filter @linky/web-app dev",
+    "dev": "docker compose -f docker-compose.dev.yml up -d --wait && bun run --filter @linky/web-app --filter @linky/push dev",
+    "dev:preview": "bun run --filter @linky/web-app dev:preview",
+    "dev:services": "docker compose -f docker-compose.dev.yml up",
     "build": "bun run --filter @linky/web-app build",
     "preview": "bun run --filter @linky/web-app preview",
     "site:dev": "bun run --filter @linky/site dev",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "dev": "docker compose -f docker-compose.dev.yml up -d --wait && bun run --filter @linky/web-app --filter @linky/push dev",
-    "dev:preview": "bun run --filter @linky/web-app dev:preview",
+    "dev:prod": "bun run --filter @linky/web-app dev:prod",
     "dev:services": "docker compose -f docker-compose.dev.yml up",
     "build": "bun run --filter @linky/web-app build",
     "preview": "bun run --filter @linky/web-app preview",


### PR DESCRIPTION
## Summary

Sets up a complete local development environment so the app runs fully against local services — no production endpoints touched in dev mode.

### New commands

- `bun run dev` — starts the docker stack detached, then runs the web app (:5173) and push service (:8787) against it via committed `.env.development` files
- `bun run dev:prod` — web app only, on :5175, against **production** services; the separate port keeps browser storage (localStorage/OPFS/service worker) isolated from local-dev sessions
- `bun run dev:services` — just the docker stack, attached

### Docker stack (`docker-compose.dev.yml`)

- **Nostr relay** — `nostr-rs-relay` on `ws://localhost:7777` (Nostr has no testnet, so a private local relay)
- **Evolu sync relay** — custom image in `docker/evolu-relay/` on `ws://localhost:4001`. The official image hardcodes a 1MB-per-owner quota, so this wraps `@evolu/nodejs` with the quota disabled, pinned to versions protocol-compatible with the app's `@evolu/common@7.4.1` (documented gotcha: bump together)
- **Cashu mint** — Nutshell **FakeWallet** on `http://localhost:3338` (same software as testnut.cashu.space); invoices auto-settle with fake sats. Commented `FAKEWALLET_*` env knobs in the compose file enable deterministic payment delays and forced `FAILED`/`PENDING` melt states for payment-timing tests

### Config changes

- Endpoints (Nostr relays, Evolu servers, main mint, push server) are now env-overridable with prod fallbacks; committed `.env.development` files wire them to the local stack (the VAPID keypair in `apps/push/.env.development` is dev-only)
- Localhost mints are treated as test mints; with a local mint configured, preset prod mints are dropped so dev never fetches their metadata
- npub.cash flows are disabled in local dev (`VITE_NPUB_CASH_DISABLED`) — local npubcash-server deferred to #219, real Lightning mint backend to #220
- Playwright's E2E webServer pinned to `--mode prod-services` so E2E keeps hitting prod endpoints as before

### Verification

- Browser-automated end-to-end check: fresh onboarding → wallet → 21-sat top-up minted and auto-settled against the local FakeWallet mint; dev mode contacts only local services (plus Google Fonts/DiceBear/Coinbase rates/testnut); preview mode confirmed connecting to `wss://evolu.linky.fit` / `wss://free.evoluhq.com`
- `bun run check-code` passes; 569 unit tests pass (113 files)


closes #213 