### PR TITLE
Fix cold-start crash on notification tap; enable native push for debug builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ IMPORTANT: When you make or change an architectural decision, document it in `do
 - Vitest excludes `tests/**/*.spec.ts` — those are Playwright E2E suites run separately
 - In this workspace/Bun setup, `bunx --cwd apps/web-app playwright test tests` can resolve incorrectly; run `cd apps/web-app && bunx playwright test tests` instead
 - SQLite WASM files served from `public/sqlite-wasm/` with `cache-control: no-store` in dev
+- Debug APKs install side-by-side as `fit.linky.app.debug`; native push in them requires a `fit.linky.app.debug` client in `google-services.json` (register that package in the Firebase console), otherwise the google-services plugin is skipped for debug-only builds and push is unsupported
 - Play upload bundles require release signing via `apps/native-shell/android/keystore.properties` or `LINKY_UPLOAD_STORE_FILE` / `LINKY_UPLOAD_STORE_PASSWORD` / `LINKY_UPLOAD_KEY_ALIAS` / `LINKY_UPLOAD_KEY_PASSWORD`; `bun run native:aab:release` fails fast when those credentials are missing
 - Dev mode now keeps the registered PWA service worker alive for push testing; use `#advanced/push-debug` to inspect persistent client/SW push logs and manually reset service workers/caches when needed
 - The pinned versions in `docker/evolu-relay/package.json` must stay protocol-compatible with the web app's `@evolu/common` — check upstream `apps/relay/CHANGELOG.md` when bumping Evolu packages

--- a/apps/native-shell/android/app/build.gradle
+++ b/apps/native-shell/android/app/build.gradle
@@ -132,10 +132,13 @@ apply from: 'capacitor.build.gradle'
 
 try {
     def servicesJSON = file('google-services.json')
-    if (servicesJSON.text && !isDebugOnlyBuild) {
+    // Debug builds use the fit.linky.app.debug application id; the plugin fails the
+    // build unless google-services.json has a client registered for that package.
+    def hasDebugClient = servicesJSON.text.contains('"fit.linky.app.debug"')
+    if (servicesJSON.text && (!isDebugOnlyBuild || hasDebugClient)) {
         apply plugin: 'com.google.gms.google-services'
     } else if (isDebugOnlyBuild) {
-        logger.info("google-services plugin not applied for debug-only build. Native push notifications are disabled for the side-by-side debug app")
+        logger.info("google-services.json has no fit.linky.app.debug client. Native push notifications are disabled for the side-by-side debug app")
     }
 } catch(Exception e) {
     logger.info("google-services.json not found, google-services plugin not applied. Push Notifications won't work")

--- a/apps/native-shell/android/app/src/main/java/fit/linky/app/MainActivity.java
+++ b/apps/native-shell/android/app/src/main/java/fit/linky/app/MainActivity.java
@@ -136,12 +136,14 @@ public class MainActivity extends BridgeActivity {
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
+		// super.onCreate() re-delivers the launch intent through onNewIntent(), which
+		// writes to bridgePreferences — so it must be initialized first.
+		bridgePreferences = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
 		super.onCreate(savedInstanceState);
 		activeInstanceRef = new WeakReference<>(this);
 		getOnBackPressedDispatcher().addCallback(this, appNavigationBackCallback);
 		getOnBackPressedDispatcher().addCallback(this, nativeQrScannerBackCallback);
 
-		bridgePreferences = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
 		nfcAdapter = NfcAdapter.getDefaultAdapter(this);
 		cacheIntentDeepLinkUrl(getIntent());
 		cacheIntentNotificationRoute(getIntent());

--- a/apps/web-app/src/pages/AdvancedPage.tsx
+++ b/apps/web-app/src/pages/AdvancedPage.tsx
@@ -289,7 +289,16 @@ export function AdvancedPage(): React.ReactElement {
         const permissionGranted = await requestNotificationPermission();
         if (!permissionGranted) {
           setPushNotificationsDisabledByUser(true);
-          pushToast(t("notificationsDenied"));
+          const isUnsupported =
+            isNativePlatform() &&
+            getNativeNotificationPermissionState() === "unsupported";
+          pushToast(
+            t(
+              isUnsupported
+                ? "notificationsUnsupported"
+                : "notificationsDenied",
+            ),
+          );
           return;
         }
 


### PR DESCRIPTION
## Crash fix

Opening the app from a notification while it was killed crashed it immediately with an NPE. Capacitor's `BridgeActivity.onCreate()` re-delivers the launch intent through `onNewIntent()`, which called `cachePendingNotificationRoute()` → `bridgePreferences.edit()` before `onCreate` had assigned `bridgePreferences`. The field is now initialized before `super.onCreate()` (the base context it needs is already attached at that point).

Reproduced and verified on a Pixel 6a: `am start -n fit.linky.app/.MainActivity --es linky_notification_route '#contacts'` after force-stop crashed before the fix and cold-starts cleanly after it.

## Native push in the side-by-side debug app

Debug APKs install as `fit.linky.app.debug`, which had no client in `google-services.json`, so the google-services plugin was skipped for debug-only builds and the notifications toggle failed with a misleading "Denied" toast.

- The plugin is now applied for debug-only builds whenever `google-services.json` contains a `fit.linky.app.debug` client (register that package in the Firebase console to get one; without it, behavior is unchanged)
- When native push is genuinely unsupported in the build, the toggle now shows "Notifications are not supported" instead of "Denied"
- Documented the debug-push gotcha in AGENTS.md

Verified on device: with the debug client present, the debug build picks up the generated Firebase resources and `FirebaseApp` initializes successfully, unblocking the registration flow.