### PR TITLE
Fix iOS chat keyboard and reaction interactions

### DIFF
--- a/apps/web-app/src/App.css
+++ b/apps/web-app/src/App.css
@@ -6692,7 +6692,6 @@ button.tag-button {
   .reply-preview,
   .badge,
   .panel,
-  .message-actions-backdrop,
   .message-actions-sheet,
   .modal-sheet,
   .menu-modal-sheet,

--- a/apps/web-app/src/App.css
+++ b/apps/web-app/src/App.css
@@ -2045,6 +2045,14 @@ button.settings-sensitive-action.is-armed {
   scroll-padding-bottom: var(--chat-compose-height, 116px);
 }
 
+@media (max-width: 960px) {
+  .chat-messages {
+    margin-bottom: var(--chat-compose-height, 116px);
+    padding-bottom: 12px;
+    scroll-padding-bottom: 12px;
+  }
+}
+
 .chat-day-separator {
   align-self: center;
   font-size: 11px;
@@ -5907,10 +5915,6 @@ button.icon {
     padding-bottom: calc(6px + var(--floating-safe-area-bottom));
     background: transparent;
     box-shadow: none;
-  }
-
-  .chat-messages {
-    padding-bottom: var(--chat-compose-height, 116px);
   }
 
   .chat-message-editor {

--- a/apps/web-app/src/app/lib/chatViewport.test.ts
+++ b/apps/web-app/src/app/lib/chatViewport.test.ts
@@ -11,11 +11,19 @@ const setClientHeight = (element: HTMLElement, height: number): void => {
   });
 };
 
+const setScrollHeight = (element: HTMLElement, height: number): void => {
+  Object.defineProperty(element, "scrollHeight", {
+    configurable: true,
+    value: height,
+  });
+};
+
 describe("chat viewport anchor", () => {
   it("keeps the same content at the bottom when the viewport shrinks", () => {
     const messages = document.createElement("div");
     messages.scrollTop = 640;
     setClientHeight(messages, 400);
+    setScrollHeight(messages, 1_600);
 
     const anchor = captureChatViewportAnchor(messages);
 
@@ -30,6 +38,7 @@ describe("chat viewport anchor", () => {
     const messages = document.createElement("div");
     messages.scrollTop = 1_200;
     setClientHeight(messages, 400);
+    setScrollHeight(messages, 1_600);
 
     const anchor = captureChatViewportAnchor(messages);
 
@@ -37,5 +46,22 @@ describe("chat viewport anchor", () => {
     restoreChatViewportAnchor(messages, anchor);
 
     expect(messages.scrollTop).toBe(1_440);
+  });
+
+  it("clamps a short chat to its reachable end", () => {
+    const messages = document.createElement("div");
+    setClientHeight(messages, 600);
+    setScrollHeight(messages, 600);
+
+    const anchor = captureChatViewportAnchor(messages);
+
+    setClientHeight(messages, 260);
+    setScrollHeight(messages, 360);
+    restoreChatViewportAnchor(messages, anchor);
+
+    expect(messages.scrollTop).toBe(100);
+    expect(messages.scrollTop + messages.clientHeight).toBe(
+      messages.scrollHeight,
+    );
   });
 });

--- a/apps/web-app/src/app/lib/chatViewport.ts
+++ b/apps/web-app/src/app/lib/chatViewport.ts
@@ -18,8 +18,12 @@ export const restoreChatViewportAnchor = (
 ): void => {
   if (!messages || !anchor) return;
 
-  messages.scrollTop = Math.max(
+  const maxScrollTop = Math.max(
     0,
-    anchor.visibleBottom - messages.clientHeight,
+    messages.scrollHeight - messages.clientHeight,
+  );
+  messages.scrollTop = Math.min(
+    maxScrollTop,
+    Math.max(0, anchor.visibleBottom - messages.clientHeight),
   );
 };

--- a/apps/web-app/src/components/MessageActionsMenu.test.tsx
+++ b/apps/web-app/src/components/MessageActionsMenu.test.tsx
@@ -1,0 +1,56 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "../App.css";
+import { MessageActionsMenu } from "./MessageActionsMenu";
+
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+  configurable: true,
+  value: true,
+  writable: true,
+});
+
+describe("MessageActionsMenu", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("keeps the conversation visible through its backdrop", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <MessageActionsMenu
+          canEdit={false}
+          canReplyOrReact={true}
+          isOpen={true}
+          labels={{
+            copy: "Copy",
+            edit: "Edit",
+            react: "React",
+            reply: "Reply",
+          }}
+          onClose={vi.fn()}
+          onCopy={vi.fn()}
+          onEdit={vi.fn()}
+          onReact={vi.fn()}
+          onReply={vi.fn()}
+        />,
+      );
+    });
+    const backdrop = container.querySelector(".message-actions-backdrop");
+
+    expect(backdrop).not.toBeNull();
+    if (!backdrop) return;
+
+    expect(getComputedStyle(backdrop).backgroundColor).toBe(
+      "rgba(0, 0, 0, 0.4)",
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/apps/web-app/src/pages/ChatPage.tsx
+++ b/apps/web-app/src/pages/ChatPage.tsx
@@ -901,6 +901,7 @@ const useChatViewport = (
     const pendingRefreshTimeouts = new Set<number>();
     let pendingViewportAnchor: ChatViewportAnchor | null = null;
     let pendingViewportAnchorFrame: number | null = null;
+    let appliedViewportHeight: number | null = null;
     const getWindowScrollTop = () =>
       Math.max(
         window.scrollY,
@@ -920,9 +921,6 @@ const useChatViewport = (
       if (getWindowScrollTop() > 1) {
         window.scrollTo(0, 0);
       }
-      pendingViewportAnchor ??= captureChatViewportAnchor(
-        chatMessagesRef.current,
-      );
       const viewport = window.visualViewport;
       const nextHeight = viewport?.height ?? window.innerHeight;
       const nextOffsetTop = viewport?.offsetTop ?? 0;
@@ -941,10 +939,15 @@ const useChatViewport = (
         viewportKeyboardInset,
         Number.isFinite(nativeKeyboardInset) ? nativeKeyboardInset : 0,
       );
-      root.style.setProperty(
-        "--chat-viewport-height",
-        `${Math.round(window.innerHeight - keyboardInset)}px`,
-      );
+      const viewportHeight = Math.round(window.innerHeight - keyboardInset);
+      const viewportHeightChanged = appliedViewportHeight !== viewportHeight;
+
+      if (viewportHeightChanged) {
+        pendingViewportAnchor ??= captureChatViewportAnchor(
+          chatMessagesRef.current,
+        );
+      }
+      root.style.setProperty("--chat-viewport-height", `${viewportHeight}px`);
       root.style.setProperty(
         "--chat-keyboard-inset",
         `${Math.round(keyboardInset)}px`,
@@ -954,6 +957,9 @@ const useChatViewport = (
       } else {
         delete root.dataset.chatKeyboardOpen;
       }
+
+      appliedViewportHeight = viewportHeight;
+      if (!viewportHeightChanged) return;
 
       if (pendingViewportAnchorFrame !== null) {
         window.cancelAnimationFrame(pendingViewportAnchorFrame);


### PR DESCRIPTION
## Summary

- reserve real mobile layout space for the chat composer so short conversations remain scrollable above the iOS keyboard
- preserve valid message scroll anchors only when the visual viewport height changes
- keep conversations visible beneath the reaction menu’s translucent backdrop
- add regression coverage for short-chat viewport restoration and reaction-menu backdrop styling

## Root cause

The fixed composer was represented only by internal message-list padding, which could produce no usable overflow for short conversations after the keyboard reduced the viewport. Repeated settled viewport callbacks also rewrote `scrollTop`. Separately, a global flat-surface rule forced the reaction backdrop to the opaque app background, visually hiding every message while the menu was open.

## Validation

- `bun run --filter @linky/web-app test -- src/app/lib/chatViewport.test.ts src/components/MessageActionsMenu.test.tsx`
- `bun run check-code`
- manually verified keyboard and reaction-menu behavior in the running iOS simulator