### PR TITLE
Keep keyboard open when tapping input-adjacent action buttons

### DIFF
--- a/apps/web-app/src/components/UnauthenticatedLayout.tsx
+++ b/apps/web-app/src/components/UnauthenticatedLayout.tsx
@@ -294,6 +294,7 @@ export const UnauthenticatedLayout: React.FC<UnauthenticatedLayoutProps> = ({
               <button
                 type="button"
                 className="onboarding-return-pasteBtn"
+                onPointerDown={(event) => event.preventDefault()}
                 onClick={() => void pasteReturningSlip39FromClipboard()}
                 disabled={onboardingIsBusy}
                 aria-label={t("onboardingReturnPasteButton")}
@@ -321,6 +322,7 @@ export const UnauthenticatedLayout: React.FC<UnauthenticatedLayoutProps> = ({
                   key={word}
                   type="button"
                   className="pill pill-muted onboarding-return-suggestion"
+                  onPointerDown={(event) => event.preventDefault()}
                   onClick={() => selectReturningSlip39Suggestion(word)}
                   disabled={onboardingIsBusy}
                 >

--- a/apps/web-app/src/pages/ChatPage.tsx
+++ b/apps/web-app/src/pages/ChatPage.tsx
@@ -731,7 +731,7 @@ const ChatComposer = memo(function ChatComposer({
                   key={`group-${suggestion.groupName}`}
                   type="button"
                   className="chat-mention-suggestion"
-                  onMouseDown={(event) => event.preventDefault()}
+                  onPointerDown={(event) => event.preventDefault()}
                   onClick={() => selectMentionSuggestion(suggestion)}
                 >
                   <span className="chat-mention-suggestion-label">
@@ -753,7 +753,7 @@ const ChatComposer = memo(function ChatComposer({
                 key={`contact-${suggestion.contact.npub}`}
                 type="button"
                 className="chat-mention-suggestion"
-                onMouseDown={(event) => event.preventDefault()}
+                onPointerDown={(event) => event.preventDefault()}
                 onClick={() => selectMentionSuggestion(suggestion)}
               >
                 <span className="chat-contact-pill-avatar" aria-hidden="true">
@@ -814,6 +814,7 @@ const ChatComposer = memo(function ChatComposer({
           <button
             type="button"
             className="chat-compose-image-button"
+            onPointerDown={(event) => event.preventDefault()}
             onClick={() => imageInputRef.current?.click()}
             disabled={!canSendImage}
             aria-label={t("chatImageAttach")}
@@ -828,10 +829,8 @@ const ChatComposer = memo(function ChatComposer({
           <button
             type="button"
             className="chat-compose-send-button"
-            onClick={() => {
-              requestSend();
-              focusComposeInput();
-            }}
+            onPointerDown={(event) => event.preventDefault()}
+            onClick={requestSend}
             disabled={!canSendChat}
             aria-label={editContext ? t("chatSaveAction") : t("send")}
             title={editContext ? t("chatSaveAction") : t("send")}

--- a/apps/web-app/src/pages/ContactNewPage.tsx
+++ b/apps/web-app/src/pages/ContactNewPage.tsx
@@ -418,6 +418,7 @@ export const ContactNewPage: FC<ContactNewPageProps> = ({
                 <button
                   type="button"
                   className="icon-only-ghost"
+                  onPointerDown={(event) => event.preventDefault()}
                   onClick={() => void pasteSearch()}
                   title={t("paste")}
                   aria-label={t("paste")}

--- a/apps/web-app/src/pages/ContactsPage.tsx
+++ b/apps/web-app/src/pages/ContactsPage.tsx
@@ -76,6 +76,7 @@ export const ContactsPage: FC<ContactsPageProps> = React.memo(
                 type="button"
                 className="contacts-search-clear"
                 aria-label={t("contactsSearchClear")}
+                onPointerDown={(event) => event.preventDefault()}
                 onClick={() => {
                   setContactsSearch("");
                   requestAnimationFrame(() => {


### PR DESCRIPTION
## Problem

On mobile, tapping the chat send button while typing dismissed the keyboard instead of sending the message. Tapping any button steals focus from the input on pointer-down, which blurs it and dismisses the keyboard; the viewport then resizes and the bottom-anchored compose bar shifts under the finger, so the click often never lands.

The same focus-steal affected other buttons that act on input content mid-typing — worst in SLIP-39 seed entry, where tapping a word suggestion hid the keyboard between every word.

## Fix

Add `onPointerDown={(event) => event.preventDefault()}` to buttons that act on input content while the user is typing. This stops the button from taking focus, so the input stays focused, the keyboard stays open, and the tap lands reliably. Sending, clearing search, pasting, or picking a suggestion no longer interrupts typing; tapping anywhere else still dismisses the keyboard as usual.

Applied to:

- **ChatPage** — send button (also dropped the after-the-fact `focusComposeInput()` repair: send now never changes focus state), gallery/attach button (same bottom-bar tap race), and both mention-suggestion buttons (switched from `onMouseDown` to `onPointerDown`, which fires at touch-start — earlier than iOS's synthesized mousedown)
- **ContactsPage** — search clear button (kept the rAF refocus as fallback for taps while unfocused)
- **UnauthenticatedLayout** — SLIP-39 word-suggestion buttons and the seed paste button
- **ContactNewPage** — paste button next to the contact search input

Deliberately skipped buttons that end the typing session (save/submit/navigation), the custom payment keypad (no system keyboard), toggles, and file inputs.