### PR TITLE
Fix long-press message menu hidden behind compose bar on iOS

### DIFF
--- a/apps/web-app/src/components/MessageActionsMenu.test.tsx
+++ b/apps/web-app/src/components/MessageActionsMenu.test.tsx
@@ -40,7 +40,8 @@ describe("MessageActionsMenu", () => {
         />,
       );
     });
-    const backdrop = container.querySelector(".message-actions-backdrop");
+    // The menu portals to document.body, so query there rather than the container.
+    const backdrop = document.body.querySelector(".message-actions-backdrop");
 
     expect(backdrop).not.toBeNull();
     if (!backdrop) return;

--- a/apps/web-app/src/components/MessageActionsMenu.tsx
+++ b/apps/web-app/src/components/MessageActionsMenu.tsx
@@ -1,4 +1,5 @@
 import type { FC } from "react";
+import { createPortal } from "react-dom";
 import { EmojiPicker } from "./EmojiPicker";
 import { CopyIcon, EditIcon, ReplyIcon } from "./icons";
 
@@ -32,7 +33,9 @@ export const MessageActionsMenu: FC<MessageActionsMenuProps> = ({
 }) => {
   if (!isOpen) return null;
 
-  return (
+  // Portaled to <body>: on iOS the chat scroller is a composited layer whose
+  // stacking context would otherwise paint this fixed sheet below the compose bar.
+  return createPortal(
     <>
       <div
         className="message-actions-backdrop"
@@ -94,6 +97,7 @@ export const MessageActionsMenu: FC<MessageActionsMenuProps> = ({
           {labels.copy}
         </button>
       </div>
-    </>
+    </>,
+    document.body,
   );
 };


### PR DESCRIPTION
## Problem

On iOS, long-pressing a chat message opened the action sheet, but everything below the emoji row and Reply item was hidden behind the compose input and Request/Pay buttons.

## Cause

`MessageActionsMenu` rendered inside `.chat-messages`, an `overflow: auto` scroller. iOS WebKit composites such scrollers into their own stacking context, so the sheet's `z-index: 101` was trapped inside it and the sibling fixed compose bar (`z-index: 30`) painted on top. Desktop browsers don't composite the scroller the same way, which is why only iOS was affected.

## Fix

Render the menu (backdrop + sheet) via `createPortal(..., document.body)` so it escapes the scroller's stacking context. No CSS or handler changes needed — no selectors or DOM-containment checks depended on the menu's previous position, and React synthetic events still propagate through portals, so the long-press/swipe handlers behave as before. The unit test now queries the backdrop on `document.body`.

## Verification

- `bun run check-code` and unit tests pass
- Verified on an iPhone 17 Pro simulator (Safari, local dev stack): the full sheet — reaction row, Reply, Edit, Copy — renders above a dimmed backdrop covering the compose bar; tapping Copy closes the sheet and shows the toast