### PR TITLE
Fix uncaught TypeError when a Nostr relay sends binary websocket frames

### DIFF
--- a/apps/web-app/src/app/lib/createNostrPool.ts
+++ b/apps/web-app/src/app/lib/createNostrPool.ts
@@ -1,0 +1,22 @@
+import { AbstractSimplePool } from "nostr-tools/pool";
+import { verifyEvent } from "nostr-tools/pure";
+import { TextFrameWebSocket } from "../../utils/textFrameWebSocket";
+
+interface CreateNostrPoolOptions {
+  enablePing?: boolean;
+  enableReconnect: boolean;
+}
+
+// SimplePool hardwires the global WebSocket, so build the pool from
+// AbstractSimplePool to plug in TextFrameWebSocket (nostr-tools crashes on
+// binary frames from non-Nostr endpoints). maxWaitForConnection mirrors
+// SimplePool's default.
+export const createNostrPool = (
+  options: CreateNostrPoolOptions,
+): AbstractSimplePool =>
+  new AbstractSimplePool({
+    verifyEvent,
+    websocketImplementation: TextFrameWebSocket,
+    maxWaitForConnection: 3000,
+    ...options,
+  });

--- a/apps/web-app/src/app/lib/nostrPool.ts
+++ b/apps/web-app/src/app/lib/nostrPool.ts
@@ -1,7 +1,7 @@
-import type { SimplePool as NostrToolsSimplePool } from "nostr-tools";
+import type { AbstractSimplePool } from "nostr-tools/pool";
 
 export type AppNostrPool = Pick<
-  NostrToolsSimplePool,
+  AbstractSimplePool,
   "listConnectionStatus" | "publish" | "querySync" | "subscribe"
 >;
 
@@ -11,11 +11,11 @@ export const getSharedAppNostrPool = async (): Promise<AppNostrPool> => {
   if (sharedAppNostrPoolPromise) return sharedAppNostrPoolPromise;
 
   sharedAppNostrPoolPromise = (async () => {
-    const { SimplePool } = await import("nostr-tools");
+    const { createNostrPool } = await import("./createNostrPool");
     // Without these, a dropped relay websocket (mobile background, network
     // switch) permanently kills live subscriptions like the inbox sync; ping
     // detects half-dead sockets and reconnect resumes subs with since=last+1.
-    return new SimplePool({ enablePing: true, enableReconnect: true });
+    return createNostrPool({ enablePing: true, enableReconnect: true });
   })().catch((error) => {
     sharedAppNostrPoolPromise = null;
     throw error;

--- a/apps/web-app/src/sw.ts
+++ b/apps/web-app/src/sw.ts
@@ -7,7 +7,7 @@ const NOTIFICATION_OPEN_URL = "/#contacts";
 const NOTIFICATION_OPEN_HASH_PARAM = "notificationOpen";
 
 import type { Event as NostrEvent } from "nostr-tools";
-import { getPublicKey, nip19, SimplePool } from "nostr-tools";
+import { getPublicKey, nip19 } from "nostr-tools";
 import { unwrapEvent } from "nostr-tools/nip17";
 import { createHandlerBoundToURL, precacheAndRoute } from "workbox-precaching";
 import { ExpirationPlugin } from "workbox-expiration";
@@ -22,6 +22,7 @@ import {
   getLinkyBankPaymentOfferText,
   isLinkyBankPaymentOfferEvent,
 } from "./app/lib/bankPaymentOffer";
+import { createNostrPool } from "./app/lib/createNostrPool";
 import {
   getBankPaymentReimbursementCopyForLanguage,
   getReceivedMoneyCopyForLanguage,
@@ -292,7 +293,7 @@ async function fetchOuterWrapEvent(
     relays,
   });
 
-  const pool = new SimplePool({ enableReconnect: false });
+  const pool = createNostrPool({ enableReconnect: false });
   try {
     const events = await pool.querySync(
       relays,

--- a/apps/web-app/src/utils/textFrameWebSocket.test.ts
+++ b/apps/web-app/src/utils/textFrameWebSocket.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { TextFrameWebSocket } from "./textFrameWebSocket";
+
+const createSocket = () => new TextFrameWebSocket("ws://127.0.0.1:1");
+
+describe("TextFrameWebSocket", () => {
+  it("delivers text frames to the onmessage handler", () => {
+    const ws = createSocket();
+    const handler = vi.fn();
+    ws.onmessage = handler;
+
+    const event = new MessageEvent("message", { data: '["EVENT","sub"]' });
+    ws.dispatchEvent(event);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(event);
+  });
+
+  it("drops binary frames instead of delivering them", () => {
+    const ws = createSocket();
+    const handler = vi.fn();
+    ws.onmessage = handler;
+
+    ws.dispatchEvent(
+      new MessageEvent("message", { data: new Blob(["binary"]) }),
+    );
+    ws.dispatchEvent(new MessageEvent("message", { data: new ArrayBuffer(8) }));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("reads back the assigned handler and supports clearing it", () => {
+    const ws = createSocket();
+    const handler = vi.fn();
+
+    ws.onmessage = handler;
+    expect(ws.onmessage).toBe(handler);
+
+    ws.onmessage = null;
+    ws.dispatchEvent(new MessageEvent("message", { data: "text" }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-app/src/utils/textFrameWebSocket.ts
+++ b/apps/web-app/src/utils/textFrameWebSocket.ts
@@ -1,0 +1,22 @@
+// nostr-tools parses every incoming frame as JSON text and throws an uncaught
+// TypeError on binary data — which arrives when a configured relay URL is not
+// actually a Nostr relay (e.g. an Evolu sync relay). This subclass shadows
+// `onmessage` with an instance accessor so the handler only ever sees string
+// frames; binary frames are dropped.
+export class TextFrameWebSocket extends WebSocket {
+  constructor(...args: ConstructorParameters<typeof WebSocket>) {
+    super(...args);
+
+    let handler: ((this: WebSocket, ev: MessageEvent) => void) | null = null;
+    Object.defineProperty(this, "onmessage", {
+      get: () => handler,
+      set: (value: ((this: WebSocket, ev: MessageEvent) => void) | null) => {
+        handler = value;
+      },
+    });
+    this.addEventListener("message", (event) => {
+      if (typeof event.data !== "string") return;
+      handler?.call(this, event);
+    });
+  }
+}


### PR DESCRIPTION
## Problem

The console fills with uncaught errors from nostr-tools:

```
Uncaught TypeError: json.slice(...).indexOf is not a function
    at getSubscriptionId (nostr-tools ... abstract-relay)
    at AbstractRelay._onmessage
```

nostr-tools' `_onmessage` assumes every websocket frame is a JSON string. When a frame is binary, `ev.data` is a `Blob`, `Blob.slice()` returns a `Blob`, and `.indexOf` throws — before the internal `try/catch`, so it's uncaught and fires on every incoming frame.

This happens in practice when a configured Nostr relay URL isn't actually a Nostr relay — e.g. `wss://evolu.petrkr.net` (an Evolu sync relay, which speaks a binary protocol) added on the relay settings page. The relay status check only verifies the websocket opens, so such a relay even shows as connected.

## Fix

- `TextFrameWebSocket` — a `WebSocket` subclass that shadows `onmessage` with an instance accessor and only delivers **text** frames to the handler; binary frames are dropped. (Binary frames are never part of the Nostr protocol.)
- `createNostrPool` — builds pools from `AbstractSimplePool` with `websocketImplementation: TextFrameWebSocket`, because `SimplePool`'s typed constructor options don't expose `websocketImplementation`. `verifyEvent` and `maxWaitForConnection: 3000` mirror what `SimplePool` passes.
- Both pool construction sites in the web app use it: the shared app pool (`nostrPool.ts`, nostr-tools stays lazily imported) and the service worker's push-decrypt pool (`sw.ts`).

## Verification

- New unit test (`textFrameWebSocket.test.ts`): text frames delivered, `Blob`/`ArrayBuffer` frames dropped, handler readable/clearable.
- Manually verified against a local websocket server sending binary frames: a stock `SimplePool` feeds them into nostr-tools' parser, the guarded pool drops them and `querySync` completes cleanly.
- `bun run check-code`, full web-app vitest suite (584 tests), and `bun run build` all pass.

## Not in scope (possible follow-up)

The relay settings page still shows a non-Nostr relay as connected, since the check is open-socket-only. With this fix it's merely useless rather than crashing; a protocol-level probe (e.g. REQ→EOSE) could flag it as incompatible.