### PR TITLE
Speed up the e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # Previously ran inside the web-app image build; here it overlaps the
+      # background image prep while still failing the `e2e` check that gates
+      # deploys.
+      - name: Typecheck web app
+        run: bun run --filter @linky/web-app typecheck
+
       - name: Resolve Playwright version
         id: playwright-version
         working-directory: apps/web-app

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Exposes ACTIONS_RUNTIME_TOKEN / ACTIONS_CACHE_URL so the raw buildx
+      # invocation below can use the type=gha cache backend.
+      - name: Expose Actions cache env to buildx
+        uses: crazy-max/ghaction-github-runtime@v3
+
+      # Image pulls and builds are the long pole (~75s cold), so they run in the
+      # background while Bun and Playwright set up; "Start local stack" joins on
+      # the status file. Distinct cache scopes keep the two images from
+      # overwriting each other's GHA cache index.
+      - name: Prepare stack images (background)
+        run: |
+          {
+            docker compose -f docker-compose.dev.yml pull -q nostr-relay cashu-mint &
+            pull=$!
+            docker buildx bake -f docker-compose.dev.yml \
+              --set 'evolu-relay.cache-from=type=gha,scope=evolu-relay' \
+              --set 'evolu-relay.cache-to=type=gha,scope=evolu-relay,mode=max' \
+              --set 'web-app.cache-from=type=gha,scope=web-app' \
+              --set 'web-app.cache-to=type=gha,scope=web-app,mode=max' \
+              --load &
+            bake=$!
+            status=0
+            wait "$pull" || status=$?
+            wait "$bake" || status=$?
+            echo "$status" > /tmp/prepare-images.status
+          } &> /tmp/prepare-images.log &
+
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -29,12 +59,29 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Resolve Playwright version
+        id: playwright-version
+        working-directory: apps/web-app
+        run: echo "version=$(bunx playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      # --only-shell: the config runs headless-only, so the full Chromium
+      # download is unnecessary.
       - name: Install Playwright browsers
         working-directory: apps/web-app
-        run: bunx playwright install --with-deps chromium
+        run: bunx playwright install --with-deps --only-shell chromium
 
       - name: Start local stack
-        run: docker compose -f docker-compose.dev.yml --profile e2e up -d --build --wait
+        run: |
+          while [ ! -f /tmp/prepare-images.status ]; do sleep 2; done
+          cat /tmp/prepare-images.log
+          [ "$(cat /tmp/prepare-images.status)" -eq 0 ]
+          docker compose -f docker-compose.dev.yml --profile e2e up -d --wait --no-build
 
       - name: Run e2e tests
         working-directory: apps/web-app

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,6 +21,9 @@ services:
       start_period: 5s
 
   evolu-relay:
+    # Explicit image name so CI can `buildx bake` this service and compose
+    # finds the result without rebuilding.
+    image: linky-evolu-relay
     build: docker/evolu-relay
     ports:
       - "4001:4000"
@@ -76,6 +79,7 @@ services:
   # ports.
   web-app:
     profiles: ["e2e"]
+    image: linky-web-app
     build:
       context: .
       dockerfile: docker/web-app/Dockerfile

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,9 +37,9 @@ services:
           "-e",
           "const s=require('net').connect(4000,'127.0.0.1');s.on('connect',()=>process.exit(0));s.on('error',()=>process.exit(1))",
         ]
-      interval: 5s
-      timeout: 3s
-      retries: 10
+      interval: 2s
+      timeout: 2s
+      retries: 25
 
   cashu-mint:
     image: docker.io/cashubtc/nutshell:0.20.3
@@ -68,9 +68,11 @@ services:
           "-c",
           "import urllib.request,sys;sys.exit(0 if urllib.request.urlopen('http://localhost:3338/v1/info').status==200 else 1)",
         ]
-      interval: 10s
-      timeout: 5s
-      retries: 10
+      # Fine-grained polling: `up --wait` blocks until healthy, so a coarse
+      # interval directly delays every stack start.
+      interval: 2s
+      timeout: 3s
+      retries: 45
       start_period: 10s
 
   # Production build of the web app for the `local-stack` Playwright project;

--- a/docker/web-app/Dockerfile
+++ b/docker/web-app/Dockerfile
@@ -35,8 +35,9 @@ ENV VITE_NOSTR_RELAYS=$VITE_NOSTR_RELAYS \
 
 WORKDIR /app/apps/web-app
 # Sourcemaps keep Playwright traces readable; passed on the CLI so this test
-# setup stays out of vite.config.ts.
-RUN bun run typecheck && ./node_modules/.bin/vite build --sourcemap
+# setup stays out of vite.config.ts. No typecheck here — the e2e workflow
+# runs it as a separate step, off the image-build critical path.
+RUN ./node_modules/.bin/vite build --sourcemap
 
 FROM nginx:alpine
 # nginx >= 1.21.2 required: its mime.types maps .wasm to application/wasm,


### PR DESCRIPTION
The e2e job ran ~2m05s with no caching and a fully serial critical path. Measured breakdown of the last main run: docker stack build+up **76s**, Playwright install **20s**, tests **21s**, everything else ~8s.

Three changes, one per commit:

1. **Overlap stack prep with test setup, cache image layers.** Image pulls and builds start in the background immediately after checkout; Bun/Playwright setup runs concurrently and the stack step joins on a status file. The two built images (`web-app`, `evolu-relay`) now build via `buildx bake` with the GitHub Actions cache backend, so their dependency-install layers (`bun install`, `npm install`) are cached between runs — only the vite build re-runs on source changes. This required explicit `image:` names in the compose file so bake and `up --no-build` agree. Playwright now installs only the Chromium headless shell (config is headless-only) and caches it keyed on the Playwright version.

2. **Tighten dev-stack healthcheck polling.** `up --wait` blocks on health, and the mint polled every 10s — up to 10s idle after the service was already up. Intervals are now 2s with retry counts scaled to keep failure windows unchanged.

3. **Move typecheck out of the web-app Dockerfile.** It serialized with the vite build on the critical path; as a workflow step it overlaps the background image prep and still fails the same `e2e` check, so the Vercel/Android gating is unchanged. (It remains the only typecheck on push to main.)

Expected result: ~60–75s warm (first run on this branch is cold — no cache yet), with the remaining time dominated by the uncacheable per-commit vite build and the 21s test run.

Validated locally: `bake --load` → `up -d --wait --no-build` comes up healthy in ~5s and the `local-stack` suite passes (14s) against the resulting image.