### PR TITLE
Fix Nostr avatars reloading, and batch profile relay queries

### DIFF
--- a/apps/web-app/src/app/hooks/composition/useContactsMessagingComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useContactsMessagingComposition.ts
@@ -24,6 +24,11 @@ import {
   loadCachedProfileMetadata,
   loadCachedProfilePicture,
   NOSTR_RELAYS,
+  primeProfileMetadataCache,
+  recordProfileMetadataLookup,
+  recordProfilePictureLookup,
+  releaseAllAvatarObjectUrls,
+  releaseAvatarObjectUrl,
   saveCachedProfileMetadata,
   saveCachedProfilePicture,
   type NostrProfileMetadata,
@@ -422,54 +427,18 @@ export const useContactsMessagingComposition = ({
     Record<string, string | null>
   >({});
 
-  const avatarObjectUrlsByNpubRef = React.useRef<Map<string, string>>(
-    new Map(),
-  );
-
   React.useEffect(() => {
-    const objectUrls = avatarObjectUrlsByNpubRef.current;
     return () => {
-      for (const url of objectUrls.values()) {
-        if (!url.startsWith("blob:")) continue;
-        try {
-          URL.revokeObjectURL(url);
-        } catch {
-          // ignore
-        }
-      }
-      objectUrls.clear();
+      releaseAllAvatarObjectUrls();
       inMemoryNostrPictureCache.clear();
     };
   }, [currentNsec]);
 
+  // Object-url lifetime is owned by nostrProfile; blob urls arrive already
+  // registered there, so this only has to drop the entry for a cleared avatar.
   const rememberBlobAvatarUrl = React.useCallback(
     (npub: string, url: string | null): string | null => {
-      const key = String(npub ?? "").trim();
-      if (!key) return url;
-
-      const existing = avatarObjectUrlsByNpubRef.current.get(key);
-
-      if (url && url.startsWith("blob:")) {
-        if (existing && existing !== url) {
-          try {
-            URL.revokeObjectURL(existing);
-          } catch {
-            // ignore
-          }
-        }
-        avatarObjectUrlsByNpubRef.current.set(key, url);
-        return url;
-      }
-
-      if (existing && existing.startsWith("blob:")) {
-        try {
-          URL.revokeObjectURL(existing);
-        } catch {
-          // ignore
-        }
-      }
-
-      avatarObjectUrlsByNpubRef.current.delete(key);
+      if (!(url && url.startsWith("blob:"))) releaseAvatarObjectUrl(npub);
       return url;
     },
     [],
@@ -1222,6 +1191,14 @@ export const useContactsMessagingComposition = ({
     let cancelled = false;
 
     const run = async () => {
+      if (nostrBootstrapReady) {
+        await primeProfileMetadataCache(prefetchedMessageNpubs, {
+          relays: nostrFetchRelays,
+          signal: controller.signal,
+        });
+        if (cancelled) return;
+      }
+
       for (const npub of prefetchedMessageNpubs) {
         if (unknownNameByNpub[npub] !== undefined) continue;
 
@@ -1248,14 +1225,14 @@ export const useContactsMessagingComposition = ({
             signal: controller.signal,
             relays: nostrFetchRelays,
           });
-          saveCachedProfileMetadata(npub, metadata);
+          recordProfileMetadataLookup(npub, metadata);
           if (cancelled) return;
           setUnknownNameByNpub((prev) => ({
             ...prev,
             [npub]: metadata ? getBestNostrName(metadata) : null,
           }));
         } catch {
-          saveCachedProfileMetadata(npub, null);
+          recordProfileMetadataLookup(npub, null);
           if (cancelled) return;
           setUnknownNameByNpub((prev) => ({
             ...prev,
@@ -1286,6 +1263,14 @@ export const useContactsMessagingComposition = ({
     let cancelled = false;
 
     const run = async () => {
+      if (nostrBootstrapReady) {
+        await primeProfileMetadataCache(prefetchedMessageNpubs, {
+          relays: nostrFetchRelays,
+          signal: controller.signal,
+        });
+        if (cancelled) return;
+      }
+
       for (const npub of prefetchedMessageNpubs) {
         const cached = loadCachedProfilePicture(npub);
         const shouldRefreshCachedPicture = isCachedProfilePictureStale(cached);
@@ -1300,10 +1285,12 @@ export const useContactsMessagingComposition = ({
           const blobUrl = await loadCachedProfileAvatarObjectUrl(npub);
           if (cancelled) return;
           if (blobUrl) {
-            setNostrPictureByNpub((prev) => ({
-              ...prev,
-              [npub]: rememberBlobAvatarUrl(npub, blobUrl),
-            }));
+            const remembered = rememberBlobAvatarUrl(npub, blobUrl);
+            setNostrPictureByNpub((prev) =>
+              prev[npub] === remembered
+                ? prev
+                : { ...prev, [npub]: remembered },
+            );
             if (!shouldRefreshCachedPicture) continue;
           }
         } catch {
@@ -1356,7 +1343,7 @@ export const useContactsMessagingComposition = ({
               signal: controller.signal,
               relays: nostrFetchRelays,
             });
-            saveCachedProfilePicture(npub, url);
+            recordProfilePictureLookup(npub, url);
             if (cancelled) return;
 
             if (url) {
@@ -1381,7 +1368,7 @@ export const useContactsMessagingComposition = ({
         } catch {
           if (cancelled) return;
           if (!cached) {
-            saveCachedProfilePicture(npub, null);
+            recordProfilePictureLookup(npub, null);
             setNostrPictureByNpub((prev) => {
               const existing = prev[npub];
               if (typeof existing === "string" && existing.trim()) return prev;

--- a/apps/web-app/src/app/hooks/useContactsNostrPrefetchEffects.ts
+++ b/apps/web-app/src/app/hooks/useContactsNostrPrefetchEffects.ts
@@ -10,6 +10,9 @@ import {
   loadCachedProfileAvatarObjectUrl,
   loadCachedProfileMetadata,
   loadCachedProfilePicture,
+  primeProfileMetadataCache,
+  recordProfileMetadataLookup,
+  recordProfilePictureLookup,
   saveCachedProfileMetadata,
   saveCachedProfilePicture,
 } from "../../nostrProfile";
@@ -144,6 +147,14 @@ export const useContactsNostrPrefetchEffects = <
     let cancelled = false;
 
     const run = async () => {
+      if (canFetchFromNostr) {
+        const npubs = contactsRef.current
+          .map((contact) => normalizeNpubIdentifier(contact.npub))
+          .filter((npub): npub is string => Boolean(npub));
+        await primeProfileMetadataCache(npubs, { relays: nostrFetchRelays });
+        if (cancelled) return;
+      }
+
       for (const contact of contactsRef.current) {
         const rawNpub = String(contact.npub ?? "").trim();
         const npub = normalizeNpubIdentifier(rawNpub);
@@ -220,7 +231,7 @@ export const useContactsNostrPrefetchEffects = <
         try {
           const metadata = await loadProfileMetadata(npub);
 
-          saveCachedProfileMetadata(npub, metadata);
+          recordProfileMetadataLookup(npub, metadata);
           if (cancelled) return;
           if (!metadata) {
             metadataCompletedRef.current.add(npub);
@@ -258,7 +269,7 @@ export const useContactsNostrPrefetchEffects = <
           }
           metadataCompletedRef.current.add(npub);
         } catch {
-          saveCachedProfileMetadata(npub, null);
+          recordProfileMetadataLookup(npub, null);
           if (cancelled) return;
         } finally {
           nostrMetadataInFlight.current.delete(npub);
@@ -296,6 +307,14 @@ export const useContactsNostrPrefetchEffects = <
     }
 
     const run = async () => {
+      if (canFetchFromNostr) {
+        await primeProfileMetadataCache(uniqueNpubs, {
+          relays: nostrFetchRelays,
+          signal: controller.signal,
+        });
+        if (cancelled) return;
+      }
+
       for (const npub of uniqueNpubs) {
         const cached = loadCachedProfilePicture(npub);
         const shouldRefreshCachedPicture = isCachedProfilePictureStale(cached);
@@ -313,10 +332,12 @@ export const useContactsNostrPrefetchEffects = <
           const blobUrl = await loadCachedProfileAvatarObjectUrl(npub);
           if (cancelled) return;
           if (blobUrl) {
-            setNostrPictureByNpub((prev) => ({
-              ...prev,
-              [npub]: rememberBlobAvatarUrl(npub, blobUrl),
-            }));
+            const remembered = rememberBlobAvatarUrl(npub, blobUrl);
+            setNostrPictureByNpub((prev) =>
+              prev[npub] === remembered
+                ? prev
+                : { ...prev, [npub]: remembered },
+            );
             if (!shouldRefreshCachedPicture) continue;
           }
         } catch {
@@ -363,9 +384,9 @@ export const useContactsNostrPrefetchEffects = <
             }
           } else {
             const metadata = await loadProfileMetadata(npub);
-            saveCachedProfileMetadata(npub, metadata);
+            recordProfileMetadataLookup(npub, metadata);
             const url = metadata ? getNostrProfilePictureUrl(metadata) : null;
-            saveCachedProfilePicture(npub, url);
+            recordProfilePictureLookup(npub, url);
             if (cancelled) return;
 
             if (url) {
@@ -390,7 +411,7 @@ export const useContactsNostrPrefetchEffects = <
         } catch {
           if (cancelled) return;
           if (!cached) {
-            saveCachedProfilePicture(npub, null);
+            recordProfilePictureLookup(npub, null);
             setNostrPictureByNpub((prev) => {
               const existing = prev[npub];
               if (typeof existing === "string" && existing.trim()) return prev;

--- a/apps/web-app/src/nostrAvatarObjectUrl.test.ts
+++ b/apps/web-app/src/nostrAvatarObjectUrl.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cacheProfileAvatarFromUrl,
+  loadCachedProfileAvatarObjectUrl,
+  peekAvatarObjectUrl,
+  releaseAllAvatarObjectUrls,
+  releaseAvatarObjectUrl,
+} from "./nostrProfile";
+
+const TEST_NPUB =
+  "npub180cvv07tqw7jwr9wnh4hp24w3wl74x64l0n6ms4qxp2vj8qz9c8sv96q8j";
+
+const OTHER_NPUB =
+  "npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9";
+
+let created: string[] = [];
+let revoked: string[] = [];
+let cacheEntries: Map<string, Blob>;
+
+const makeBlob = (body: string): Blob => new Blob([body]);
+
+beforeEach(() => {
+  created = [];
+  revoked = [];
+  cacheEntries = new Map();
+
+  // Only the two object-url statics are faked; `new URL(...)` must keep working
+  // because nostrProfile builds its cache-key requests with it.
+  let counter = 0;
+  URL.createObjectURL ??= () => "";
+  URL.revokeObjectURL ??= () => undefined;
+  vi.spyOn(URL, "createObjectURL").mockImplementation(() => {
+    counter += 1;
+    const url = `blob:mock/${counter}`;
+    created.push(url);
+    return url;
+  });
+  vi.spyOn(URL, "revokeObjectURL").mockImplementation((url: string) => {
+    revoked.push(url);
+  });
+
+  const cache = {
+    match: (req: Request) =>
+      Promise.resolve(
+        cacheEntries.has(req.url)
+          ? new Response(cacheEntries.get(req.url))
+          : undefined,
+      ),
+    put: (req: Request, res: Response) =>
+      res.blob().then((blob) => {
+        cacheEntries.set(req.url, blob);
+      }),
+    delete: (req: Request) =>
+      Promise.resolve(cacheEntries.delete(req.url) || false),
+  };
+  vi.stubGlobal("caches", { open: () => Promise.resolve(cache) });
+});
+
+afterEach(() => {
+  releaseAllAvatarObjectUrls();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const seedCachedAvatar = async (npub: string, body: string) => {
+  vi.stubGlobal("fetch", () => Promise.resolve(new Response(makeBlob(body))));
+  const url = await cacheProfileAvatarFromUrl(
+    npub,
+    `${globalThis.location.origin}/avatar.png`,
+  );
+  expect(url).toBeTruthy();
+  return url;
+};
+
+describe("avatar object url identity", () => {
+  it("hands out one stable object url per npub across repeated loads", async () => {
+    await seedCachedAvatar(TEST_NPUB, "avatar-bytes");
+    const mintedByCaching = created.length;
+
+    const first = await loadCachedProfileAvatarObjectUrl(TEST_NPUB);
+    const second = await loadCachedProfileAvatarObjectUrl(TEST_NPUB);
+    const third = await loadCachedProfileAvatarObjectUrl(TEST_NPUB);
+
+    expect(first).toBeTruthy();
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+    // Re-reading a cached avatar must not mint a second object url, because a
+    // changed <img> src identity forces the browser to reload the image.
+    expect(created.length).toBe(mintedByCaching);
+    expect(revoked).toEqual([]);
+  });
+
+  it("keeps separate object urls per npub", async () => {
+    await seedCachedAvatar(TEST_NPUB, "one");
+    await seedCachedAvatar(OTHER_NPUB, "two");
+
+    const a = await loadCachedProfileAvatarObjectUrl(TEST_NPUB);
+    const b = await loadCachedProfileAvatarObjectUrl(OTHER_NPUB);
+
+    expect(a).toBeTruthy();
+    expect(b).toBeTruthy();
+    expect(a).not.toBe(b);
+    expect(peekAvatarObjectUrl(TEST_NPUB)).toBe(a);
+    expect(peekAvatarObjectUrl(OTHER_NPUB)).toBe(b);
+  });
+
+  it("peek reports nothing before an avatar is loaded", () => {
+    expect(peekAvatarObjectUrl(TEST_NPUB)).toBeNull();
+  });
+
+  it("revokes the previous url only when the avatar bytes are replaced", async () => {
+    await seedCachedAvatar(TEST_NPUB, "old-bytes");
+    const first = await loadCachedProfileAvatarObjectUrl(TEST_NPUB);
+
+    const replaced = await seedCachedAvatar(TEST_NPUB, "new-bytes");
+
+    expect(replaced).not.toBe(first);
+    expect(revoked).toEqual([first]);
+    expect(peekAvatarObjectUrl(TEST_NPUB)).toBe(replaced);
+  });
+
+  it("releases a single npub without touching the others", async () => {
+    await seedCachedAvatar(TEST_NPUB, "one");
+    await seedCachedAvatar(OTHER_NPUB, "two");
+    const a = peekAvatarObjectUrl(TEST_NPUB);
+    const b = peekAvatarObjectUrl(OTHER_NPUB);
+
+    releaseAvatarObjectUrl(TEST_NPUB);
+
+    expect(revoked).toEqual([a]);
+    expect(peekAvatarObjectUrl(TEST_NPUB)).toBeNull();
+    expect(peekAvatarObjectUrl(OTHER_NPUB)).toBe(b);
+  });
+
+  it("releases every npub on identity change", async () => {
+    await seedCachedAvatar(TEST_NPUB, "one");
+    await seedCachedAvatar(OTHER_NPUB, "two");
+
+    releaseAllAvatarObjectUrls();
+
+    expect(revoked.length).toBe(2);
+    expect(peekAvatarObjectUrl(TEST_NPUB)).toBeNull();
+    expect(peekAvatarObjectUrl(OTHER_NPUB)).toBeNull();
+  });
+});

--- a/apps/web-app/src/nostrProfile.ts
+++ b/apps/web-app/src/nostrProfile.ts
@@ -65,11 +65,61 @@ const makeAvatarCacheRequest = (npub: string): Request | null => {
   }
 };
 
+/**
+ * The single live `blob:` URL per npub that is currently handed to `<img src>`.
+ *
+ * Minting a second object URL for an avatar we already display changes the
+ * `src` identity, so the browser drops the decoded image and reloads it; and
+ * revoking the previous URL while that reload is still in flight fails the load
+ * outright. Every object URL for a cached avatar must therefore come from here.
+ */
+const avatarObjectUrlByNpub = new Map<string, string>();
+
+const revokeObjectUrl = (url: string): void => {
+  try {
+    URL.revokeObjectURL(url);
+  } catch {
+    // ignore
+  }
+};
+
+export const peekAvatarObjectUrl = (npub: string): string | null => {
+  const trimmed = String(npub ?? "").trim();
+  if (!trimmed) return null;
+  return avatarObjectUrlByNpub.get(trimmed) ?? null;
+};
+
+export const releaseAvatarObjectUrl = (npub: string): void => {
+  const trimmed = String(npub ?? "").trim();
+  if (!trimmed) return;
+  const existing = avatarObjectUrlByNpub.get(trimmed);
+  if (!existing) return;
+  avatarObjectUrlByNpub.delete(trimmed);
+  revokeObjectUrl(existing);
+};
+
+export const releaseAllAvatarObjectUrls = (): void => {
+  for (const url of avatarObjectUrlByNpub.values()) revokeObjectUrl(url);
+  avatarObjectUrlByNpub.clear();
+};
+
+/** Replaces the live object URL for `npub`; only called when bytes changed. */
+const replaceAvatarObjectUrl = (npub: string, blob: Blob): string => {
+  releaseAvatarObjectUrl(npub);
+  const url = URL.createObjectURL(blob);
+  avatarObjectUrlByNpub.set(npub, url);
+  return url;
+};
+
 export const loadCachedProfileAvatarObjectUrl = async (
   npub: string,
 ): Promise<string | null> => {
   const trimmed = String(npub ?? "").trim();
   if (!trimmed) return null;
+
+  const live = avatarObjectUrlByNpub.get(trimmed);
+  if (live) return live;
+
   if (!canUseCacheStorage()) return null;
 
   const req = makeAvatarCacheRequest(trimmed);
@@ -81,7 +131,12 @@ export const loadCachedProfileAvatarObjectUrl = async (
     if (!match) return null;
     const blob = await match.blob();
     if (!blob || blob.size <= 0) return null;
-    return URL.createObjectURL(blob);
+
+    // A concurrent caller may have claimed the URL while we awaited the cache.
+    const claimed = avatarObjectUrlByNpub.get(trimmed);
+    if (claimed) return claimed;
+
+    return replaceAvatarObjectUrl(trimmed, blob);
   } catch {
     return null;
   }
@@ -113,7 +168,7 @@ export const cacheProfileAvatarFromUrl = async (
 
     const blob = await res.blob();
     if (!blob || blob.size <= 0) return null;
-    return URL.createObjectURL(blob);
+    return replaceAvatarObjectUrl(trimmed, blob);
   } catch {
     return null;
   }
@@ -124,6 +179,7 @@ export const deleteCachedProfileAvatar = async (
 ): Promise<void> => {
   const trimmed = String(npub ?? "").trim();
   if (!trimmed) return;
+  releaseAvatarObjectUrl(trimmed);
   if (!canUseCacheStorage()) return;
   const req = makeAvatarCacheRequest(trimmed);
   if (!req) return;
@@ -271,6 +327,37 @@ export const saveCachedProfileMetadata = (
   }
 };
 
+/*
+ * A relay set that answers with nothing is ambiguous: a profile that does not
+ * exist and relays that never replied are indistinguishable from the client.
+ * Background prefetches therefore record a miss only when they have nothing
+ * cached yet, so one slow or unreachable relay round cannot blank an avatar
+ * that is already on screen.
+ */
+export const recordProfileMetadataLookup = (
+  npub: string,
+  metadata: NostrProfileMetadata | null,
+): void => {
+  if (metadata) {
+    saveCachedProfileMetadata(npub, metadata);
+    return;
+  }
+  if (loadCachedProfileMetadata(npub)?.metadata) return;
+  saveCachedProfileMetadata(npub, null);
+};
+
+export const recordProfilePictureLookup = (
+  npub: string,
+  url: string | null,
+): void => {
+  if (url) {
+    saveCachedProfilePicture(npub, url);
+    return;
+  }
+  if (loadCachedProfilePicture(npub)?.url) return;
+  saveCachedProfilePicture(npub, null);
+};
+
 const asTrimmedNonEmptyString = (value: unknown): string | undefined => {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
@@ -357,11 +444,32 @@ export const fetchNostrProfileMetadata = async (
         (b.created_at ?? 0) - (a.created_at ?? 0),
     )[0];
 
-  if (!newest?.content) return null;
+  return parseProfileMetadataEvent(newest);
+};
+
+const newestEventPerAuthor = (
+  events: readonly NostrToolsEvent[],
+): Map<string, NostrToolsEvent> => {
+  const newest = new Map<string, NostrToolsEvent>();
+  for (const event of events) {
+    const author = event.pubkey;
+    if (typeof author !== "string" || !author) continue;
+    const current = newest.get(author);
+    if (!current || (event.created_at ?? 0) > (current.created_at ?? 0)) {
+      newest.set(author, event);
+    }
+  }
+  return newest;
+};
+
+const parseProfileMetadataEvent = (
+  event: NostrToolsEvent | undefined,
+): NostrProfileMetadata | null => {
+  if (!event?.content) return null;
 
   let raw: unknown;
   try {
-    raw = JSON.parse(newest.content);
+    raw = JSON.parse(event.content);
   } catch {
     return null;
   }
@@ -393,6 +501,119 @@ export const fetchNostrProfileMetadata = async (
   // If nothing useful, treat as null so we can TTL it.
   if (Object.keys(metadata).length === 0) return null;
   return metadata;
+};
+
+/**
+ * Relays cap how many authors they accept in one filter; 50 is widely safe.
+ */
+const PROFILE_BATCH_SIZE = 50;
+
+const decodeNpubs = async (
+  npubs: readonly string[],
+): Promise<Map<string, string>> => {
+  const { nip19 } = await getNostrTools();
+  const npubByPubkey = new Map<string, string>();
+
+  for (const npub of npubs) {
+    const trimmed = String(npub ?? "").trim();
+    if (!trimmed) continue;
+    try {
+      const decoded = nip19.decode(trimmed);
+      if (decoded.type !== "npub") continue;
+      if (typeof decoded.data !== "string") continue;
+      npubByPubkey.set(decoded.data, trimmed);
+    } catch {
+      continue;
+    }
+  }
+
+  return npubByPubkey;
+};
+
+const primeInFlight = new Map<string, Promise<void>>();
+
+/**
+ * Warms the metadata cache for many profiles using as few relay round trips as
+ * possible.
+ *
+ * kind:0 is a replaceable event, so one filter can carry many authors and the
+ * relay answers with the newest event for each. Asking per npub instead
+ * serialises a round trip — and its 8s `maxWait` — for every single contact,
+ * which is why avatars trickle in one by one on a cold start.
+ */
+export const primeProfileMetadataCache = (
+  npubs: readonly string[],
+  options?: { relays?: string[]; signal?: AbortSignal },
+): Promise<void> => {
+  const pending = npubs.filter((npub) => !loadCachedProfileMetadata(npub));
+  if (pending.length === 0) return Promise.resolve();
+
+  const relays = normalizeRelayUrls(
+    options?.relays && options.relays.length > 0
+      ? options.relays
+      : NOSTR_RELAYS,
+  );
+  if (relays.length === 0) return Promise.resolve();
+
+  const key = `${[...pending].sort().join(",")}|${[...relays].sort().join(",")}`;
+  const existing = primeInFlight.get(key);
+  if (existing) return existing;
+
+  const run = runProfileMetadataPrime(pending, relays, options).finally(() => {
+    primeInFlight.delete(key);
+  });
+  primeInFlight.set(key, run);
+  return run;
+};
+
+const runProfileMetadataPrime = async (
+  pending: readonly string[],
+  relays: string[],
+  options?: { signal?: AbortSignal },
+): Promise<void> => {
+  if (options?.signal?.aborted) return;
+
+  const npubByPubkey = await decodeNpubs(pending);
+  if (npubByPubkey.size === 0) return;
+
+  const pubkeys = Array.from(npubByPubkey.keys());
+  const chunks: string[][] = [];
+  for (let i = 0; i < pubkeys.length; i += PROFILE_BATCH_SIZE) {
+    chunks.push(pubkeys.slice(i, i + PROFILE_BATCH_SIZE));
+  }
+
+  const pool = await getSharedAppNostrPool();
+
+  await Promise.all(
+    chunks.map(async (authors) => {
+      let events: NostrToolsEvent[] = [];
+      try {
+        events = await pool.querySync(
+          relays,
+          { authors, kinds: [0] },
+          { maxWait: 8000 },
+        );
+      } catch {
+        return;
+      }
+
+      if (options?.signal?.aborted) return;
+
+      // Nothing at all came back: unreachable relays and absent profiles are
+      // indistinguishable, so record no misses rather than blanking avatars.
+      if (events.length === 0) return;
+
+      const newestByAuthor = newestEventPerAuthor(events);
+      for (const author of authors) {
+        const npub = npubByPubkey.get(author);
+        if (!npub) continue;
+        recordProfileMetadataLookup(
+          npub,
+          parseProfileMetadataEvent(newestByAuthor.get(author)),
+        );
+      }
+    }),
+  );
 };
 
 export const fetchNostrProfilePicture = async (

--- a/apps/web-app/src/nostrProfileBatch.test.ts
+++ b/apps/web-app/src/nostrProfileBatch.test.ts
@@ -1,0 +1,190 @@
+import type { Event as NostrToolsEvent } from "nostr-tools";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const querySync = vi.fn();
+
+vi.mock("./app/lib/nostrPool", () => ({
+  getSharedAppNostrPool: () => Promise.resolve({ querySync }),
+}));
+
+const {
+  loadCachedProfileMetadata,
+  loadCachedProfilePicture,
+  primeProfileMetadataCache,
+  recordProfileMetadataLookup,
+  recordProfilePictureLookup,
+  saveCachedProfileMetadata,
+  saveCachedProfilePicture,
+} = await import("./nostrProfile");
+const { nip19 } = await import("nostr-tools");
+
+const RELAYS = ["wss://relay.example.com"];
+
+const npubOf = (seed: string): string =>
+  nip19.npubEncode(seed.repeat(64).slice(0, 64));
+
+const profileEvent = (npub: string, content: object): NostrToolsEvent => {
+  const decoded = nip19.decode(npub);
+  if (decoded.type !== "npub" || typeof decoded.data !== "string") {
+    throw new Error("bad npub fixture");
+  }
+  return {
+    content: JSON.stringify(content),
+    created_at: 1_700_000_000,
+    id: "id",
+    kind: 0,
+    pubkey: decoded.data,
+    sig: "sig",
+    tags: [],
+  };
+};
+
+beforeEach(() => {
+  querySync.mockReset();
+  const values = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      get length() {
+        return values.size;
+      },
+      clear: () => values.clear(),
+      getItem: (key: string) => values.get(key) ?? null,
+      key: (i: number) => Array.from(values.keys())[i] ?? null,
+      removeItem: (key: string) => values.delete(key),
+      setItem: (key: string, value: string) => values.set(key, value),
+    },
+  });
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("primeProfileMetadataCache", () => {
+  it("fetches many profiles in a single multi-author query", async () => {
+    const a = npubOf("a1");
+    const b = npubOf("b2");
+    const c = npubOf("c3");
+
+    querySync.mockResolvedValue([
+      profileEvent(a, { name: "Alice", picture: "https://x.test/a.png" }),
+      profileEvent(b, { name: "Bob" }),
+      profileEvent(c, { name: "Carol" }),
+    ]);
+
+    await primeProfileMetadataCache([a, b, c], { relays: RELAYS });
+
+    expect(querySync).toHaveBeenCalledTimes(1);
+    const [, filter] = querySync.mock.calls[0] ?? [];
+    expect(filter.kinds).toEqual([0]);
+    expect(filter.authors).toHaveLength(3);
+
+    expect(loadCachedProfileMetadata(a)?.metadata?.name).toBe("Alice");
+    expect(loadCachedProfileMetadata(b)?.metadata?.name).toBe("Bob");
+    expect(loadCachedProfileMetadata(c)?.metadata?.name).toBe("Carol");
+  });
+
+  it("skips npubs that are already cached", async () => {
+    const a = npubOf("a1");
+    const b = npubOf("b2");
+    saveCachedProfileMetadata(a, { name: "Cached" });
+    querySync.mockResolvedValue([profileEvent(b, { name: "Bob" })]);
+
+    await primeProfileMetadataCache([a, b], { relays: RELAYS });
+
+    const [, filter] = querySync.mock.calls[0] ?? [];
+    expect(filter.authors).toHaveLength(1);
+    expect(loadCachedProfileMetadata(a)?.metadata?.name).toBe("Cached");
+  });
+
+  it("issues no query when every npub is cached", async () => {
+    const a = npubOf("a1");
+    saveCachedProfileMetadata(a, { name: "Cached" });
+
+    await primeProfileMetadataCache([a], { relays: RELAYS });
+
+    expect(querySync).not.toHaveBeenCalled();
+  });
+
+  it("shares one in-flight query between concurrent callers", async () => {
+    const a = npubOf("a1");
+    querySync.mockResolvedValue([profileEvent(a, { name: "Alice" })]);
+
+    await Promise.all([
+      primeProfileMetadataCache([a], { relays: RELAYS }),
+      primeProfileMetadataCache([a], { relays: RELAYS }),
+      primeProfileMetadataCache([a], { relays: RELAYS }),
+    ]);
+
+    expect(querySync).toHaveBeenCalledTimes(1);
+  });
+
+  it("records no misses when the relays answer with nothing", async () => {
+    const a = npubOf("a1");
+    querySync.mockResolvedValue([]);
+
+    await primeProfileMetadataCache([a], { relays: RELAYS });
+
+    // An unreachable relay set and an absent profile look identical, so the
+    // empty round must not be cached as "this profile has no metadata".
+    expect(loadCachedProfileMetadata(a)).toBeUndefined();
+  });
+
+  it("records a miss for an author absent from a non-empty response", async () => {
+    const a = npubOf("a1");
+    const b = npubOf("b2");
+    querySync.mockResolvedValue([profileEvent(a, { name: "Alice" })]);
+
+    await primeProfileMetadataCache([a, b], { relays: RELAYS });
+
+    expect(loadCachedProfileMetadata(b)?.metadata).toBeNull();
+  });
+
+  it("survives a rejected query without caching misses", async () => {
+    const a = npubOf("a1");
+    querySync.mockRejectedValue(new Error("relay down"));
+
+    await expect(
+      primeProfileMetadataCache([a], { relays: RELAYS }),
+    ).resolves.toBeUndefined();
+    expect(loadCachedProfileMetadata(a)).toBeUndefined();
+  });
+});
+
+describe("lookup recorders keep known-good values", () => {
+  it("does not blank cached metadata on an empty result", () => {
+    const a = npubOf("a1");
+    saveCachedProfileMetadata(a, { name: "Alice" });
+
+    recordProfileMetadataLookup(a, null);
+
+    expect(loadCachedProfileMetadata(a)?.metadata?.name).toBe("Alice");
+  });
+
+  it("records a miss when nothing was cached", () => {
+    const a = npubOf("a1");
+
+    recordProfileMetadataLookup(a, null);
+
+    expect(loadCachedProfileMetadata(a)?.metadata).toBeNull();
+  });
+
+  it("does not blank a cached picture on an empty result", () => {
+    const a = npubOf("a1");
+    saveCachedProfilePicture(a, "https://x.test/a.png");
+
+    recordProfilePictureLookup(a, null);
+
+    expect(loadCachedProfilePicture(a)?.url).toBe("https://x.test/a.png");
+  });
+
+  it("still overwrites a cached picture with a new one", () => {
+    const a = npubOf("a1");
+    saveCachedProfilePicture(a, "https://x.test/old.png");
+
+    recordProfilePictureLookup(a, "https://x.test/new.png");
+
+    expect(loadCachedProfilePicture(a)?.url).toBe("https://x.test/new.png");
+  });
+});


### PR DESCRIPTION
## Problem

Reported: *"images often reload even though I already had them. Sometimes the image doesn't load. Overall, check to see if I'm calling the relays incorrectly."*

All three turned out to be real, and present on current `main`. I checked merged PRs first — #121 *avatar refresh* (2026-05-27) introduced this caching layer and nothing since has touched the churn.

## Root cause: an object-URL cache that was never read

`avatarObjectUrlByNpub` (was `avatarObjectUrlsByNpubRef`) tracked the live `blob:` URL per npub, but was only ever **written** — nothing read it to decide whether a new URL was needed. So every prefetch pass:

1. called `URL.createObjectURL(blob)` again for an avatar already on screen,
2. `rememberBlobAvatarUrl` revoked the **previous** URL — the one still in the `<img src>`,
3. React saw a changed `src` → browser drops the decoded image and reloads it.

When the revoke landed while that reload was still in flight, the load failed outright — that is the "sometimes the image doesn't load" half.

The loop ran much more often than it appears: `prefetchedMessageNpubs` is memoized on `chatMessages`, so **every incoming chat message** re-ran the entire avatar pass, for every unknown-chat participant.

Because `canFetchAvatarAsBlob` only permits blob caching for same-origin and `api.dicebear.com`, this hit precisely the DiceBear avatars Linky generates for new accounts — i.e. most Linky-to-Linky contacts.

## Fixes

**1. One object URL per npub.** Lifetime now has a single owner in `nostrProfile.ts`. `loadCachedProfileAvatarObjectUrl` returns the URL it already handed out instead of minting a second one; only `cacheProfileAvatarFromUrl` (genuinely new bytes) and `deleteCachedProfileAvatar` replace or release it. `rememberBlobAvatarUrl` no longer keeps a competing registry.

**2. An empty relay response no longer blanks a good avatar.** Unreachable relays and a genuinely absent profile are indistinguishable from the client, but the code cached both as "this profile has no picture" — so one slow round blanked avatars already on screen, then refetched 2 minutes later. `recordProfileMetadataLookup` / `recordProfilePictureLookup` record a miss only when nothing is cached yet.

**3. Relay queries are batched.** This is the "calling the relays incorrectly" part. Prefetch issued **one `querySync` per contact, awaited sequentially**, each with an 8s `maxWait` — 50 contacts meant up to 50 serialised round trips, which is why avatars trickled in one at a time on a cold start.

kind:0 is a replaceable event, so a single filter can carry many authors and the relay returns the newest per author. `primeProfileMetadataCache` warms the cache in one multi-author query (chunked at 50, the widely-safe filter cap), with in-flight dedupe so concurrent effects share a query. The existing per-npub path stays as the fallback and for the 12h staleness refresh.

## Tests

`src/nostrAvatarObjectUrl.test.ts` (6) — pins URL identity across repeated loads, per-npub isolation, revoke-only-on-replace, single and bulk release. Written first; it failed with `expected 'blob:mock/3' to be 'blob:mock/2'`, reproducing the churn.

`src/nostrProfileBatch.test.ts` (11) — single multi-author query, cached npubs skipped, no query when fully cached, concurrent callers share one query, empty/rejected responses record no misses, and the recorders never downgrade a known-good value.

## Verification

- `bun run check-code` — clean (typecheck, eslint, prettier)
- `bun run test` — 21 tests across the three profile suites pass

`src/app/hooks/mint/useNpubCashMintSelection.test.tsx` has 3 failures; I confirmed by stashing that these fail identically on clean `main` and are unrelated to this change.

Not covered here: chat images (Blossom) are a separate pipeline — see #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)