### PR TITLE
Fix push image workspace install

### DIFF
--- a/apps/push/Dockerfile
+++ b/apps/push/Dockerfile
@@ -9,6 +9,8 @@ COPY apps/site/package.json apps/site/package.json
 COPY apps/web-app/package.json apps/web-app/package.json
 COPY packages/core/package.json packages/core/package.json
 COPY packages/config/package.json packages/config/package.json
+COPY packages/linkstr/package.json packages/linkstr/package.json
+COPY packages/linkstr-react/package.json packages/linkstr-react/package.json
 
 RUN bun install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

- include the `@linky/linkstr` and `@linky/linkstr-react` package manifests in the push image dependency layer
- allow Bun's frozen workspace install to resolve every workspace dependency referenced by the copied manifests

## Root cause

The push Dockerfile copied the `core` and `web-app` manifests before running `bun install --frozen-lockfile`, but omitted the newly referenced `linkstr` and `linkstr-react` workspace manifests. Bun therefore failed with `Workspace dependency ... not found` in the [Push Image workflow](https://github.com/hynek-jina/linky/actions/runs/31887019051/job/95017705933).

## Validation

- `bun run check-code`
- `docker build --file apps/push/Dockerfile --tag linky-push-ci-fix-test .`
