### PR TITLE
Fix contact archiving: keep the chat, mark it read, auto-restore on new messages

### DIFF
--- a/apps/web-app/src/app/hooks/composition/useContactsMessagingComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useContactsMessagingComposition.ts
@@ -804,10 +804,6 @@ export const useContactsMessagingComposition = ({
     [bankPaymentOfferMessages, lastMessageByContactId],
   );
 
-  const pendingArchivedContactThreadIdsRef = React.useRef(
-    new Map<string, string>(),
-  );
-
   const evoluOwnersReadyForNostr = isSeedLogin
     ? Boolean(
         cashuOwnerId &&
@@ -1035,6 +1031,9 @@ export const useContactsMessagingComposition = ({
   ]);
 
   React.useEffect(() => {
+    // The lightning-address match guesses identity and writes an npub, so it
+    // only considers active contacts; a direct npub match also reclaims
+    // threads of archived contacts.
     const activeContacts = contacts.filter((contact) => {
       const archivedAtSec = Number(contact.archivedAtSec ?? 0);
       return !Number.isFinite(archivedAtSec) || archivedAtSec <= 0;
@@ -1045,7 +1044,7 @@ export const useContactsMessagingComposition = ({
       const unknownNpub = normalizeNpubIdentifier(unknownContact.npub);
       if (!unknownContactId || !unknownNpub) continue;
 
-      let knownContact = activeContacts.find((contact) => {
+      let knownContact = contacts.find((contact) => {
         const knownContactId = String(contact.id ?? "").trim();
         if (!knownContactId || knownContactId === unknownContactId) {
           return false;
@@ -2347,32 +2346,26 @@ export const useContactsMessagingComposition = ({
       contacts.find(
         (contact) => String(contact.id ?? "").trim() === normalizedContactId,
       ) ?? null;
-    const archivedContactNpub = normalizeNpubIdentifier(contactToArchive?.npub);
-    let unknownThreadContactId: string | null = null;
-    if (archivedContactNpub) {
-      unknownThreadContactId = buildUnknownContactId(
-        decodeNpub(archivedContactNpub),
-      );
-    }
 
     const archivedAtSec = Math.ceil(Date.now() / 1e3);
     const storedContactOwnerId = contactToArchive
       ? resolveContactRowOwnerLane(contactToArchive, contactsVisibleOwnerIds)
       : null;
     const archiveOwnerId = storedContactOwnerId ?? contactsOwnerId;
+    // Archiving marks the conversation read; the messages stay on this contact
+    // and a newer incoming message restores it from the archive.
+    const payload = {
+      id,
+      archivedAtSec,
+      chatLastSeenAtSec: Math.max(
+        archivedAtSec,
+        Number(contactToArchive?.chatLastSeenAtSec ?? 0) || 0,
+      ),
+    };
     const result = archiveOwnerId
-      ? update("contact", { id, archivedAtSec }, { ownerId: archiveOwnerId })
-      : update("contact", { id, archivedAtSec });
+      ? update("contact", payload, { ownerId: archiveOwnerId })
+      : update("contact", payload);
     if (result.ok) {
-      if (
-        unknownThreadContactId &&
-        unknownThreadContactId !== normalizedContactId
-      ) {
-        pendingArchivedContactThreadIdsRef.current.set(
-          normalizedContactId,
-          unknownThreadContactId,
-        );
-      }
       setStatus(t("contactArchived"));
       closeContactDetail();
       return;
@@ -2380,7 +2373,7 @@ export const useContactsMessagingComposition = ({
     setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
   };
 
-  const restoreArchivedContact = React.useCallback(
+  const unarchiveContact = React.useCallback(
     (id: ContactId) => {
       const contactToRestore =
         contacts.find((contact) => contact.id === id) ?? null;
@@ -2406,23 +2399,29 @@ export const useContactsMessagingComposition = ({
             reassignNostrConversationContactId(unknownContactId, String(id));
           }
         }
-        setStatus(t("contactRestored"));
-        closeContactDetail();
-        return;
       }
-
-      setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
+      return result;
     },
     [
-      closeContactDetail,
       contacts,
       contactsOwnerId,
       contactsVisibleOwnerIds,
       reassignNostrConversationContactId,
-      setStatus,
-      t,
       update,
     ],
+  );
+
+  const restoreArchivedContact = React.useCallback(
+    (id: ContactId) => {
+      const result = unarchiveContact(id);
+      if (result.ok) {
+        setStatus(t("contactRestored"));
+        closeContactDetail();
+        return;
+      }
+      setStatus(`${t("errorPrefix")}: ${String(result.error)}`);
+    },
+    [closeContactDetail, setStatus, t, unarchiveContact],
   );
 
   const publishMuteList = useAtomSet(publishMuteListAtom, {
@@ -2479,21 +2478,18 @@ export const useContactsMessagingComposition = ({
     },
   );
 
+  // An incoming message newer than the archive brings the contact back.
   React.useEffect(() => {
     for (const contact of contacts) {
-      const contactId = String(contact.id ?? "").trim();
-      if (!contactId) continue;
-      const unknownContactId =
-        pendingArchivedContactThreadIdsRef.current.get(contactId);
-      if (!unknownContactId) continue;
-
       const archivedAtSec = Number(contact.archivedAtSec ?? 0);
       if (!Number.isFinite(archivedAtSec) || archivedAtSec <= 0) continue;
-
-      pendingArchivedContactThreadIdsRef.current.delete(contactId);
-      reassignNostrConversationContactId(contactId, unknownContactId);
+      const contactId = String(contact.id ?? "").trim();
+      if (!contactId) continue;
+      const newestIncomingAtSec = unreadByContactId.get(contactId) ?? 0;
+      if (newestIncomingAtSec <= archivedAtSec) continue;
+      unarchiveContact(contact.id);
     }
-  }, [contacts, reassignNostrConversationContactId]);
+  }, [contacts, unarchiveContact, unreadByContactId]);
 
   const blockArchivedContact = React.useCallback(async () => {
     if (route.kind !== "contactEdit") return;

--- a/apps/web-app/src/app/hooks/messages/useLinkstrInboxSync.ts
+++ b/apps/web-app/src/app/hooks/messages/useLinkstrInboxSync.ts
@@ -72,9 +72,9 @@ const buildContactIndex = (
   contacts: readonly InboxContactRowLike[],
 ): Map<string, InboxContact> => {
   const contactByPubkey = new Map<string, InboxContact>();
+  // Archived contacts stay in the index: their incoming messages land on the
+  // contact itself, which then restores it from the archive.
   for (const contact of contacts) {
-    const archivedAtSec = Number(contact.archivedAtSec ?? 0);
-    if (Number.isFinite(archivedAtSec) && archivedAtSec > 0) continue;
     const npub = normalizeNpubIdentifier(contact.npub);
     if (!npub) continue;
     const pubkey = decodeNpub(npub);


### PR DESCRIPTION
## Problem

Pressing **Archive** on a contact left the app in a weird dual state: the contact moved to the Archive filter, but its chat instantly reappeared in the conversation list as an *unknown* chat.

Three causes:

1. `handleDelete` deliberately reassigned the whole message thread to a synthetic `unknown:<pubkey>` id, so the conversation was resurrected as an unknown chat.
2. `buildContactIndex` in the inbox sync skipped archived contacts, so new incoming messages also landed in that unknown thread instead of returning to the contact.
3. Nothing marked the conversation read or brought the contact back when they wrote again.

## Behavior after this change

1. **Archive marks everything read** — the archive write also advances `chatLastSeenAtSec` to the archive time (never regressing an existing cursor).
2. **The contact and its chat move to the archive together** — the thread stays on the contact id; since archived contacts are filtered from the home list, the chat simply disappears. No unknown-chat ghost.
3. **A new message brings the contact back** — archived contacts stay in the inbox contact index, so their incoming messages resolve to the real contact, and an effect clears `archivedAtSec` whenever an incoming message newer than the archive time arrives. The restoring message shows as unread.

Existing broken state self-heals: the unknown-thread merge effect now also matches archived contacts (by exact npub), so threads orphaned by the old behavior are merged back onto the archived contact; if they contain post-archive incoming messages the contact is restored, consistently with the new rule. The lightning-address *guess* match still only considers active contacts, since it writes an npub onto the matched contact.

Blocked-and-archived contacts stay archived — blocked pubkeys are dropped before the inbox, so no message can restore them.

## Testing

- `bun run check-code` passes
- `bun run test` passes (584 tests)