### PR TITLE
Make sharing a chat image export the actual photo, not a dead blob: URL

### DIFF
--- a/apps/web-app/src/App.css
+++ b/apps/web-app/src/App.css
@@ -2208,6 +2208,15 @@ button.settings-sensitive-action.is-armed {
   background: rgba(15, 23, 42, 0.7);
 }
 
+/* No native long-press callout on chat images: it would share the blob: URL,
+   which is useless outside this tab; long-press opens the message menu instead. */
+.chat-private-image,
+.chat-image-viewer-image {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
 .chat-private-image {
   display: block;
   width: min(260px, 70vw);

--- a/apps/web-app/src/app/lib/privateImageFile.test.ts
+++ b/apps/web-app/src/app/lib/privateImageFile.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { InspectorRow } from "../../devtools/inspector";
+import { reportInspectorRows } from "../../devtools/inspector";
+import {
+  downloadPrivateImageBlob,
+  isCancelledShareError,
+  sharePrivateImageBlob,
+} from "./privateImageFile";
+
+vi.mock("../../devtools/inspector", () => ({
+  reportInspectorRows: vi.fn(),
+}));
+
+vi.mock("../../devtools/inspector/inspectorEnabled", () => ({
+  getInspectorEmissionEnabled: () => true,
+}));
+
+const reportedRows = vi.mocked(reportInspectorRows);
+
+const share = vi.fn<(data?: ShareData) => Promise<void>>(async () => undefined);
+
+const lastReportedRow = (): InspectorRow | undefined =>
+  reportedRows.mock.calls.at(-1)?.[0]?.[0];
+
+describe("privateImageFile", () => {
+  beforeEach(() => {
+    reportedRows.mockClear();
+    share.mockReset();
+    share.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "share", {
+      configurable: true,
+      value: share,
+      writable: true,
+    });
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:test"),
+      writable: true,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("shares the image bytes as a file, never a url or text", async () => {
+    await sharePrivateImageBlob(
+      new Blob(["img"], { type: "image/jpeg" }),
+      "Image",
+      { rumor: "rumor-1" },
+    );
+
+    expect(share).toHaveBeenCalledTimes(1);
+    const shared = share.mock.calls[0]?.[0];
+    expect(shared?.files?.[0]?.name).toBe("linky-image.jpg");
+    expect(shared?.files?.[0]?.type).toBe("image/jpeg");
+    expect(shared && "url" in shared).toBe(false);
+    expect(shared && "text" in shared).toBe(false);
+
+    const row = lastReportedRow();
+    expect(row?.tag).toBe("ChatImageShared");
+    expect(row?.links).toEqual({ rumor: "rumor-1" });
+  });
+
+  it("derives the file extension from the blob type", async () => {
+    await sharePrivateImageBlob(
+      new Blob(["img"], { type: "image/png" }),
+      "Image",
+    );
+
+    expect(share.mock.calls[0]?.[0]?.files?.[0]?.name).toBe("linky-image.png");
+  });
+
+  it("throws share-unavailable when the device cannot share", async () => {
+    Object.defineProperty(navigator, "share", {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
+
+    await expect(
+      sharePrivateImageBlob(new Blob(["img"], { type: "image/jpeg" }), "Image"),
+    ).rejects.toThrow("share-unavailable");
+  });
+
+  it("reports a failure row only for non-cancel share errors", async () => {
+    share.mockRejectedValueOnce(new DOMException("denied", "AbortError"));
+    await expect(
+      sharePrivateImageBlob(new Blob(["img"], { type: "image/jpeg" }), "Image"),
+    ).rejects.toThrow();
+    expect(reportedRows).not.toHaveBeenCalled();
+
+    share.mockRejectedValueOnce(new Error("boom"));
+    await expect(
+      sharePrivateImageBlob(new Blob(["img"], { type: "image/jpeg" }), "Image"),
+    ).rejects.toThrow("boom");
+    expect(lastReportedRow()?.tag).toBe("ChatImageShareFailed");
+  });
+
+  it("downloads through an anchor named after the file", () => {
+    let downloadName = "";
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        downloadName = this.download;
+      });
+
+    downloadPrivateImageBlob(new Blob(["img"], { type: "image/webp" }), {
+      rumor: "rumor-2",
+    });
+
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(downloadName).toBe("linky-image.webp");
+    const row = lastReportedRow();
+    expect(row?.tag).toBe("ChatImageSaved");
+    expect(row?.links).toEqual({ rumor: "rumor-2" });
+    expect(row && typeof row.payload === "object").toBe(true);
+    click.mockRestore();
+  });
+
+  it("recognizes cancelled share errors", () => {
+    expect(isCancelledShareError(new DOMException("nope", "AbortError"))).toBe(
+      true,
+    );
+    expect(isCancelledShareError(new Error("Share canceled"))).toBe(true);
+    expect(isCancelledShareError(new Error("boom"))).toBe(false);
+    expect(isCancelledShareError(null)).toBe(false);
+  });
+});

--- a/apps/web-app/src/app/lib/privateImageFile.ts
+++ b/apps/web-app/src/app/lib/privateImageFile.ts
@@ -1,0 +1,127 @@
+import { reportInspectorRows } from "../../devtools/inspector";
+import { getInspectorEmissionEnabled } from "../../devtools/inspector/inspectorEnabled";
+
+const EXTENSION_BY_IMAGE_TYPE: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+};
+
+export interface PrivateImageExportLinks {
+  rumor?: string;
+}
+
+const toPrivateImageFile = (blob: Blob): File => {
+  const type = blob.type || "image/jpeg";
+  const extension = EXTENSION_BY_IMAGE_TYPE[type] ?? "jpg";
+  return new File([blob], `linky-image.${extension}`, { type });
+};
+
+const reportPrivateImageExport = (
+  tag: string,
+  summary: string,
+  file: File,
+  links: PrivateImageExportLinks,
+  error?: unknown,
+): void => {
+  if (!getInspectorEmissionEnabled()) return;
+  reportInspectorRows([
+    {
+      at: Date.now(),
+      channel: "app.log",
+      tag,
+      summary,
+      links: links.rumor ? { rumor: links.rumor } : {},
+      payload: {
+        fileName: file.name,
+        fileType: file.type,
+        size: file.size,
+        ...(error !== undefined ? { error } : {}),
+      },
+    },
+  ]);
+};
+
+export const isCancelledShareError = (error: unknown): boolean => {
+  if (typeof error !== "object" || error === null) return false;
+
+  const name =
+    "name" in error && typeof error.name === "string" ? error.name : "";
+  if (name === "AbortError") return true;
+
+  const message =
+    "message" in error && typeof error.message === "string"
+      ? error.message
+      : "";
+  return /cancel|abort|dismiss/i.test(message);
+};
+
+export const downloadPrivateImageBlob = (
+  blob: Blob,
+  links: PrivateImageExportLinks = {},
+): void => {
+  const file = toPrivateImageFile(blob);
+  const url = URL.createObjectURL(file);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = file.name;
+  anchor.rel = "noopener";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+  reportPrivateImageExport(
+    "ChatImageSaved",
+    "Chat image saved as a file",
+    file,
+    links,
+  );
+};
+
+export const canSharePrivateImage = (): boolean =>
+  typeof navigator.share === "function";
+
+export const sharePrivateImageBlob = async (
+  blob: Blob,
+  title: string,
+  links: PrivateImageExportLinks = {},
+): Promise<void> => {
+  if (!canSharePrivateImage()) {
+    throw new Error("share-unavailable");
+  }
+
+  const file = toPrivateImageFile(blob);
+  const shareData: ShareData = {
+    files: [file],
+    title,
+  };
+
+  if (
+    typeof navigator.canShare === "function" &&
+    !navigator.canShare(shareData)
+  ) {
+    throw new Error("share-unavailable");
+  }
+
+  try {
+    await navigator.share(shareData);
+  } catch (error) {
+    if (!isCancelledShareError(error)) {
+      reportPrivateImageExport(
+        "ChatImageShareFailed",
+        "System share of a chat image failed",
+        file,
+        links,
+        error,
+      );
+    }
+    throw error;
+  }
+
+  reportPrivateImageExport(
+    "ChatImageShared",
+    "Chat image shared via the system share sheet",
+    file,
+    links,
+  );
+};

--- a/apps/web-app/src/components/ChatMessage.test.tsx
+++ b/apps/web-app/src/components/ChatMessage.test.tsx
@@ -1,8 +1,24 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { serializePrivateImageMessage } from "../app/lib/privateImageMessage";
 import type { LocalNostrMessage } from "../app/types/appTypes";
 import { ChatMessage, type NpubMessageContactInfo } from "./ChatMessage";
+
+vi.mock("../app/lib/privateImageMessage", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../app/lib/privateImageMessage")>();
+  return {
+    ...actual,
+    decryptPrivateImageMessage: vi.fn(
+      async () => new Blob(["img"], { type: "image/jpeg" }),
+    ),
+  };
+});
+
+vi.mock("../devtools/inspector", () => ({
+  reportInspectorRows: vi.fn(),
+}));
 
 vi.mock("../app/context/AppShellContexts", () => ({
   useAppShellCore: () => ({
@@ -69,6 +85,8 @@ const renderChatMessage = async (
           edited: "edited",
           react: "react",
           reply: "reply",
+          save: "save",
+          share: "share",
         }}
         bankPaymentOfferInfo={null}
         bankPaymentOfferPeerNotice={null}
@@ -154,5 +172,98 @@ describe("ChatMessage contact actions", () => {
 
     expect(oneUnsaved.querySelector(".chat-add-all-contacts")).toBeNull();
     expect(outgoing.querySelector(".chat-add-all-contacts")).toBeNull();
+  });
+});
+
+describe("ChatMessage image message actions", () => {
+  const imageMessageContent = serializePrivateImageMessage({
+    encryptedSha256: "a".repeat(64),
+    encryptedSize: 4,
+    encryptionAlgorithm: "aes-gcm",
+    fileType: "image/jpeg",
+    height: 10,
+    key: "b".repeat(64),
+    nonce: "c".repeat(24),
+    originalSha256: "d".repeat(64),
+    storageEncoding: "base64",
+    type: "linky.private_image.v1",
+    url: "https://example.com/blob",
+    width: 10,
+  });
+  const share = vi.fn<(data?: ShareData) => Promise<void>>(
+    async () => undefined,
+  );
+
+  beforeEach(() => {
+    share.mockClear();
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:test"),
+      writable: true,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+      writable: true,
+    });
+    Object.defineProperty(navigator, "share", {
+      configurable: true,
+      value: share,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  const openMenu = async (container: HTMLElement) => {
+    const menuButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Message actions"]',
+    );
+    await act(async () => {
+      menuButton?.click();
+    });
+  };
+
+  const menuItemLabels = (): string[] =>
+    Array.from(document.body.querySelectorAll(".message-actions-item")).map(
+      (item) => item.textContent ?? "",
+    );
+
+  it("offers share and save instead of copy once the image is decrypted", async () => {
+    const container = await renderChatMessage(imageMessageContent);
+    await openMenu(container);
+
+    expect(menuItemLabels()).toEqual(["share", "save"]);
+  });
+
+  it("shares the decrypted image as a file through the system share", async () => {
+    const container = await renderChatMessage(imageMessageContent);
+    await openMenu(container);
+
+    const shareItem = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>(
+        ".message-actions-item",
+      ),
+    ).find((item) => item.textContent === "share");
+    await act(async () => {
+      shareItem?.click();
+    });
+
+    expect(share).toHaveBeenCalledTimes(1);
+    const shared = share.mock.calls[0]?.[0];
+    const sharedFile = shared?.files?.[0];
+    expect(sharedFile?.name).toBe("linky-image.jpg");
+    expect(sharedFile?.type).toBe("image/jpeg");
+    expect(shared && "url" in shared).toBe(false);
+    expect(shared && "text" in shared).toBe(false);
+  });
+
+  it("keeps copy for plain text messages", async () => {
+    const container = await renderChatMessage("hello there");
+    await openMenu(container);
+
+    expect(menuItemLabels()).toEqual(["copy"]);
   });
 });

--- a/apps/web-app/src/components/ChatMessage.test.tsx
+++ b/apps/web-app/src/components/ChatMessage.test.tsx
@@ -63,6 +63,7 @@ const contactInfo = (
 });
 
 interface RenderChatMessageOptions {
+  canReplyOrReact?: boolean;
   direction?: "in" | "out";
   getNpubMessageContactInfo?: (npub: string) => NpubMessageContactInfo | null;
   onAddNpubContacts?: (npubs: readonly string[]) => void;
@@ -93,7 +94,7 @@ const renderChatMessage = async (
         canOpenBankPaymentOfferDetails={true}
         canActOnPaymentRequest={false}
         canEdit={false}
-        canReplyOrReact={false}
+        canReplyOrReact={options.canReplyOrReact ?? false}
         chatPendingLabel="pending"
         chatSeenLabel="seen"
         declineInfo={null}
@@ -265,5 +266,59 @@ describe("ChatMessage image message actions", () => {
     await openMenu(container);
 
     expect(menuItemLabels()).toEqual(["copy"]);
+  });
+
+  it("opens the viewer on a plain tap", async () => {
+    const container = await renderChatMessage(imageMessageContent, {
+      canReplyOrReact: true,
+    });
+    const imageButton = container.querySelector<HTMLButtonElement>(
+      ".chat-private-image-button",
+    );
+
+    await act(async () => {
+      imageButton?.click();
+    });
+
+    expect(container.querySelector(".chat-image-viewer")).not.toBeNull();
+  });
+
+  it("swallows the click synthesized after a long-press", async () => {
+    vi.useFakeTimers();
+    try {
+      const container = await renderChatMessage(imageMessageContent, {
+        canReplyOrReact: true,
+      });
+      const imageButton = container.querySelector<HTMLButtonElement>(
+        ".chat-private-image-button",
+      );
+      expect(imageButton).not.toBeNull();
+
+      const touchEvent = (type: string): MouseEvent => {
+        const event = new MouseEvent(type, { bubbles: true });
+        Object.defineProperty(event, "pointerType", { value: "touch" });
+        return event;
+      };
+
+      await act(async () => {
+        imageButton?.dispatchEvent(touchEvent("pointerdown"));
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(
+        document.body.querySelector(".message-actions-sheet"),
+      ).not.toBeNull();
+
+      await act(async () => {
+        imageButton?.dispatchEvent(touchEvent("pointerup"));
+        imageButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      expect(container.querySelector(".chat-image-viewer")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/web-app/src/components/ChatMessage.tsx
+++ b/apps/web-app/src/components/ChatMessage.tsx
@@ -215,6 +215,7 @@ function ChatMessageComponent({
   );
   const [nowMs, setNowMs] = React.useState(() => Date.now());
   const longPressTimerRef = React.useRef<number | null>(null);
+  const longPressFiredRef = React.useRef(false);
   const touchStartRef = React.useRef<{ x: number; y: number } | null>(null);
   const swipeTriggeredRef = React.useRef(false);
   const messageDivRef = React.useRef<HTMLDivElement | null>(null);
@@ -645,14 +646,26 @@ function ChatMessageComponent({
   }, []);
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    longPressFiredRef.current = false;
     if (event.pointerType !== "touch" || !canReplyOrReact) return;
 
     touchStartRef.current = { x: event.clientX, y: event.clientY };
     swipeTriggeredRef.current = false;
     clearLongPress();
     longPressTimerRef.current = window.setTimeout(() => {
+      longPressFiredRef.current = true;
       openMenu();
     }, LONG_PRESS_MS);
+  };
+
+  // Touch browsers can still synthesize a click after the long-press timer
+  // opened the menu; swallow it so it doesn't also trigger bubble content
+  // (e.g. the image viewer).
+  const handleClickCapture = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!longPressFiredRef.current) return;
+    longPressFiredRef.current = false;
+    event.preventDefault();
+    event.stopPropagation();
   };
 
   const resetSwipeTransform = React.useCallback(() => {
@@ -730,6 +743,7 @@ function ChatMessageComponent({
               messageElRef(el, messageId);
             }
           }}
+          onClickCapture={handleClickCapture}
           onContextMenu={(event) => {
             event.preventDefault();
             openMenu();

--- a/apps/web-app/src/components/ChatMessage.tsx
+++ b/apps/web-app/src/components/ChatMessage.tsx
@@ -9,6 +9,12 @@ import {
 } from "../app/lib/bankPaymentOffer";
 import { parseIdentityChangeMessageContent } from "../app/lib/identityChangeMessage";
 import {
+  canSharePrivateImage,
+  downloadPrivateImageBlob,
+  isCancelledShareError,
+  sharePrivateImageBlob,
+} from "../app/lib/privateImageFile";
+import {
   extractMessageLinks,
   normalizeMessageLinkMatch,
 } from "../app/lib/messageLinks";
@@ -61,6 +67,8 @@ interface ChatMessageProps {
     edited: string;
     react: string;
     reply: string;
+    save: string;
+    share: string;
   };
   bankPaymentOfferInfo: LinkyBankPaymentOfferInfo | null;
   bankPaymentOfferPeerNotice: BankPaymentOfferPeerNotice | null;
@@ -202,6 +210,9 @@ function ChatMessageComponent({
   const { formatDisplayedAmountParts, formatDisplayedAmountText, t } =
     useAppShellCore();
   const [menuOpen, setMenuOpen] = React.useState(false);
+  const [privateImageBlob, setPrivateImageBlob] = React.useState<Blob | null>(
+    null,
+  );
   const [nowMs, setNowMs] = React.useState(() => Date.now());
   const longPressTimerRef = React.useRef<number | null>(null);
   const touchStartRef = React.useRef<{ x: number; y: number } | null>(null);
@@ -606,6 +617,27 @@ function ChatMessageComponent({
     if (el?.isConnected) el.focus();
   }, []);
 
+  const imageActions = React.useMemo(() => {
+    if (!privateImageInfo || !privateImageBlob) return null;
+    const exportLinks = rumorId ? { rumor: rumorId } : {};
+    return {
+      canShare: canSharePrivateImage(),
+      onSave: () => {
+        downloadPrivateImageBlob(privateImageBlob, exportLinks);
+      },
+      onShare: () => {
+        void sharePrivateImageBlob(
+          privateImageBlob,
+          t("chatImageMessage"),
+          exportLinks,
+        ).catch((error: unknown) => {
+          if (isCancelledShareError(error)) return;
+          downloadPrivateImageBlob(privateImageBlob, exportLinks);
+        });
+      },
+    };
+  }, [privateImageBlob, privateImageInfo, rumorId, t]);
+
   const clearLongPress = React.useCallback(() => {
     if (longPressTimerRef.current == null) return;
     window.clearTimeout(longPressTimerRef.current);
@@ -708,8 +740,10 @@ function ChatMessageComponent({
           onPointerCancel={handlePointerUp}
         >
           <MessageActionsMenu
+            canCopy={!privateImageInfo}
             canEdit={canEdit}
             canReplyOrReact={canReplyOrReact}
+            imageActions={imageActions}
             isOpen={menuOpen}
             labels={actionLabels}
             onReply={() => onReply(message)}
@@ -867,7 +901,12 @@ function ChatMessageComponent({
                   {t("paymentRequestDeclinedMessage")}
                 </span>
               ) : privateImageInfo ? (
-                <PrivateImageBubble payload={privateImageInfo} t={t} />
+                <PrivateImageBubble
+                  onBlobChange={setPrivateImageBlob}
+                  payload={privateImageInfo}
+                  rumorId={rumorId}
+                  t={t}
+                />
               ) : tokenInfo && isStandaloneTokenMessage ? (
                 renderCashuTokenPill(tokenInfo)
               ) : inlineMessageContent ? (

--- a/apps/web-app/src/components/MessageActionsMenu.test.tsx
+++ b/apps/web-app/src/components/MessageActionsMenu.test.tsx
@@ -10,36 +10,56 @@ Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
   writable: true,
 });
 
+const defaultLabels = {
+  copy: "Copy",
+  edit: "Edit",
+  react: "React",
+  reply: "Reply",
+  save: "Save",
+  share: "Share",
+};
+
+type MenuProps = Parameters<typeof MessageActionsMenu>[0];
+
+const renderMenu = async (overrides: Partial<MenuProps> = {}) => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <MessageActionsMenu
+        canCopy={true}
+        canEdit={false}
+        canReplyOrReact={true}
+        imageActions={null}
+        isOpen={true}
+        labels={defaultLabels}
+        onClose={vi.fn()}
+        onCopy={vi.fn()}
+        onEdit={vi.fn()}
+        onReact={vi.fn()}
+        onReply={vi.fn()}
+        {...overrides}
+      />,
+    );
+  });
+
+  return root;
+};
+
+const menuItemLabels = (): string[] =>
+  Array.from(document.body.querySelectorAll(".message-actions-item")).map(
+    (item) => item.textContent ?? "",
+  );
+
 describe("MessageActionsMenu", () => {
   afterEach(() => {
     document.body.innerHTML = "";
   });
 
   it("keeps the conversation visible through its backdrop", async () => {
-    const container = document.createElement("div");
-    document.body.appendChild(container);
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(
-        <MessageActionsMenu
-          canEdit={false}
-          canReplyOrReact={true}
-          isOpen={true}
-          labels={{
-            copy: "Copy",
-            edit: "Edit",
-            react: "React",
-            reply: "Reply",
-          }}
-          onClose={vi.fn()}
-          onCopy={vi.fn()}
-          onEdit={vi.fn()}
-          onReact={vi.fn()}
-          onReply={vi.fn()}
-        />,
-      );
-    });
+    const root = await renderMenu();
     // The menu portals to document.body, so query there rather than the container.
     const backdrop = document.body.querySelector(".message-actions-backdrop");
 
@@ -49,6 +69,45 @@ describe("MessageActionsMenu", () => {
     expect(getComputedStyle(backdrop).backgroundColor).toBe(
       "rgba(0, 0, 0, 0.4)",
     );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("offers share and save instead of copy for image messages", async () => {
+    const onSave = vi.fn();
+    const onShare = vi.fn();
+    const root = await renderMenu({
+      canCopy: false,
+      imageActions: { canShare: true, onSave, onShare },
+    });
+
+    expect(menuItemLabels()).toEqual(["Reply", "Share", "Save"]);
+
+    const [, shareItem, saveItem] = Array.from(
+      document.body.querySelectorAll(".message-actions-item"),
+    );
+    await act(async () => {
+      shareItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      saveItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onShare).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("hides the share item when the device cannot share files", async () => {
+    const root = await renderMenu({
+      canCopy: false,
+      imageActions: { canShare: false, onSave: vi.fn(), onShare: vi.fn() },
+    });
+
+    expect(menuItemLabels()).toEqual(["Reply", "Save"]);
 
     await act(async () => {
       root.unmount();

--- a/apps/web-app/src/components/MessageActionsMenu.tsx
+++ b/apps/web-app/src/components/MessageActionsMenu.tsx
@@ -1,17 +1,28 @@
+import { Download } from "lucide-react";
 import type { FC } from "react";
 import { createPortal } from "react-dom";
 import { EmojiPicker } from "./EmojiPicker";
-import { CopyIcon, EditIcon, ReplyIcon } from "./icons";
+import { CopyIcon, EditIcon, ReplyIcon, ShareIcon } from "./icons";
+
+export interface MessageImageActions {
+  canShare: boolean;
+  onSave: () => void;
+  onShare: () => void;
+}
 
 interface MessageActionsMenuProps {
+  canCopy: boolean;
   canEdit: boolean;
   canReplyOrReact: boolean;
+  imageActions: MessageImageActions | null;
   isOpen: boolean;
   labels: {
     copy: string;
     edit: string;
     react: string;
     reply: string;
+    save: string;
+    share: string;
   };
   onClose: () => void;
   onCopy: () => void;
@@ -21,8 +32,10 @@ interface MessageActionsMenuProps {
 }
 
 export const MessageActionsMenu: FC<MessageActionsMenuProps> = ({
+  canCopy,
   canEdit,
   canReplyOrReact,
+  imageActions,
   isOpen,
   labels,
   onClose,
@@ -83,19 +96,51 @@ export const MessageActionsMenu: FC<MessageActionsMenuProps> = ({
             {labels.edit}
           </button>
         )}
-        <button
-          type="button"
-          className="message-actions-item"
-          onClick={() => {
-            onCopy();
-            onClose();
-          }}
-        >
-          <span className="message-actions-icon">
-            <CopyIcon size={18} />
-          </span>
-          {labels.copy}
-        </button>
+        {imageActions?.canShare && (
+          <button
+            type="button"
+            className="message-actions-item"
+            onClick={() => {
+              imageActions.onShare();
+              onClose();
+            }}
+          >
+            <span className="message-actions-icon">
+              <ShareIcon size={18} />
+            </span>
+            {labels.share}
+          </button>
+        )}
+        {imageActions && (
+          <button
+            type="button"
+            className="message-actions-item"
+            onClick={() => {
+              imageActions.onSave();
+              onClose();
+            }}
+          >
+            <span className="message-actions-icon">
+              <Download size={18} />
+            </span>
+            {labels.save}
+          </button>
+        )}
+        {canCopy && (
+          <button
+            type="button"
+            className="message-actions-item"
+            onClick={() => {
+              onCopy();
+              onClose();
+            }}
+          >
+            <span className="message-actions-icon">
+              <CopyIcon size={18} />
+            </span>
+            {labels.copy}
+          </button>
+        )}
       </div>
     </>,
     document.body,

--- a/apps/web-app/src/components/PrivateImageBubble.test.tsx
+++ b/apps/web-app/src/components/PrivateImageBubble.test.tsx
@@ -1,0 +1,119 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  decryptPrivateImageMessage,
+  type PrivateImageMessagePayload,
+} from "../app/lib/privateImageMessage";
+import { PrivateImageBubble } from "./PrivateImageBubble";
+
+vi.mock("../app/lib/privateImageMessage", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../app/lib/privateImageMessage")>();
+  return {
+    ...actual,
+    decryptPrivateImageMessage: vi.fn(
+      async () => new Blob(["img"], { type: "image/jpeg" }),
+    ),
+  };
+});
+
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+  configurable: true,
+  value: true,
+  writable: true,
+});
+
+const decryptMock = vi.mocked(decryptPrivateImageMessage);
+
+const payload: PrivateImageMessagePayload = {
+  encryptedSha256: "a".repeat(64),
+  encryptedSize: 4,
+  encryptionAlgorithm: "aes-gcm",
+  fileType: "image/jpeg",
+  height: 10,
+  key: "b".repeat(64),
+  nonce: "c".repeat(24),
+  originalSha256: "d".repeat(64),
+  storageEncoding: "base64",
+  type: "linky.private_image.v1",
+  url: "https://example.com/blob",
+  width: 10,
+};
+
+describe("PrivateImageBubble", () => {
+  beforeEach(() => {
+    decryptMock.mockClear();
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:test"),
+      writable: true,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("decrypts once even when the parent re-renders with a fresh onBlobChange", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const render = async () => {
+      await act(async () => {
+        root.render(
+          <PrivateImageBubble
+            onBlobChange={() => undefined}
+            payload={payload}
+            rumorId={null}
+            t={(key) => key}
+          />,
+        );
+      });
+    };
+
+    await render();
+    expect(decryptMock).toHaveBeenCalledTimes(1);
+
+    // The bank offer detail page re-renders every second for its countdown,
+    // passing a new inline callback each time.
+    await render();
+    await render();
+
+    expect(decryptMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("reports the decrypted blob to the parent", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onBlobChange = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <PrivateImageBubble
+          onBlobChange={onBlobChange}
+          payload={payload}
+          rumorId={null}
+          t={(key) => key}
+        />,
+      );
+    });
+
+    expect(onBlobChange).toHaveBeenLastCalledWith(expect.any(Blob));
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/apps/web-app/src/components/PrivateImageBubble.tsx
+++ b/apps/web-app/src/components/PrivateImageBubble.tsx
@@ -1,71 +1,29 @@
 import { Download } from "lucide-react";
 import React from "react";
 import {
+  downloadPrivateImageBlob,
+  isCancelledShareError,
+  sharePrivateImageBlob,
+} from "../app/lib/privateImageFile";
+import {
   decryptPrivateImageMessage,
   type PrivateImageMessagePayload,
 } from "../app/lib/privateImageMessage";
 import { ShareIcon } from "./icons";
 
 interface PrivateImageBubbleProps {
+  onBlobChange: (blob: Blob | null) => void;
   payload: PrivateImageMessagePayload;
+  rumorId: string | null;
   t: (key: string) => string;
 }
 
-const PRIVATE_IMAGE_FILENAME = "linky-obrazek.jpg";
-
-const isCancelledShareError = (error: unknown): boolean => {
-  if (typeof error !== "object" || error === null) return false;
-
-  const name =
-    "name" in error && typeof error.name === "string" ? error.name : "";
-  if (name === "AbortError") return true;
-
-  const message =
-    "message" in error && typeof error.message === "string"
-      ? error.message
-      : "";
-  return /cancel|abort|dismiss/i.test(message);
-};
-
-const downloadPrivateImageBlob = (blob: Blob) => {
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.href = url;
-  anchor.download = PRIVATE_IMAGE_FILENAME;
-  anchor.rel = "noopener";
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  window.setTimeout(() => URL.revokeObjectURL(url), 0);
-};
-
-const sharePrivateImageBlob = async (
-  blob: Blob,
-  title: string,
-): Promise<void> => {
-  if (typeof navigator.share !== "function") {
-    throw new Error("share-unavailable");
-  }
-
-  const file = new File([blob], PRIVATE_IMAGE_FILENAME, {
-    type: blob.type || "image/jpeg",
-  });
-  const shareData: ShareData = {
-    files: [file],
-    title,
-  };
-
-  if (
-    typeof navigator.canShare === "function" &&
-    !navigator.canShare(shareData)
-  ) {
-    throw new Error("share-unavailable");
-  }
-
-  await navigator.share(shareData);
-};
-
-export function PrivateImageBubble({ payload, t }: PrivateImageBubbleProps) {
+export function PrivateImageBubble({
+  onBlobChange,
+  payload,
+  rumorId,
+  t,
+}: PrivateImageBubbleProps) {
   const placeholderRef = React.useRef<HTMLDivElement | null>(null);
   const [shouldLoad, setShouldLoad] = React.useState(
     typeof IntersectionObserver === "undefined",
@@ -102,6 +60,7 @@ export function PrivateImageBubble({ payload, t }: PrivateImageBubbleProps) {
 
     setImageUrl(null);
     setImageBlob(null);
+    onBlobChange(null);
     setFailed(false);
     setViewerOpen(false);
     setViewerErrorText(null);
@@ -111,6 +70,7 @@ export function PrivateImageBubble({ payload, t }: PrivateImageBubbleProps) {
         if (cancelled) return;
         objectUrl = URL.createObjectURL(blob);
         setImageBlob(blob);
+        onBlobChange(blob);
         setImageUrl(objectUrl);
       })
       .catch(() => {
@@ -121,7 +81,7 @@ export function PrivateImageBubble({ payload, t }: PrivateImageBubbleProps) {
       cancelled = true;
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
-  }, [payload, shouldLoad]);
+  }, [onBlobChange, payload, shouldLoad]);
 
   React.useEffect(() => {
     if (!viewerOpen) return;
@@ -146,9 +106,11 @@ export function PrivateImageBubble({ payload, t }: PrivateImageBubbleProps) {
     setViewerErrorText(null);
   };
 
+  const exportLinks = rumorId ? { rumor: rumorId } : {};
+
   const saveImage = () => {
     if (!imageBlob) return;
-    downloadPrivateImageBlob(imageBlob);
+    downloadPrivateImageBlob(imageBlob, exportLinks);
   };
 
   const shareImage = async () => {
@@ -156,7 +118,11 @@ export function PrivateImageBubble({ payload, t }: PrivateImageBubbleProps) {
 
     setViewerErrorText(null);
     try {
-      await sharePrivateImageBlob(imageBlob, t("chatImageMessage"));
+      await sharePrivateImageBlob(
+        imageBlob,
+        t("chatImageMessage"),
+        exportLinks,
+      );
     } catch (error) {
       if (isCancelledShareError(error)) return;
       setViewerErrorText(t("shareUnavailable"));
@@ -194,7 +160,6 @@ export function PrivateImageBubble({ payload, t }: PrivateImageBubbleProps) {
         type="button"
         className="chat-private-image-button"
         onClick={openViewer}
-        onPointerDown={(event) => event.stopPropagation()}
         aria-label={t("chatImageOpen")}
       >
         <img

--- a/apps/web-app/src/components/PrivateImageBubble.tsx
+++ b/apps/web-app/src/components/PrivateImageBubble.tsx
@@ -36,6 +36,14 @@ export function PrivateImageBubble({
     null,
   );
 
+  // Latest-ref so an inline callback identity can't retrigger the decrypt
+  // effect (parents like the bank offer page re-render every second). Must
+  // stay declared before the decrypt effect so it syncs first.
+  const onBlobChangeRef = React.useRef(onBlobChange);
+  React.useEffect(() => {
+    onBlobChangeRef.current = onBlobChange;
+  }, [onBlobChange]);
+
   React.useEffect(() => {
     if (shouldLoad || typeof IntersectionObserver === "undefined") return;
     const element = placeholderRef.current;
@@ -60,7 +68,7 @@ export function PrivateImageBubble({
 
     setImageUrl(null);
     setImageBlob(null);
-    onBlobChange(null);
+    onBlobChangeRef.current(null);
     setFailed(false);
     setViewerOpen(false);
     setViewerErrorText(null);
@@ -70,7 +78,7 @@ export function PrivateImageBubble({
         if (cancelled) return;
         objectUrl = URL.createObjectURL(blob);
         setImageBlob(blob);
-        onBlobChange(blob);
+        onBlobChangeRef.current(blob);
         setImageUrl(objectUrl);
       })
       .catch(() => {
@@ -81,7 +89,7 @@ export function PrivateImageBubble({
       cancelled = true;
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
-  }, [onBlobChange, payload, shouldLoad]);
+  }, [payload, shouldLoad]);
 
   React.useEffect(() => {
     if (!viewerOpen) return;

--- a/apps/web-app/src/devtools/inspectorPage/inspectorGlossary.ts
+++ b/apps/web-app/src/devtools/inspectorPage/inspectorGlossary.ts
@@ -25,12 +25,16 @@ const TAG_DESCRIPTIONS: Record<string, string> = {
     "An event delivered by a relay on an open subscription, before decryption or routing. Follow its wrap id to see what the inbox made of it.",
   InboxRouted:
     "The inbox decrypted an incoming gift wrap and routed it to an app-level fact (e.g. ReactionAdded) — or dropped it (WrapDropped) when the rumor could not be used, for example an unsupported kind.",
+  ChatImageShared:
+    "User exported a decrypted chat image through the system share sheet; the rumor link ties it to the message it came from.",
+  ChatImageSaved:
+    "User saved a decrypted chat image as a file download; the rumor link ties it to the message it came from.",
+  ChatImageShareFailed:
+    "System share of a chat image failed for a reason other than the user cancelling; the app fell back to a file download when triggered from the message menu.",
 };
 
 const describeTag = (row: CollectedInspectorRow): string => {
-  const known = row.channel.startsWith("nostr.")
-    ? TAG_DESCRIPTIONS[row.tag]
-    : undefined;
+  const known = TAG_DESCRIPTIONS[row.tag];
   if (known) return known;
   return `An inspector event tagged "${row.tag}" on the "${row.channel}" channel. Rows sharing any of its link ids are related.`;
 };

--- a/apps/web-app/src/pages/BankPaymentOfferDetailPage.tsx
+++ b/apps/web-app/src/pages/BankPaymentOfferDetailPage.tsx
@@ -188,7 +188,12 @@ const PaymentConfirmation = ({
 }) => (
   <div className="bank-payment-offer-confirmation">
     <strong>{t("bankPaymentOfferConfirmation")}</strong>
-    <PrivateImageBubble payload={confirmation.payload} t={t} />
+    <PrivateImageBubble
+      onBlobChange={() => undefined}
+      payload={confirmation.payload}
+      rumorId={String(confirmation.message.rumorId ?? "").trim() || null}
+      t={t}
+    />
   </div>
 );
 

--- a/apps/web-app/src/pages/ChatPage.tsx
+++ b/apps/web-app/src/pages/ChatPage.tsx
@@ -323,6 +323,8 @@ const ChatMessageList = memo(function ChatMessageList({
       edited: t("chatEdited"),
       react: t("chatReactAction"),
       reply: t("chatReplyAction"),
+      save: t("chatImageSave"),
+      share: t("share"),
     }),
     [t],
   );


### PR DESCRIPTION
Closes #279

## Problem

Receiving an image in chat (e.g. a bank payment confirmation) and trying to pass it on was a dead end:

- The message's three-dots menu only offered **Reply** and **Copy** — no share.
- Long-pressing the image (the standard iOS gesture) surfaced WebKit's native callout, whose **Share** exported the literal string `blob:https://app.linky.fit/...` — a pointer into the current tab's memory that no other app or person can open.

The app actually already had a correct file-based share (`navigator.share` with a real `File`), but it was only reachable through the fullscreen viewer's footer, so users never found it before hitting the two broken paths.

## What changed

- **Long-press on a chat image now opens the app's message menu** instead of the native callout (`-webkit-touch-callout: none` on chat/viewer images, and the image bubble no longer swallows the long-press gesture).
- **The message menu gains Share and Save for decrypted image messages**, wired to the same file-based helpers as the viewer. Share is hidden on devices without `navigator.share`, and a failed (non-cancelled) share falls back to a file download. Copy — which only produced the raw `linky:image:v1:...` payload string — is hidden for image messages.
- **Share/download helpers moved to `app/lib/privateImageFile.ts`**, shared by the menu and the viewer.
- **Exported filename is now `linky-image.<ext>`** with the extension derived from the blob type, replacing the hardcoded Czech `linky-obrazek.jpg`.
- **Inspector events**: `ChatImageShared` / `ChatImageSaved` / `ChatImageShareFailed` rows on `app.log`, linked to the message rumor id, with glossary entries.

## Verification

- New unit tests prove the share payload is a real `File` (`files:[...]`, never `url`/`text`), the filename/extension derivation, the cancel-vs-failure handling, and the download anchor naming.
- Component tests drive the real menu on a real (mock-decrypted) image message: menu shows **Share/Save** without **Copy**, clicking Share calls `navigator.share` with `linky-image.jpg`; text messages keep **Copy**.
- `bun run check-code` and the full unit suite (133 files, 633 tests) pass.

Not covered: manual on-device iOS verification of the share sheet — worth a quick check on a real phone before release.