### PR TITLE
Settle proxy payments directly from chat

### DIFF
--- a/apps/web-app/src/components/ChatMessage.test.tsx
+++ b/apps/web-app/src/components/ChatMessage.test.tsx
@@ -1,6 +1,7 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LinkyBankPaymentOfferInfo } from "../app/lib/bankPaymentOffer";
 import { serializePrivateImageMessage } from "../app/lib/privateImageMessage";
 import type { LocalNostrMessage } from "../app/types/appTypes";
 import { ChatMessage, type NpubMessageContactInfo } from "./ChatMessage";
@@ -63,10 +64,13 @@ const contactInfo = (
 });
 
 interface RenderChatMessageOptions {
+  bankPaymentOfferInfo?: LinkyBankPaymentOfferInfo | null;
   canReplyOrReact?: boolean;
+  canSettleBankPaymentOffer?: boolean;
   direction?: "in" | "out";
   getNpubMessageContactInfo?: (npub: string) => NpubMessageContactInfo | null;
   onAddNpubContacts?: (npubs: readonly string[]) => void;
+  onSettleBankPaymentOffer?: () => Promise<void>;
 }
 
 const renderChatMessage = async (
@@ -89,9 +93,10 @@ const renderChatMessage = async (
           save: "save",
           share: "share",
         }}
-        bankPaymentOfferInfo={null}
+        bankPaymentOfferInfo={options.bankPaymentOfferInfo ?? null}
         bankPaymentOfferPeerNotice={null}
         canOpenBankPaymentOfferDetails={true}
+        canSettleBankPaymentOffer={options.canSettleBankPaymentOffer ?? false}
         canActOnPaymentRequest={false}
         canEdit={false}
         canReplyOrReact={options.canReplyOrReact ?? false}
@@ -124,6 +129,9 @@ const renderChatMessage = async (
         onPayPaymentRequest={() => undefined}
         onReact={() => undefined}
         onReply={() => undefined}
+        onSettleBankPaymentOffer={
+          options.onSettleBankPaymentOffer ?? (async () => undefined)
+        }
         payPaymentRequestBusy={false}
         payPaymentRequestDisabled={false}
         paymentRequestInfo={null}
@@ -131,6 +139,7 @@ const renderChatMessage = async (
         previousMessage={null}
         reactions={[]}
         replyQuoteText={null}
+        settleBankPaymentOfferBusy={false}
       />,
     );
   });
@@ -320,5 +329,56 @@ describe("ChatMessage image message actions", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("ChatMessage bank payment offer actions", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("settles a paid offer from the chat card", async () => {
+    const onSettleBankPaymentOffer = vi.fn(async () => undefined);
+    const bankPaymentOfferInfo: LinkyBankPaymentOfferInfo = {
+      amountSat: 10,
+      amountText: "10 sat",
+      bankPaidAtSec: 1_700_000_000,
+      expiresAtSec: 1_700_000_300,
+      extensionSec: null,
+      initiatedAtSec: 1_699_999_900,
+      offerId: "offer-1",
+      offererPublicKey: "offerer-pubkey",
+      spdPayload: null,
+      status: "bank_paid",
+      statusUpdatedAtSec: 1_700_000_000,
+      text: "Bank payment marked paid",
+    };
+    const container = await renderChatMessage("offer", {
+      bankPaymentOfferInfo,
+      canSettleBankPaymentOffer: true,
+      direction: "out",
+      onSettleBankPaymentOffer,
+    });
+    const detailsButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(
+        ".chat-payment-request-actions button",
+      ),
+    ).find((button) => button.textContent?.includes("details"));
+    const settleButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(
+        ".chat-payment-request-actions button",
+      ),
+    ).find((button) =>
+      button.textContent?.includes("bankPaymentOfferMarkDone"),
+    );
+
+    expect(detailsButton).toBeDefined();
+    expect(settleButton).toBeDefined();
+
+    await act(async () => {
+      settleButton?.click();
+    });
+
+    expect(onSettleBankPaymentOffer).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web-app/src/components/ChatMessage.tsx
+++ b/apps/web-app/src/components/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import { CheckCheck, Info, Plus, X } from "lucide-react";
+import { Check, CheckCheck, Info, Plus, X } from "lucide-react";
 import React from "react";
 import { useAppShellCore } from "../app/context/AppShellContexts";
 import {
@@ -73,6 +73,7 @@ interface ChatMessageProps {
   bankPaymentOfferInfo: LinkyBankPaymentOfferInfo | null;
   bankPaymentOfferPeerNotice: BankPaymentOfferPeerNotice | null;
   canOpenBankPaymentOfferDetails: boolean;
+  canSettleBankPaymentOffer: boolean;
   canEdit: boolean;
   canActOnPaymentRequest: boolean;
   canReplyOrReact: boolean;
@@ -90,6 +91,7 @@ interface ChatMessageProps {
   nextMessage: LocalNostrMessage | null;
   onCopy: (message: LocalNostrMessage) => void;
   onOpenBankPaymentOfferDetails: () => void;
+  onSettleBankPaymentOffer: () => Promise<void>;
   onDeclinePaymentRequest: () => void;
   onEdit: (message: LocalNostrMessage) => void;
   onMintIconError: (origin: string, nextUrl: string | null) => void;
@@ -106,6 +108,7 @@ interface ChatMessageProps {
   previousMessage: LocalNostrMessage | null;
   reactions: readonly ChatReactionChip[];
   replyQuoteText: string | null;
+  settleBankPaymentOfferBusy: boolean;
 }
 
 const SWIPE_REPLY_THRESHOLD = 48;
@@ -173,6 +176,7 @@ function ChatMessageComponent({
   bankPaymentOfferInfo,
   bankPaymentOfferPeerNotice,
   canOpenBankPaymentOfferDetails,
+  canSettleBankPaymentOffer,
   canEdit,
   canActOnPaymentRequest,
   canReplyOrReact,
@@ -199,6 +203,7 @@ function ChatMessageComponent({
   onPayPaymentRequest,
   onReact,
   onReply,
+  onSettleBankPaymentOffer,
   payPaymentRequestBusy,
   payPaymentRequestDisabled,
   paymentRequestInfo,
@@ -206,6 +211,7 @@ function ChatMessageComponent({
   previousMessage,
   reactions,
   replyQuoteText,
+  settleBankPaymentOfferBusy,
 }: ChatMessageProps) {
   const { formatDisplayedAmountParts, formatDisplayedAmountText, t } =
     useAppShellCore();
@@ -213,6 +219,8 @@ function ChatMessageComponent({
   const [privateImageBlob, setPrivateImageBlob] = React.useState<Blob | null>(
     null,
   );
+  const [isSettlingBankPaymentOffer, setIsSettlingBankPaymentOffer] =
+    React.useState(false);
   const [nowMs, setNowMs] = React.useState(() => Date.now());
   const longPressTimerRef = React.useRef<number | null>(null);
   const longPressFiredRef = React.useRef(false);
@@ -294,6 +302,23 @@ function ChatMessageComponent({
       : bankPaymentOfferPeerNotice === "backup_recipient"
         ? t("bankPaymentOfferBackupRecipient")
         : "";
+
+  const settleBankPaymentOffer = async () => {
+    if (
+      !canSettleBankPaymentOffer ||
+      settleBankPaymentOfferBusy ||
+      isSettlingBankPaymentOffer
+    ) {
+      return;
+    }
+
+    setIsSettlingBankPaymentOffer(true);
+    try {
+      await onSettleBankPaymentOffer();
+    } finally {
+      setIsSettlingBankPaymentOffer(false);
+    }
+  };
 
   React.useEffect(() => {
     if (!bankOfferPhaseTtlSec) return;
@@ -836,18 +861,42 @@ function ChatMessageComponent({
                   !isLinkyBankPaymentOfferTerminalStatus(
                     bankPaymentOfferInfo.status,
                   ) ? (
-                    <button
-                      type="button"
-                      className="btn-wide chat-payment-request-pay"
-                      onClick={onOpenBankPaymentOfferDetails}
-                    >
-                      <span className="btn-label-with-icon">
-                        <span className="btn-label-icon" aria-hidden="true">
-                          <Info size={18} />
+                    <div className="chat-payment-request-actions">
+                      <button
+                        type="button"
+                        className={`btn-wide ${canSettleBankPaymentOffer ? "secondary" : "chat-payment-request-pay"}`}
+                        onClick={onOpenBankPaymentOfferDetails}
+                      >
+                        <span className="btn-label-with-icon">
+                          <span className="btn-label-icon" aria-hidden="true">
+                            <Info size={18} />
+                          </span>
+                          <span>{t("details")}</span>
                         </span>
-                        <span>{t("details")}</span>
-                      </span>
-                    </button>
+                      </button>
+                      {canSettleBankPaymentOffer ? (
+                        <button
+                          type="button"
+                          className="btn-wide chat-payment-request-pay"
+                          disabled={
+                            settleBankPaymentOfferBusy ||
+                            isSettlingBankPaymentOffer
+                          }
+                          onClick={() => void settleBankPaymentOffer()}
+                        >
+                          <span className="btn-label-with-icon">
+                            <span className="btn-label-icon" aria-hidden="true">
+                              {isSettlingBankPaymentOffer ? (
+                                <span className="btn-spinner" />
+                              ) : (
+                                <Check size={18} />
+                              )}
+                            </span>
+                            <span>{t("bankPaymentOfferMarkDone")}</span>
+                          </span>
+                        </button>
+                      ) : null}
+                    </div>
                   ) : null}
                 </div>
               ) : paymentRequestInfo ? (

--- a/apps/web-app/src/i18n/cs.ts
+++ b/apps/web-app/src/i18n/cs.ts
@@ -676,6 +676,7 @@ export const cs = {
   bankPaymentOfferCancel: "Zrušit nabídku",
   bankPaymentOfferDetails: "Platební údaje",
   bankPaymentOfferMarkPaid: "Zaplaceno",
+  bankPaymentOfferMarkDone: "Dokončit",
   bankPaymentOfferSettle: "Potvrdit vyrovnání",
   bankPaymentOfferNotPaid: "Nebylo zaplaceno",
   bankPaymentOfferAcceptedByOther:

--- a/apps/web-app/src/i18n/de.ts
+++ b/apps/web-app/src/i18n/de.ts
@@ -653,6 +653,7 @@ export const de = {
   bankPaymentOfferCancel: "Angebot abbrechen",
   bankPaymentOfferDetails: "Zahlungsdetails",
   bankPaymentOfferMarkPaid: "Ich habe bezahlt",
+  bankPaymentOfferMarkDone: "Erledigen",
   bankPaymentOfferSettle: "Abschluss bestätigen",
   bankPaymentOfferNotPaid: "Nicht bezahlt",
   bankPaymentOfferAcceptedByOther:

--- a/apps/web-app/src/i18n/en.ts
+++ b/apps/web-app/src/i18n/en.ts
@@ -667,6 +667,7 @@ export const en = {
   bankPaymentOfferCancel: "Cancel offer",
   bankPaymentOfferDetails: "Payment details",
   bankPaymentOfferMarkPaid: "I paid",
+  bankPaymentOfferMarkDone: "Mark done",
   bankPaymentOfferSettle: "Confirm settlement",
   bankPaymentOfferNotPaid: "Not paid",
   bankPaymentOfferAcceptedByOther:

--- a/apps/web-app/src/pages/ChatPage.tsx
+++ b/apps/web-app/src/pages/ChatPage.tsx
@@ -166,12 +166,14 @@ interface ChatMessageViewModel extends ParsedChatMessage {
   canActOnPaymentRequest: boolean;
   canEdit: boolean;
   canReplyOrReact: boolean;
+  canSettleBankPaymentOffer: boolean;
   isSeen: boolean;
   message: LocalNostrMessage;
   nextMessage: LocalNostrMessage | null;
   onDeclinePaymentRequest: () => void;
   onOpenBankPaymentOfferDetails: () => void;
   onPayPaymentRequest: (requestInfo: CashuPaymentRequestMessageInfo) => void;
+  onSettleBankPaymentOffer: () => Promise<void>;
   payPaymentRequestDisabled: boolean;
   paymentRequestStatus: "declined" | "paid" | "requested" | null;
   previousMessage: LocalNostrMessage | null;
@@ -278,6 +280,7 @@ interface ChatMessageListProps {
   onPayPaymentRequest: ChatPageProps["onPayPaymentRequest"];
   onReact: ChatPageProps["onReact"];
   onReply: ChatPageProps["onReply"];
+  onSettleBankPaymentOffer: ChatPageProps["onSettleBankPaymentOffer"];
   /** Peer's reported seen window; 0 bounds mean no receipt yet. */
   peerSeenSinceSec: number;
   peerSeenUpToSec: number;
@@ -309,6 +312,7 @@ const ChatMessageList = memo(function ChatMessageList({
   onPayPaymentRequest,
   onReact,
   onReply,
+  onSettleBankPaymentOffer,
   peerSeenSinceSec,
   peerSeenUpToSec,
   reactionsByMessageId,
@@ -437,6 +441,13 @@ const ChatMessageList = memo(function ChatMessageList({
         parsed.bankPaymentOfferInfo,
         offersById,
       );
+      const offererPublicKey = String(
+        parsed.bankPaymentOfferInfo?.offererPublicKey ?? "",
+      ).trim();
+      const canSettleBankPaymentOffer =
+        parsed.bankPaymentOfferInfo?.status === "bank_paid" &&
+        ((Boolean(offererPublicKey) && offererPublicKey === chatOwnPubkeyHex) ||
+          String(message.direction ?? "") === "out");
 
       return {
         ...parsed,
@@ -454,6 +465,7 @@ const ChatMessageList = memo(function ChatMessageList({
           !parsed.bankPaymentOfferInfo &&
           !parsed.declineInfo,
         canReplyOrReact: Boolean(rumorId),
+        canSettleBankPaymentOffer,
         isSeen,
         message,
         nextMessage:
@@ -473,6 +485,7 @@ const ChatMessageList = memo(function ChatMessageList({
         onPayPaymentRequest: (requestInfo) => {
           void onPayPaymentRequest(message, requestInfo);
         },
+        onSettleBankPaymentOffer: () => onSettleBankPaymentOffer(message),
         payPaymentRequestDisabled:
           !parsed.paymentRequestInfo ||
           cashuIsBusy ||
@@ -500,6 +513,7 @@ const ChatMessageList = memo(function ChatMessageList({
     getCashuTokenMessageInfo,
     onDeclinePaymentRequest,
     onPayPaymentRequest,
+    onSettleBankPaymentOffer,
     peerSeenSinceSec,
     peerSeenUpToSec,
     reactionsByMessageId,
@@ -540,15 +554,18 @@ const ChatMessageList = memo(function ChatMessageList({
             bankPaymentOfferInfo={viewModel.bankPaymentOfferInfo}
             bankPaymentOfferPeerNotice={viewModel.bankPaymentOfferPeerNotice}
             canOpenBankPaymentOfferDetails={canOpenBankPaymentOfferDetails}
+            canSettleBankPaymentOffer={viewModel.canSettleBankPaymentOffer}
             onOpenBankPaymentOfferDetails={
               viewModel.onOpenBankPaymentOfferDetails
             }
             onDeclinePaymentRequest={viewModel.onDeclinePaymentRequest}
             onPayPaymentRequest={viewModel.onPayPaymentRequest}
+            onSettleBankPaymentOffer={viewModel.onSettleBankPaymentOffer}
             canActOnPaymentRequest={viewModel.canActOnPaymentRequest}
             payPaymentRequestDisabled={viewModel.payPaymentRequestDisabled}
             payPaymentRequestBusy={cashuIsBusy}
             replyQuoteText={viewModel.replyQuoteText}
+            settleBankPaymentOfferBusy={cashuIsBusy}
             onCopy={onCopy}
             onAddNpubContacts={onAddNpubContacts}
             onEdit={onEdit}
@@ -1156,6 +1173,7 @@ export const ChatPage: FC<ChatPageProps> = ({
   onEdit,
   onOpenNpubContact,
   onPayPaymentRequest,
+  onSettleBankPaymentOffer,
   onReact,
   onReply,
   openContactPay,
@@ -1304,6 +1322,7 @@ export const ChatPage: FC<ChatPageProps> = ({
         onEdit={onEdit}
         onOpenNpubContact={onOpenNpubContact}
         onPayPaymentRequest={onPayPaymentRequest}
+        onSettleBankPaymentOffer={onSettleBankPaymentOffer}
         onReact={onReact}
         onReply={onReply}
         peerSeenSinceSec={Number(selectedContact.chatPeerSeenSinceSec ?? 0)}

--- a/apps/web-app/tests/proxy-payment.spec.ts
+++ b/apps/web-app/tests/proxy-payment.spec.ts
@@ -142,7 +142,7 @@ const offerDetailUrl = (page: Page) =>
 
 test("proxy payment: bank details reach exactly one acceptor, who is paid in sats", async ({
   browser,
-}) => {
+}, testInfo) => {
   const a = await bootAccount(browser, "A");
   const b = await bootAccount(browser, "B");
   const c = await bootAccount(browser, "C");
@@ -161,15 +161,23 @@ test("proxy payment: bank details reach exactly one acceptor, who is paid in sat
       await advertiseCzk(c);
     });
 
+    const offererChatByRecipientNpub = new Map<string, string>();
+
     // Ordering is load-bearing: an empty status query is cached as null and
     // never retried, so B and C must have their status on the relay before A
     // adds them as contacts.
     await test.step("A adds B and C", async () => {
       // One at a time: adding the second contact while the first's status fetch
       // is in flight loses that status (see waitForContactStatusFetched).
-      await addContactByNpub(a.page, b.identity.npub);
+      offererChatByRecipientNpub.set(
+        b.identity.npub,
+        await addContactByNpub(a.page, b.identity.npub),
+      );
       await waitForContactStatusFetched(a.page, b.identity.npub);
-      await addContactByNpub(a.page, c.identity.npub);
+      offererChatByRecipientNpub.set(
+        c.identity.npub,
+        await addContactByNpub(a.page, c.identity.npub),
+      );
       await waitForContactStatusFetched(a.page, c.identity.npub);
     });
 
@@ -220,7 +228,9 @@ test("proxy payment: bank details reach exactly one acceptor, who is paid in sat
           timeout: 60_000,
         });
         const match = offerDetailUrl(a.page);
-        if (!match?.[2]) throw new Error(`no offerId in ${a.page.url()}`);
+        if (!match?.[1] || !match[2]) {
+          throw new Error(`invalid offer detail URL ${a.page.url()}`);
+        }
         return decodeURIComponent(match[2]);
       });
 
@@ -342,30 +352,36 @@ test("proxy payment: bank details reach exactly one acceptor, who is paid in sat
     });
 
     await test.step("A settles and the winner is paid in sats", async () => {
+      const winnerChatId = offererChatByRecipientNpub.get(winner.identity.npub);
+      if (!winnerChatId) throw new Error("winner chat not found");
+      await a.page.goto(`/#chat/${encodeURIComponent(winnerChatId)}`);
       const settle = a.page.getByRole("button", {
-        name: "Confirm settlement",
+        name: "Mark done",
       });
-      // The button is conditionally rendered, not disabled, so it must be
-      // absent before bank_paid rather than merely disabled.
       await expect(settle).toBeVisible({ timeout: 120_000 });
+      const offerCard = a.page.locator(".chat-bank-payment-offer-card", {
+        has: settle,
+      });
+      await expect(
+        offerCard.getByRole("button", { name: "Details" }),
+      ).toBeVisible();
+      await expect(
+        a.page.getByText("Camera not available.", { exact: true }),
+      ).toBeHidden();
+      await testInfo.attach("mark payment done from chat", {
+        body: await offerCard.screenshot(),
+        contentType: "image/png",
+      });
 
       // Park the winner on the wallet page and stay there: re-mounting the
       // settled offer detail triggers its auto-return-to-chat effect, which
       // races with (and can clobber) a subsequent goto to #wallet.
       await winner.page.goto("/#wallet");
 
-      // settleBankPaymentOffer opens with `if (cashuIsBusy) return;` and shows
-      // no toast, so a fire-and-forget click can silently do nothing.
+      await expect(settle).toBeEnabled();
+      await settle.click();
       await expect
-        .poll(
-          async () => {
-            if (await settle.isVisible().catch(() => false)) {
-              await settle.click().catch(() => {});
-            }
-            return readBalanceSat(winner.page);
-          },
-          { timeout: 240_000 },
-        )
+        .poll(() => readBalanceSat(winner.page), { timeout: 240_000 })
         .toBeGreaterThan(0);
 
       const received = await readBalanceSat(winner.page);


### PR DESCRIPTION
Closes #278.

When the helper marks the bank transfer as paid, the offer owner can now finish the proxy payment directly from the chat card instead of opening the detail page. The new Mark done action sits next to Details, uses the existing settlement pipeline, and shows its pending state while the Cashu payment is sent.

The full proxy-payment browser test now returns to the winning recipient chat, captures the new card, clicks Mark done there, and verifies the recipient wallet balance and offer cleanup.

## Testing

- bun run check-code
- bun run --filter @linky/web-app test --run src/components/ChatMessage.test.tsx
- E2E_SKIP_WEBSERVER=1 bunx playwright test --project=local-stack tests/proxy-payment.spec.ts