### PR TITLE
Allow pasted amounts when receiving payments

### DIFF
--- a/apps/web-app/src/components/useAmountInputKeypad.test.ts
+++ b/apps/web-app/src/components/useAmountInputKeypad.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { normalizePastedAmountInput } from "./useAmountInputKeypad";
+
+describe("normalizePastedAmountInput", () => {
+  it("accepts a whole-number amount", () => {
+    expect(normalizePastedAmountInput(" 21000 ", false)).toBe("21000");
+  });
+
+  it("normalizes a decimal comma when decimal input is enabled", () => {
+    expect(normalizePastedAmountInput("12,34", true)).toBe("12.34");
+  });
+
+  it("rejects non-amount clipboard content", () => {
+    expect(normalizePastedAmountInput("cashuA...", false)).toBeNull();
+    expect(normalizePastedAmountInput("12.34", false)).toBeNull();
+  });
+});

--- a/apps/web-app/src/components/useAmountInputKeypad.ts
+++ b/apps/web-app/src/components/useAmountInputKeypad.ts
@@ -1,5 +1,6 @@
 import React from "react";
 import { useAppShellCore } from "../app/context/AppShellContexts";
+import { readClipboardText } from "../platform/clipboard";
 
 interface AmountInputDraft {
   amountSat: string;
@@ -16,7 +17,17 @@ interface UseAmountInputKeypadResult {
   decimalKeyEnabled: boolean;
   inputDisplayValue: string | null;
   onKeyPress: (key: string) => void;
+  pasteFromClipboard: () => Promise<boolean>;
 }
+
+export const normalizePastedAmountInput = (
+  value: string,
+  allowDecimals: boolean,
+): string | null => {
+  const normalized = value.trim().replace(",", ".");
+  const pattern = allowDecimals ? /^\d+(?:\.\d{0,2})?$/ : /^\d+$/;
+  return pattern.test(normalized) ? normalized : null;
+};
 
 export const useAmountInputKeypad = ({
   amount,
@@ -56,11 +67,45 @@ export const useAmountInputKeypad = ({
     ],
   );
 
+  const pasteFromClipboard = React.useCallback(async () => {
+    const clipboardText = await readClipboardText();
+    if (clipboardText === null) return false;
+
+    const pastedAmount = normalizePastedAmountInput(
+      clipboardText,
+      decimalAmountInputKeyVisible,
+    );
+    if (pastedAmount === null) return false;
+
+    let result = { amountSat: "", displayValue: "" };
+    for (const key of pastedAmount) {
+      result = applyAmountInputKeyWithDraft(
+        result.amountSat,
+        result.displayValue,
+        key,
+      );
+    }
+
+    setDraft({
+      amountSat: result.amountSat,
+      displayCurrency,
+      displayValue: result.displayValue,
+    });
+    onAmountChange(result.amountSat);
+    return true;
+  }, [
+    applyAmountInputKeyWithDraft,
+    decimalAmountInputKeyVisible,
+    displayCurrency,
+    onAmountChange,
+  ]);
+
   return {
     decimalKeyEnabled: decimalAmountInputKeyVisible,
     inputDisplayValue: decimalAmountInputKeyVisible
       ? currentDisplayValue
       : null,
     onKeyPress,
+    pasteFromClipboard,
   };
 };

--- a/apps/web-app/src/pages/TopupPage.tsx
+++ b/apps/web-app/src/pages/TopupPage.tsx
@@ -37,6 +37,10 @@ export const TopupPage: FC<TopupPageProps> = ({
     amount: topupAmount,
     onAmountChange: (nextAmount) => setTopupAmount(nextAmount),
   });
+  const pasteAmountOrScanValue = async () => {
+    if (await amountInput.pasteFromClipboard()) return;
+    await pasteScanValue();
+  };
 
   return (
     <section className="panel">
@@ -90,7 +94,7 @@ export const TopupPage: FC<TopupPageProps> = ({
           <button
             type="button"
             className="btn-wide secondary"
-            onClick={() => void pasteScanValue()}
+            onClick={() => void pasteAmountOrScanValue()}
           >
             <span className="btn-label-with-icon">
               <span className="btn-label-icon" aria-hidden="true">


### PR DESCRIPTION
Entering a receive amount only supported keypad taps because Paste sent every clipboard value through the payment scanner.

This change recognizes plain numeric clipboard values first and applies them through the same display-currency conversion as keypad input. Non-amount clipboard content still follows the existing scanner path.

Testing:
- bun run check-code
- bun run --filter @linky/web-app test (687 tests)
- bun run --filter @linky/web-app build
- Local browser: Wallet → Receive → Paste with 21000 displayed 21,000 sat and enabled Show top-up invoice