### PR TITLE
docs: usage guides so a new developer can use linkshu and linkstr

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,10 @@ IMPORTANT: When you make or change an architectural decision, document it in `do
 - Comments should not duplicate the code! The code should be self explanatory, use function names, proper code split into logical chunks
 - Explain unidiomatic code in comments - keep the comments brief and to the point if you need to write it!
 
+## Package docs
+
+`packages/linkshu/docs/` and `packages/linkstr/docs/` hold usage guides for the two libraries (linkstr-react is documented in `packages/linkstr/docs/react.md`). Read the relevant guide before using or changing a package, and follow the package's `AGENTS.md`: a change to an exported surface or documented behavior updates the matching guide in the same commit.
+
 ## Inspector events
 
 When implementing or refactoring a meaningful operation — user-initiated actions, network/relay/mint traffic, sync, push, notable state transitions — emit an inspector event for it. Follow the `adding-inspector-events` skill (`.agents/skills/adding-inspector-events/`) for row design, correlation links, and the no-key-material rule.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ It is local-first: data is stored in Evolu (SQLite) and syncs between devices.
 
 The repo also contains a separate public website in `apps/site/` intended for `linky.fit`, while the product app remains a distinct deployment on `app.linky.fit`. Its `/cashu/` redemption page uses the shared linkshu wallet and linkstr delivery packages, with local recovery for interrupted payments.
 
+## Packages
+
+- [`packages/linkstr`](./packages/linkstr/README.md) — Nostr protocol library; usage guides in [`packages/linkstr/docs/`](./packages/linkstr/docs/README.md) (also covers `@linky/linkstr-react`)
+- [`packages/linkshu`](./packages/linkshu/README.md) — cashu wallet library; usage guides in [`packages/linkshu/docs/`](./packages/linkshu/docs/README.md)
+
 ## Protocols and stack
 
 - Nostr (chat, profile, auth-related flows)

--- a/packages/linkshu/AGENTS.md
+++ b/packages/linkshu/AGENTS.md
@@ -1,0 +1,7 @@
+# @linky/linkshu
+
+Usage guides for this package live in `docs/` (index: `docs/README.md`). Read the guide for a vertical before changing it; the guide states the persistence order and error contract callers rely on.
+
+## Keep the docs in sync
+
+Changing the public surface — anything exported from `src/index.ts` (drafts, receipts, service methods, errors, ports, config) or the behavior a guide describes — is done only when the matching `docs/*.md` file is updated in the same commit. Done means: every snippet in the touched guide still typechecks against the new surface, every table row still names a real field or error tag, and a new vertical or port has its own guide linked from `docs/README.md`.

--- a/packages/linkshu/README.md
+++ b/packages/linkshu/README.md
@@ -6,6 +6,13 @@ restore, …) is defined here as an Effect service over branded `Schema` types.
 Raw cashu-ts types never cross the package boundary: callers hand in drafts
 and get receipts; token text is the currency of the API.
 
+## Documentation
+
+Usage guides live in [`docs/`](./docs/README.md): start with
+[getting started](./docs/getting-started.md), then the guide for the
+operation you need (receive, send, melt, top up, restore, …). This README
+holds the design rules; the guides show how to call the package.
+
 ## Verticals
 
 - `receive/` — one call from pasted/scanned text to an `accepted` row:

--- a/packages/linkshu/docs/README.md
+++ b/packages/linkshu/docs/README.md
@@ -1,0 +1,37 @@
+# @linky/linkshu guides
+
+How to use Linky's cashu wallet library. These are guides, not an API reference: the exported types are the reference, and the [package README](../README.md) holds the design rules and rationale.
+
+## Where to start
+
+1. [Getting started](./getting-started.md) — wire the seed and ports, run a first call, and learn the core concepts in one page. Read this first.
+2. The guide for the operation you need, from the list below. Each one opens with a working example; jump to its Errors section when a call fails.
+
+[Concepts](./concepts.md) is the lookup behind both: branded primitives, token states, error classification, and a short Effect primer.
+
+## Wallet operations
+
+- [Receive](./receive.md) — from pasted or scanned text to an accepted row
+- [Send](./send.md) — swap an amount out into an encoded token
+- [Melt](./melt.md) — pay a bolt11 invoice
+- [Top up](./topup.md) — mint quote, invoice, settlement, and resuming interrupted topups
+- [Autoswap](./autoswap.md) — move a foreign-mint balance to the main mint
+- [Validation](./validation.md) — NUT-07 proof-state checks and local merge
+- [Restore](./restore.md) — NUT-09 seed recovery and the seed-bound wipe
+- [Tokens](./tokens.md) — read model, balances, lifecycle transitions, `returnToWallet`, token codec
+- [Mints](./mints.md) — mint info, fees, the known-mint set, icons
+- [Fee probe](./fee-probe.md) — Lightning fee estimation via a melt quote
+- [Lightning utilities](./lightning-utilities.md) — invoice preview, LNURL-pay, lightning addresses, fiat rates
+
+## Integrating the package
+
+- [Ports](./ports.md) — implementing `KeyValueStore`, `TokenStore`, and `CashuSeed` for a new platform
+- [Errors](./errors.md) — every tagged error, when it happens, what to do
+- [Inspector](./inspector.md) — diagnostics events and how to consume them
+- [Testing](./testing.md) — in-memory ports, test helpers, the integration suite
+
+## Finding your way
+
+- Looking for a type or method name? Open `src/index.ts` and follow the export; every guide names the file it documents.
+- Something behaves unexpectedly? The operation guide's "How it works" section states the persistence order and what survives an interruption; the [Errors](./errors.md) table says what each failure means.
+- Want a working consumer to copy from? `apps/linkshu-cli` runs every operation on file-based ports; the web app's adapters are named in [Ports](./ports.md).

--- a/packages/linkshu/docs/autoswap.md
+++ b/packages/linkshu/docs/autoswap.md
@@ -1,0 +1,114 @@
+# Autoswap
+
+`Autoswap` moves a foreign mint's balance into your main mint: it quotes a topup at the target, pays that invoice by melting at the source, and mints at the target. Use it for the explicit "melt to main mint" action. When to trigger it is caller policy; the package never swaps on its own.
+
+## Quick example
+
+Prerequisites: a configured runtime ([getting-started.md](./getting-started.md)) and a balance at `sourceMint` ([receive.md](./receive.md)); both mints must be Lightning-backed.
+
+```ts
+import { Effect } from "effect";
+import { Autoswap, AutoswapDraft } from "@linky/linkshu";
+import type { MintUrl } from "@linky/linkshu";
+
+const consolidate = (sourceMint: MintUrl, targetMint: MintUrl) =>
+  Effect.gen(function* () {
+    const autoswap = yield* Autoswap;
+    const receipt = yield* autoswap.claim(
+      new AutoswapDraft({ sourceMint, targetMint }),
+    );
+    return receipt.movedAmount; // sat that arrived at the target
+  });
+```
+
+At startup, and whenever connectivity returns, drain interrupted swaps:
+
+```ts
+const resumeSwaps = Effect.gen(function* () {
+  const autoswap = yield* Autoswap;
+  for (const result of yield* autoswap.resumePendingClaims) {
+    switch (result.status) {
+      case "claimed":
+        console.log("moved", result.amount, "sat into row", result.rowId);
+        break;
+      case "not-claimable-yet":
+        // the melt may still be settling, or the target was unreachable;
+        // the record stays for the next resume
+        break;
+      case "dropped":
+        console.log("gave up on", result.quoteId, "at", result.targetMint);
+        break;
+    }
+  }
+});
+```
+
+## How it works
+
+1. **Size.** `accepted` rows at the source are NUT-07 filtered (fully spent ones marked `error`). The starting amount is the balance minus the source's cashu input-fee allowance.
+2. **Quote at the target** for that amount.
+3. **Persist the claim** before the invoice can be paid.
+4. **Melt at the source** against the target's invoice through [`Melt`](./melt.md) — fee-inclusive swap, `reserved` inputs row, change persisted.
+5. **Wait for the target** to see the payment, then mint through the same claim machinery as [topup](./topup.md): the row is inserted before the record is removed.
+
+### How amounts step down
+
+A melt `InsufficientFunds` costs only an unpaid quote, because the melt prices itself before touching a proof. The package retries automatically with up to four progressively smaller amounts to leave room for the Lightning fee reserve; if none fits, the last `InsufficientFunds` surfaces.
+
+### When it is a no-op
+
+- Nothing spendable at the source after the input-fee allowance → `InsufficientFunds` with `required = max(inputFee, 1)`; no quote is created.
+- `resumePendingClaims` with no records → empty array; it never fails.
+
+### `resumePendingClaims`
+
+For every persisted claim, ask the target mint once:
+
+| Mint says                                                         | Result `status`                   | Record                                                      |
+| ----------------------------------------------------------------- | --------------------------------- | ----------------------------------------------------------- |
+| `PAID`/`ISSUED`, mint succeeds or reclaims                        | `claimed` (`rowId`, `amount` set) | removed                                                     |
+| `UNPAID` before the 24 h deadline                                 | `not-claimable-yet`               | kept — the melt may still be settling                       |
+| `UNPAID` after the deadline, or `MintRejected` after the deadline | `dropped`                         | removed                                                     |
+| unreachable / any other failure                                   | `not-claimable-yet`               | kept — a mint that will not answer says nothing about funds |
+
+## Inputs and outputs
+
+`AutoswapDraft` (`autoswap/domain.ts`): `sourceMint: MintUrl`, `targetMint: MintUrl`.
+
+`AutoswapReceipt`:
+
+| Field         | Type                | Notes                                           |
+| ------------- | ------------------- | ----------------------------------------------- |
+| `sourceMint`  | `MintUrl`           |                                                 |
+| `targetMint`  | `MintUrl`           |                                                 |
+| `movedAmount` | `Amount`            | what landed at the target, persisted `accepted` |
+| `feePaid`     | `NonNegativeAmount` | Lightning fee the source melt paid              |
+| `rowId`       | `TokenRowId`        | the target row                                  |
+
+`AutoswapClaimResult` (from `resumePendingClaims`):
+
+| Field        | Type                                            |
+| ------------ | ----------------------------------------------- |
+| `quoteId`    | `QuoteId`                                       |
+| `targetMint` | `MintUrl`                                       |
+| `status`     | `"claimed" \| "not-claimable-yet" \| "dropped"` |
+| `rowId`      | `Schema.NullOr(TokenRowId)`                     |
+| `amount`     | `Schema.NullOr(Amount)`                         |
+
+## Errors
+
+Every failure except `InsufficientFunds` leaves the claim record behind on purpose: the source melt may already have paid the invoice. After any of them, run `resumePendingClaims` before calling `claim` again — a second `claim` would quote a new invoice while the first may still settle.
+
+| Tag                  | When                                                                                                                  | What to do                                                                      |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `InsufficientFunds`  | no sizing fit within four attempts, or nothing to move                                                                | leave the balance where it is                                                   |
+| `PaymentFailed`      | the source melt failed or its quote expired, or the melt settled but the target still reports `UNPAID` after the poll | `resumePendingClaims` finishes it                                               |
+| `MintUnreachable`    | either mint unreachable                                                                                               | `resumePendingClaims` when the mints answer; do not start a fresh `claim` first |
+| `MintRejected`       | definitive rejection at either mint                                                                                   | surface `detail`; `resumePendingClaims` decides the record's fate               |
+| `CounterLockTimeout` | counter lease held elsewhere                                                                                          | `resumePendingClaims` later                                                     |
+
+## Related
+
+- [melt.md](./melt.md), [topup.md](./topup.md) — the two halves
+- [mints.md](./mints.md) — `MintInfo.inputFeePpk`
+- [errors.md](./errors.md)

--- a/packages/linkshu/docs/concepts.md
+++ b/packages/linkshu/docs/concepts.md
@@ -1,0 +1,141 @@
+# Concepts
+
+The lookup behind every linkshu call: what goes in, what comes out, how rows move, and how failures are classified. Come back to the Effect primer when a signature looks foreign.
+
+## Drafts in, receipts out
+
+Every operation takes a draft (`ReceiveDraft`, `SendDraft`, `MeltDraft`, `TopupDraft`, …) and returns a receipt or report (`ReceiveReceipt`, `SendReceipt`, `MeltReceipt`, `ValidationReport`, …). Both are `Schema.Class` values over branded primitives. Raw cashu-ts types never appear: the currency of the API is **token text** (`cashuA…`/`cashuB…`), never proof lists.
+
+Receipts resolve only after the funds they describe are persisted. Change, remainders, and recovered proofs are `accepted` rows before you see the receipt.
+
+## Branded primitives
+
+All in `src/domain/primitives.ts`. Each is an effect `Schema` with a brand, so a plain `string` or `number` does not type-check where one is expected.
+
+| Primitive              | Base         | Constraint                                 |
+| ---------------------- | ------------ | ------------------------------------------ |
+| `MintUrl`              | string       | http(s) url with a host, no trailing slash |
+| `CurrencyUnit`         | string       | non-empty (`"sat"` today)                  |
+| `KeysetId`             | string       | even-length hex                            |
+| `TokenText`            | string       | starts with `cashu`                        |
+| `Bolt11Invoice`        | string       | starts with `ln` (case-insensitive)        |
+| `Amount`               | integer      | positive                                   |
+| `NonNegativeAmount`    | integer      | zero or positive (fees, balances)          |
+| `QuoteId`              | string       | non-empty                                  |
+| `TokenRowId`           | string       | non-empty; assigned by the `TokenStore`    |
+| `DeterministicCounter` | integer      | zero or positive                           |
+| `UnixSeconds`          | integer      | positive                                   |
+| `Bip39Seed`            | `Uint8Array` | exactly 64 bytes                           |
+
+Three ways to construct one:
+
+```ts
+import { Amount, MintUrl, SendDraft } from "@linky/linkshu";
+import { Schema } from "effect";
+
+// 1. `.make` — throws on invalid input; use when the value is already known good.
+const amount = Amount.make(21);
+const mint = MintUrl.make("https://mint.example");
+
+// 2. Option-returning decoder — for user input you validate yourself.
+const decodeAmount = Schema.decodeUnknownOption(Amount);
+const maybeAmount = decodeAmount(Number("21")); // Option<Amount>
+
+// 3. Decode a whole draft from plain values; every field is validated at once.
+const decodeSendDraft = Schema.decodeUnknownSync(SendDraft);
+const draft = decodeSendDraft({
+  mint: "https://mint.example",
+  amount: 21,
+  produceAs: "issued",
+});
+```
+
+For mint urls, use `parseMintUrl(raw)`: it trims, strips trailing slashes, and returns `MintUrl | null`. Store and compare only that normalized form, or two spellings of one mint fork its counters.
+
+## Token rows and the lifecycle
+
+The `TokenStore` holds one row per token (`StoredTokenRow`). Each row has an `originalTokenText` (its dedup identity, never rewritten) and a `tokenText` (the current spendable encoding, rewritten as swaps move proofs forward). The package decides every `state`; the platform only persists.
+
+| State          | Meaning                                                                                | Balance? |
+| -------------- | -------------------------------------------------------------------------------------- | -------- |
+| `pending`      | In flight: an incoming token being accepted, or an outgoing one not yet confirmed sent | no       |
+| `accepted`     | Owned and spendable; `tokenText` holds fresh post-swap proofs                          | **yes**  |
+| `reserved`     | Earmarked for a handover, or held by a mint mid-melt; not yet issued                   | no       |
+| `issued`       | Handed out for someone to claim (QR, share); pruned once claimed                       | no       |
+| `externalized` | Handed off outside the app entirely                                                    | no       |
+| `error`        | Accept or validation failed definitively; `error` holds the serialized tagged error    | no       |
+
+`Tokens.balances` sums `accepted` rows only. `spendable` is the largest single-mint balance, because cashu cannot spend across mints in one operation.
+
+Legal transitions (`src/token/internal/lifecycle.ts`):
+
+| From           | To                                            |
+| -------------- | --------------------------------------------- |
+| `pending`      | `accepted`, `error`                           |
+| `accepted`     | `reserved`, `issued`, `externalized`, `error` |
+| `reserved`     | `accepted`, `issued`, `externalized`, `error` |
+| `issued`       | `accepted`, `externalized`, `error`           |
+| `externalized` | `accepted`                                    |
+| `error`        | `accepted`                                    |
+
+Who moves rows:
+
+- `Receive` inserts `pending`, swaps at the mint, then flips to `accepted` — or to `error` on a definitive rejection.
+- `Send` produces the outgoing row as `issued` or `pending` (your choice via `produceAs`) and the change as `accepted`; the source rows are removed.
+- `Melt` parks its inputs as `reserved` while the mint holds them; change comes back `accepted`.
+- `Topup`, `Restore`, `Autoswap` insert `accepted` rows.
+- `Tokens.reserve` / `markIssued` / `markExternalized` / `returnToWallet` are the transitions you call from UI actions ([tokens.md](./tokens.md)).
+- `Validation` marks fully spent rows `error` and rewrites partially spent ones; `checkIssued` removes claimed `issued` rows; `Tokens.deleteSpent` removes mint-confirmed spent rows.
+
+A request for an illegal transition fails with `InvalidTokenTransition`. To drop a row whose funds verifiably left (a `pending` messenger send once published), call `TokenStore.remove` directly — that is a delete, not a transition.
+
+## Deterministic counters and the lease
+
+Proof secrets derive from the seed and a per-(mint, unit, keyset) counter (NUT-13). Two contexts (tabs, a service worker, two CLI processes) advancing one counter at once would derive the same secrets and collide at the mint. So share one durable `KeyValueStore` between every context that uses the seed; the package serializes counter use through a lease in that store and recovers from collisions itself. If it cannot get the lease in time the operation fails with `CounterLockTimeout` before deriving anything: retry later.
+
+## Error classification
+
+One rule everywhere: a row is marked `error` only on a **definitive** mint rejection. A **transient** failure does not establish that funds are spent; follow the operation's retry or resume instructions.
+
+| Raw failure                                                | Classified as        | Kind       |
+| ---------------------------------------------------------- | -------------------- | ---------- |
+| Mint protocol error (`MintOperationError`, NUT error code) | `MintRejected`       | definitive |
+| HTTP 4xx                                                   | `MintRejected`       | definitive |
+| HTTP 5xx, fetch/network error, abort, timeout              | `MintUnreachable`    | transient  |
+| Lease not acquired                                         | `CounterLockTimeout` | transient  |
+
+The raw cashu-ts error never crosses the boundary. [errors.md](./errors.md) lists every error and what to do with it.
+
+## Effect primer
+
+Only what you need to use this package.
+
+**An `Effect<A, E, R>` is a description** of a computation that succeeds with `A`, fails with a typed `E`, and needs services `R`. Nothing runs until you hand it to a runtime.
+
+**Write sequential code with `Effect.gen`**; `yield*` unwraps an effect (or fails the whole generator with its error):
+
+```ts
+import { Tokens } from "@linky/linkshu";
+import { Effect } from "effect";
+
+const total = Effect.gen(function* () {
+  const tokens = yield* Tokens; // the service instance
+  const balances = yield* tokens.balances; // an Effect<WalletBalances>
+  return balances.total;
+});
+```
+
+**Services** are classes you `yield*` (`Receive`, `Tokens`, `KeyValueStore`, …). A **Layer** is how a service gets built; `linkshuServices(config)` is the one layer you need, and `Effect.provide`/`Layer.provideMerge` attach layers to effects and other layers.
+
+**Run** an effect with `runLinkshu` (one-shot), `ManagedRuntime.runPromise` (long-lived), or in tests `Effect.runPromise(program.pipe(Effect.provide(layer)))`.
+
+**Typed failures vs defects**: a `yield*` of a failing effect fails the program with that error type, which `Effect.either`, `Effect.catchTag`, and `Effect.catchTags` handle. Bugs (a throw inside `Effect.sync`, `Amount.make(-1)`) are defects; they reject the promise and are not in `E`.
+
+**Scopes**: some effects need `Scope.Scope` (`Topup.start`, `Topup.resumePending`). Wrap them in `Effect.scoped` for a self-contained run, or `Scope.extend` into a scope you own so background polling outlives the call.
+
+## Related
+
+- [getting-started.md](./getting-started.md) — wiring and first call
+- [ports.md](./ports.md) — what the stores must guarantee
+- [errors.md](./errors.md) — the tagged error catalogue
+- [tokens.md](./tokens.md) — read model and lifecycle actions

--- a/packages/linkshu/docs/errors.md
+++ b/packages/linkshu/docs/errors.md
@@ -1,0 +1,142 @@
+# Errors
+
+Every failure linkshu reports, what it means, and how to handle it. You need this when writing the code that shows a wallet failure to a user, decides whether to retry, or stores the failure on a row.
+
+## The catalogue
+
+All errors are `Schema.TaggedError` classes from `src/domain/errors.ts` (plus `InvalidTokenTransition` from `src/token/domain.ts`). Branch on `_tag`; never string-match `detail`.
+
+| Tag                      | Fields                          | When                                                                                                                       | Caller should                                                                                                                       |
+| ------------------------ | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `TokenParseFailed`       | `reason`, `detail`              | No token in the text, or undecodable. `reason` is `empty`, `no-token-found`, `undecodable`, `no-proofs`, `multiple-mints`. | Tell the user the input is not a token. Nothing was stored.                                                                         |
+| `TokenAlreadyKnown`      | `rowId`                         | A row (any state) already has this token text.                                                                             | Show "already in wallet"; link to `rowId`.                                                                                          |
+| `TokenAlreadySpent`      | `mint`                          | The mint definitively reported the proofs spent (NUT-07 / code 11001).                                                     | Show "already spent". Receive persisted an `error` row for it.                                                                      |
+| `MintUnreachable`        | `mint`, `detail`                | Network, timeout, 5xx. **Transient.**                                                                                      | Retry later. Recovery depends on when the failure occurred; an interrupted melt may leave `reserved` inputs ([melt.md](./melt.md)). |
+| `MintRejected`           | `mint`, `code`, `detail`        | Definitive protocol rejection (`code` is the NUT error code when known).                                                   | Surface it; the flow already persisted whatever the rejection implies.                                                              |
+| `InsufficientFunds`      | `mint`, `required`, `available` | Balance at `mint` cannot cover the amount (plus fee reserve for melt/autoswap).                                            | Offer a smaller amount or a top-up; `required`/`available` size the next attempt.                                                   |
+| `QuoteExpired`           | `quoteId`, `mint`               | The mint says the quote expired before it settled.                                                                         | Start a fresh quote.                                                                                                                |
+| `PaymentFailed`          | `mint`, `quoteId`, `detail`     | The mint accepted the melt but the Lightning payment did not settle.                                                       | Show failure; balance is intact (inputs may be `reserved` until validation).                                                        |
+| `QuoteAlreadyIssued`     | `quoteId`, `mint`               | `Topup.adopt`: the mint already issued this quote and no local record claims it.                                           | Nothing to mint; another wallet holds the proofs.                                                                                   |
+| `CounterLockTimeout`     | `mint`, `unit`, `keysetId`      | Another tab/process held the counter lease too long. **Transient.** Nothing derived.                                       | Retry. Web app copy: "Wallet is busy in another window".                                                                            |
+| `TokenRowNotFound`       | `rowId`                         | A row id the store no longer has.                                                                                          | Refresh the list.                                                                                                                   |
+| `InvalidTokenTransition` | `rowId`, `from`, `to`           | A `Tokens` transition the state machine forbids.                                                                           | Hide the action for that state; see the transition table in [concepts.md](./concepts.md).                                           |
+
+## Which operation fails how
+
+Each vertical exports a union type and schema of the errors it can produce.
+
+| Operation                                             | Error type                                                                                   |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `Receive.receive`, `Tokens.returnToWallet`            | `ReceiveError` (+ `TokenRowNotFound`, `InvalidTokenTransition` for `returnToWallet`)         |
+| `Send.send`                                           | `SendError`                                                                                  |
+| `Melt.quote`, `Melt.melt`                             | `MeltError`                                                                                  |
+| `Topup.start`                                         | `MintUnreachable \| MintRejected`                                                            |
+| `TopupHandle.result`                                  | `TopupError`                                                                                 |
+| `Topup.adopt`                                         | `TopupAdoptError`                                                                            |
+| `Autoswap.claim`                                      | `AutoswapError`                                                                              |
+| `FeeProbe.probeLightningFee`                          | `FeeProbeError`                                                                              |
+| `Mints.info`                                          | `MintUnreachable \| MintRejected`                                                            |
+| `Tokens.reserve`, `markIssued`, `markExternalized`    | `TokenRowNotFound \| InvalidTokenTransition`                                                 |
+| `Validation.checkRow`                                 | `TokenRowNotFound`                                                                           |
+| `Validation.checkAll`, `Restore.restore`              | never — unreachable mints are listed in the report's `unavailableMints`                      |
+| `Validation.checkIssued`, `Tokens.deleteSpent`        | never — rows they cannot verify stay untouched; the report does not say which mints answered |
+| `Topup.resumePending`, `Autoswap.resumePendingClaims` | never — each resumed handle or claim result carries its own outcome                          |
+
+Invalid input is not a package error. `new SendDraft({ … })` and `Schema.decodeUnknownSync(SendDraft)(…)` throw a `ParseError`; validate first with `Schema.decodeUnknownOption`, or accept that it becomes a defect (the web app wraps the decode in `Effect.suspend` so a bad draft rejects the promise).
+
+## Handling in Effect
+
+Handle one tag and keep the rest typed:
+
+```ts
+import { Receive, ReceiveDraft } from "@linky/linkshu";
+import { Effect } from "effect";
+
+const receiveOrReuse = (text: string) =>
+  Effect.flatMap(Receive, (receive) =>
+    receive.receive(new ReceiveDraft({ text })),
+  ).pipe(
+    Effect.catchTag("TokenAlreadyKnown", (known) =>
+      Effect.succeed({ rowId: known.rowId, duplicate: true as const }),
+    ),
+  );
+```
+
+Handle several tags at once — the classification rule in one place:
+
+```ts
+import type { ReceiveError } from "@linky/linkshu";
+import { Effect } from "effect";
+
+const withRetryHint = <A, R>(operation: Effect.Effect<A, ReceiveError, R>) =>
+  operation.pipe(
+    Effect.catchTags({
+      MintUnreachable: () => Effect.fail("retry-later" as const),
+      CounterLockTimeout: () => Effect.fail("retry-later" as const),
+    }),
+  );
+```
+
+Get the outcome as a value at the Promise boundary (what both real consumers do). One complete operation, run one-shot:
+
+```ts
+import { Bip39Seed, runLinkshu, Send, SendDraft } from "@linky/linkshu";
+import { Effect, Either, Schema } from "effect";
+
+const decodeSendDraft = Schema.decodeUnknownSync(SendDraft);
+
+export const describeSend = async (
+  bip39Seed: Bip39Seed,
+  mint: string,
+  amount: number,
+): Promise<string> => {
+  const outcome = await runLinkshu(
+    { bip39Seed },
+    Effect.either(
+      Effect.suspend(() => {
+        const draft = decodeSendDraft({ mint, amount, produceAs: "issued" });
+        return Effect.flatMap(Send, (send) => send.send(draft));
+      }),
+    ),
+  );
+  if (Either.isLeft(outcome)) {
+    switch (outcome.left._tag) {
+      case "InsufficientFunds":
+        return `need ${outcome.left.required}, have ${outcome.left.available}`;
+      default:
+        return outcome.left._tag;
+    }
+  }
+  return `sent ${outcome.right.amount} ${outcome.right.unit}`;
+};
+```
+
+The web app turns tags into display text in `apps/web-app/src/app/lib/cashuStoredError.ts` (`describeTaggedCashuError`). Extend that switch when you add an error; do not build another mapping.
+
+## Serialization
+
+Because every error is a `Schema.TaggedError`, it round-trips through JSON via `Schema.parseJson`. This is how rows carry their last failure in the `error` column:
+
+```ts
+import { MintUrl, ReceiveError, TokenAlreadySpent } from "@linky/linkshu";
+import { Schema } from "effect";
+
+const encodeReceiveError = Schema.encodeSync(Schema.parseJson(ReceiveError));
+const decodeReceiveError = Schema.decodeUnknownOption(
+  Schema.parseJson(ReceiveError),
+);
+
+const stored = encodeReceiveError(
+  new TokenAlreadySpent({ mint: MintUrl.make("https://mint.example") }),
+);
+// '{"_tag":"TokenAlreadySpent","mint":"https://mint.example"}'
+const back = decodeReceiveError(stored); // Option<ReceiveError>
+```
+
+Receive and Validation write exactly this shape. Read it back with the union schema of the vertical that wrote it, or parse the JSON and read `_tag` when you only need to classify.
+
+## Related
+
+- [concepts.md](./concepts.md) — the definitive-vs-transient rule and the transition table
+- [receive.md](./receive.md), [send.md](./send.md), [melt.md](./melt.md), [topup.md](./topup.md) — where each error comes from
+- [inspector.md](./inspector.md) — `OperationFailed` events carry the same tagged errors

--- a/packages/linkshu/docs/fee-probe.md
+++ b/packages/linkshu/docs/fee-probe.md
@@ -1,0 +1,70 @@
+# FeeProbe
+
+`FeeProbe` estimates a mint's Lightning fee. Mints publish no such number (NUT-06 has no field for it), so the only way to learn one is to ask for a melt quote against a real invoice and read the fee reserve. Use it to show "Lightning fee ≈ x %" on a mint page. Nothing is paid.
+
+## Quick example
+
+Prerequisites: a configured runtime ([getting-started.md](./getting-started.md)) and two reachable Lightning-backed mints; nothing is paid, so no balance is needed.
+
+```ts
+import { Effect } from "effect";
+import { FeeProbe, FeeProbeDraft, MintUrl } from "@linky/linkshu";
+
+const lightningFee = Effect.gen(function* () {
+  const feeProbe = yield* FeeProbe;
+  const result = yield* feeProbe.probeLightningFee(
+    new FeeProbeDraft({
+      mint: MintUrl.make("https://cashu.cz"),
+      probeMint: MintUrl.make("https://mint.minibits.cash/Bitcoin"),
+    }),
+  );
+  return `${result.percent.toFixed(2)} % (${result.feeReserve} sat on ${result.amount})`;
+});
+```
+
+## How it works
+
+1. Read the cache. A result for `mint` younger than 24 h is returned as-is; no request is made.
+2. Otherwise: create a mint quote for `amount` (default 10 000 sat) at `probeMint` to obtain an invoice, then ask `mint` for a melt quote on that invoice. `feeReserve` and `percent = feeReserve / amount × 100` come from that quote. The whole probe is capped at 15 s.
+3. Cache the result, emit a `LightningFeeProbed` inspector row, return.
+
+Pick `probeMint` as a _different_, Lightning-backed mint; a mint quoting a melt to its own invoice is not representative. Linky's `MintsPage` picks one from the production presets and skips test mints entirely.
+
+### What it never does
+
+- Never pays the invoice, mints, or melts. Both quotes are left unpaid and expire on their own.
+- Never touches token rows or deterministic counters.
+- Never retries on its own; a failure is not cached either (the app keeps a short client-side backoff for failed probes).
+
+## Inputs and outputs
+
+`FeeProbeDraft` (`feeProbe/domain.ts`):
+
+| Field       | Type                      | Notes                                      |
+| ----------- | ------------------------- | ------------------------------------------ |
+| `mint`      | `MintUrl`                 | mint whose Lightning fee you want          |
+| `probeMint` | `MintUrl`                 | another mint that issues the probe invoice |
+| `amount`    | `Schema.optional(Amount)` | probe size; default 10 000 sat             |
+
+`LightningFeeProbeResult`:
+
+| Field        | Type                | Notes                                            |
+| ------------ | ------------------- | ------------------------------------------------ |
+| `mint`       | `MintUrl`           |                                                  |
+| `probeMint`  | `MintUrl`           |                                                  |
+| `amount`     | `Amount`            | the mint's quoted amount, else the requested one |
+| `feeReserve` | `NonNegativeAmount` | sat the mint would reserve                       |
+| `percent`    | `Schema.Number`     | `feeReserve / amount * 100`                      |
+
+## Errors
+
+| Tag               | When                                                                                        | What to do                        |
+| ----------------- | ------------------------------------------------------------------------------------------- | --------------------------------- |
+| `MintUnreachable` | either mint unreachable, or the probe exceeded 15 s                                         | show "unknown"; retry later       |
+| `MintRejected`    | a mint answered with an unusable quote (no invoice, no fee reserve) or rejected the request | show "unknown"; `detail` explains |
+
+## Related
+
+- [mints.md](./mints.md) — `MintInfo.inputFeePpk` is the cashu-side fee
+- [melt.md](./melt.md) — where the real fee is charged
+- [inspector.md](./inspector.md) — `LightningFeeProbed`

--- a/packages/linkshu/docs/getting-started.md
+++ b/packages/linkshu/docs/getting-started.md
@@ -1,0 +1,195 @@
+# Getting started
+
+Wire `@linky/linkshu` and make a first wallet call. Read this before touching cashu code in the web app, the CLI, or a script.
+
+## What it is
+
+`@linky/linkshu` is Linky's cashu wallet as an Effect library. Every wallet operation (receive, send, pay an invoice, top up, validate, restore, …) is a typed service that takes a draft and returns a receipt. You bring the seed and two storage ports; the package owns everything else, including the token lifecycle and the deterministic counters.
+
+## Core concepts
+
+[concepts.md](./concepts.md) goes deeper on each.
+
+- **Services.** Each operation is an Effect service (`Receive`, `Send`, `Melt`, `Topup`, …). `yield* Receive` gives you the instance; call a method on it.
+- **Drafts in, receipts out.** Methods take a draft (`ReceiveDraft`, `SendDraft`, …) and return a receipt (`ReceiveReceipt`, `SendReceipt`, …). Both are typed over branded primitives (`MintUrl`, `Amount`, `TokenText`), so a plain string or number does not type-check until you decode it.
+- **Token rows.** Every token is a row in your `TokenStore` with a state; only `accepted` counts as balance. The package decides every state change; your store only persists it.
+- **Ports.** You supply storage (`KeyValueStore`, `TokenStore`) and the seed. In-memory defaults exist for tests. The package talks to mints itself.
+- **Errors are values.** Every failure is a tagged error (`MintRejected`, `MintUnreachable`, `InsufficientFunds`, …) you match on `_tag`.
+
+## Install and import
+
+Add the workspace dependency and import from the package root:
+
+```json
+{ "dependencies": { "@linky/linkshu": "workspace:*", "effect": "^3.19.19" } }
+```
+
+```ts
+import { Receive, ReceiveDraft, runLinkshu } from "@linky/linkshu";
+import { Effect } from "effect";
+```
+
+`@linky/linkshu/lightning-address` is a second entry for the lightning-address helpers; see [lightning-utilities.md](./lightning-utilities.md).
+
+## First run
+
+`runLinkshu` builds the services, runs your effect, and tears everything down. With no ports given it uses in-memory stores, so this needs no mint, no network, and no setup. Save it as `first-run.ts` next to a `package.json` that lists the dependency (for example in `apps/linkshu-cli/`):
+
+```ts
+import {
+  Bip39Seed,
+  Receive,
+  ReceiveDraft,
+  runLinkshu,
+  Tokens,
+} from "@linky/linkshu";
+import { Effect, Either } from "effect";
+
+// Disposable seed: random bytes own nothing and are gone when the process exits.
+const bip39Seed = Bip39Seed.make(crypto.getRandomValues(new Uint8Array(64)));
+
+const program = Effect.gen(function* () {
+  const tokens = yield* Tokens;
+  const balances = yield* tokens.balances;
+  console.log(
+    `balance ${balances.total} sat across ${balances.perMint.length} mints`,
+  );
+
+  const receive = yield* Receive;
+  const outcome = yield* Effect.either(
+    receive.receive(new ReceiveDraft({ text: "not a cashu token" })),
+  );
+  if (Either.isLeft(outcome)) {
+    const failure = outcome.left;
+    console.log(
+      failure._tag === "TokenParseFailed"
+        ? `no token in input (${failure.reason})`
+        : `receive failed: ${failure._tag}`,
+    );
+    return;
+  }
+  console.log(`received ${outcome.right.amount} ${outcome.right.unit}`);
+});
+
+await runLinkshu({ bip39Seed }, program);
+```
+
+```bash
+bun run first-run.ts
+```
+
+Expected output:
+
+```
+balance 0 sat across 0 mints
+no token in input (no-token-found)
+```
+
+What happened: `Tokens.balances` read an empty store, and `Receive.receive` failed with `TokenParseFailed`. `Effect.either` turned that typed failure into a value; without it the promise rejects with the error. Nothing was stored, because a parse failure never creates a row.
+
+To put real funds in, paste a token: [receive.md](./receive.md). Or mint some against the local Docker mint: [topup.md](./topup.md).
+
+## The three inputs you bring
+
+| Input           | Type                         | What it is                                                                                                   |
+| --------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `bip39Seed`     | `Bip39Seed`                  | The raw 64-byte BIP-39 seed. All deterministic derivation hangs off it; the package never sees the mnemonic. |
+| `keyValueStore` | `Layer.Layer<KeyValueStore>` | Durable string storage with lease locks. Optional: in-memory default.                                        |
+| `tokenStore`    | `Layer.Layer<TokenStore>`    | The token row store. Optional: in-memory default.                                                            |
+
+The in-memory defaults lose everything when the runtime ends. A real consumer implements the ports ([ports.md](./ports.md)); the CLI's file-based ones are the shortest working pair.
+
+Build the seed from a mnemonic on your side with `mnemonicToSeedSync` from `@scure/bip39`, then `Bip39Seed.make(bytes)`. `Bip39Seed.make` throws unless the array is exactly 64 bytes. The web app does this in `apps/web-app/src/platform/linkshu/resolveLinkshuSeed.ts`.
+
+## Long-lived: `linkshuServices` + `ManagedRuntime`
+
+An app keeps one runtime alive for the wallet UI. `linkshuServices` returns the layer; the inspector must be provided _around_ it, because the services read it while the layer is built. `config` carries your seed and the storage layers from [ports.md](./ports.md):
+
+```ts
+import {
+  Inspector,
+  linkshuServices,
+  Receive,
+  ReceiveDraft,
+  Tokens,
+} from "@linky/linkshu";
+import type { LinkshuServicesConfig } from "@linky/linkshu";
+import { Effect, Layer, ManagedRuntime } from "effect";
+
+export const makeWallet = (config: LinkshuServicesConfig) => {
+  const runtime = ManagedRuntime.make(
+    linkshuServices(config).pipe(Layer.provideMerge(Inspector.disabled)),
+  );
+  return {
+    balances: () =>
+      runtime.runPromise(Effect.flatMap(Tokens, (tokens) => tokens.balances)),
+    receive: (text: string) =>
+      runtime.runPromise(
+        Effect.either(
+          Effect.flatMap(Receive, (receive) =>
+            receive.receive(new ReceiveDraft({ text })),
+          ),
+        ),
+      ),
+    dispose: () => runtime.dispose(),
+  };
+};
+```
+
+Rebuild the runtime when the seed changes and dispose the old one. Topup handles poll in a `Scope`; keep one long-lived scope next to the runtime and close it before `dispose` — see [topup.md](./topup.md). The web app's version is `apps/web-app/src/app/hooks/composition/useLinkshuComposition.ts`.
+
+## Drafts from user input
+
+`new SendDraft({...})` needs already-branded values. From plain strings and numbers, decode the whole draft instead; every field is validated at once and a bad one throws a `ParseError`:
+
+```ts
+import { Send, SendDraft } from "@linky/linkshu";
+import { Effect, Schema } from "effect";
+
+const decodeSendDraft = Schema.decodeUnknownSync(SendDraft);
+
+export const sendFromForm = (mint: string, amount: number) =>
+  Effect.suspend(() => {
+    const draft = decodeSendDraft({ mint, amount, produceAs: "issued" });
+    return Effect.flatMap(Send, (send) => send.send(draft));
+  });
+```
+
+`Effect.suspend` keeps the throw inside the effect, so a bad form value rejects the promise like any other defect. Validate first with `Schema.decodeUnknownOption` when you want to show the error instead.
+
+## The services
+
+| Service      | Methods                                                                                          | Guide                            |
+| ------------ | ------------------------------------------------------------------------------------------------ | -------------------------------- |
+| `Receive`    | `receive`                                                                                        | [receive.md](./receive.md)       |
+| `Send`       | `send`                                                                                           | [send.md](./send.md)             |
+| `Melt`       | `quote`, `melt`, `status`                                                                        | [melt.md](./melt.md)             |
+| `Topup`      | `start`, `adopt`, `resumePending`                                                                | [topup.md](./topup.md)           |
+| `Autoswap`   | `claim`, `resumePendingClaims`                                                                   | [autoswap.md](./autoswap.md)     |
+| `Validation` | `checkAll`, `checkRow`, `checkIssued`                                                            | [validation.md](./validation.md) |
+| `Restore`    | `restore`, `wipeSeedBoundState`                                                                  | [restore.md](./restore.md)       |
+| `Tokens`     | `list`, `balances`, `reserve`, `markIssued`, `markExternalized`, `returnToWallet`, `deleteSpent` | [tokens.md](./tokens.md)         |
+| `Mints`      | `info`, `knownMints`                                                                             | [mints.md](./mints.md)           |
+| `FeeProbe`   | `probeLightningFee`                                                                              | [fee-probe.md](./fee-probe.md)   |
+
+Helpers that need no runtime (token codec, invoice preview, LNURL) are in [tokens.md](./tokens.md) and [lightning-utilities.md](./lightning-utilities.md).
+
+## Next: a funded wallet
+
+`apps/linkshu-cli` is a complete consumer on file-based ports. Run it against the local mint to see a top-up land as balance (needs Docker):
+
+```bash
+docker compose -f docker-compose.dev.yml up -d --wait cashu-mint
+bun run linkshu --data-dir /tmp/wallet topup 128
+bun run linkshu --data-dir /tmp/wallet --verbose balance
+```
+
+`--verbose` prints every inspector event to stderr; [inspector.md](./inspector.md) explains them.
+
+## Related
+
+- [concepts.md](./concepts.md) — drafts, receipts, primitives, token states, counters, Effect primer
+- [ports.md](./ports.md) — implementing `KeyValueStore`, `TokenStore`, `CashuSeed`
+- [errors.md](./errors.md) — every tagged error and how to handle it
+- [inspector.md](./inspector.md) — diagnostics events
+- [testing.md](./testing.md) — unit and integration testing

--- a/packages/linkshu/docs/inspector.md
+++ b/packages/linkshu/docs/inspector.md
@@ -1,0 +1,146 @@
+# Inspector
+
+The optional diagnostics bus: how to switch it on, what it emits, and how the CLI and web app consume it. You need this when debugging a wallet flow, adding a consumer, or emitting from a new vertical.
+
+## What it is
+
+`Inspector` (`src/inspector/Inspector.ts`) is a `Context.Tag` with two members:
+
+| Member        | Type                                           | Notes                                                                                              |
+| ------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `emit(build)` | `(build: () => LinkshuInspectorEvent) => void` | Sync and total. The builder runs lazily; a throwing builder is logged and dropped, never a defect. |
+| `events`      | `Stream.Stream<LinkshuInspectorEvent>`         | Single consumer; fan out downstream if you need more.                                              |
+
+Verticals resolve it with `Inspector.orNoop`, so a runtime without the layer pays one no-op call per event.
+
+## Providing it
+
+Three layers ship with the package:
+
+| Layer                | Use                                                                                                        |
+| -------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `Inspector.live`     | Sliding in-memory queue (1024 events); consume `events` as a stream. Scoped, so it needs a scope/runtime.  |
+| `Inspector.disabled` | No-op service, for composition roots that provide the tag unconditionally.                                 |
+| your own             | `Layer.succeed(Inspector, { emit, events: Stream.empty })` — a callback sink; what both real consumers do. |
+
+The layer must sit **around** the services layer, because services read the inspector while the layer is being built. `runLinkshu` does this for you through its `inspector` option:
+
+```ts
+import { Inspector, runLinkshu, Tokens } from "@linky/linkshu";
+import type { Bip39Seed } from "@linky/linkshu";
+import { Effect } from "effect";
+
+const balancesWithInspector = (bip39Seed: Bip39Seed) =>
+  runLinkshu(
+    { bip39Seed, inspector: Inspector.live },
+    Effect.flatMap(Tokens, (tokens) => tokens.balances),
+  );
+```
+
+With `linkshuServices`, provide-merge it onto the services layer:
+
+```ts
+import { Inspector, linkshuServices } from "@linky/linkshu";
+import type { Bip39Seed } from "@linky/linkshu";
+import { Layer } from "effect";
+
+const inspectedServices = (bip39Seed: Bip39Seed) =>
+  linkshuServices({ bip39Seed }).pipe(Layer.provideMerge(Inspector.live));
+```
+
+## Subscribing
+
+A callback sink is the simplest consumer and needs no stream plumbing:
+
+```ts
+import { Inspector } from "@linky/linkshu";
+import type { LinkshuInspectorEvent } from "@linky/linkshu";
+import { Layer, Stream } from "effect";
+
+export const consoleInspector = (
+  onEvent: (event: LinkshuInspectorEvent) => void,
+): Layer.Layer<Inspector> =>
+  Layer.succeed(Inspector, {
+    emit: (build) => {
+      try {
+        onEvent(build());
+      } catch (error) {
+        console.warn("linkshu inspector emission failed", error);
+      }
+    },
+    events: Stream.empty,
+  });
+```
+
+Keep the `try/catch`: `emit` is total by contract, and your sink is part of it.
+
+To consume `Inspector.live` as a stream, fork the consumer in a runtime that has the layer, and stop it before the runtime goes away:
+
+```ts
+import { Inspector, linkshuServices } from "@linky/linkshu";
+import type { Bip39Seed } from "@linky/linkshu";
+import { Effect, Fiber, Layer, ManagedRuntime, Stream } from "effect";
+
+export const startInspectedWallet = (bip39Seed: Bip39Seed) => {
+  const runtime = ManagedRuntime.make(
+    linkshuServices({ bip39Seed }).pipe(Layer.provideMerge(Inspector.live)),
+  );
+
+  const consumer = runtime.runFork(
+    Effect.flatMap(Inspector, (inspector) =>
+      Stream.runForEach(inspector.events, (event) =>
+        Effect.sync(() => console.log(event._tag)),
+      ),
+    ),
+  );
+
+  const shutdown = async () => {
+    await Effect.runPromise(Fiber.interrupt(consumer));
+    await runtime.dispose();
+  };
+
+  return { runtime, shutdown };
+};
+```
+
+Call `shutdown` at application exit. Disposing the runtime also closes the queue behind `Inspector.live`, so events emitted after that are dropped.
+
+## Event families
+
+All in `src/inspector/events.ts`; `LinkshuInspectorEvent` is their union.
+
+| Tag                     | Fields                                                                               | Emitted when                                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `OperationSucceeded`    | `name`, `params`, `result`                                                           | A public operation finished.                                                                  |
+| `OperationFailed`       | `name`, `params`, `error`                                                            | A public operation failed with a typed error (the tagged error object is `error`).            |
+| `TokenLifecycleChanged` | `rowId`, `from`, `to`, `reason`                                                      | A row was inserted (`from: null`), transitioned, or had its text rewritten (`from === to`).   |
+| `CounterAdvanced`       | `mint`, `unit`, `keysetId`, `from`, `to`, `reason`                                   | A deterministic counter moved; `reason` is `used`, `collision-recovery`, or `restore`.        |
+| `QuoteStateChanged`     | `flow`, `quoteId`, `mint`, `state`                                                   | A mint/melt quote was observed in a new state while `topup`, `autoswap`, or `melt` polled it. |
+| `LightningFeeProbed`    | `mint`, `probeMint`, `meltQuoteId`, `mintQuoteId`, `amount`, `feeReserve`, `percent` | A fee probe measured a mint's Lightning fee.                                                  |
+
+Operation `name` is `<vertical>.<method>` in camelCase, matching the service and method you called: `receive.receive`, `topup.resumePending`. One operation usually produces several rows — a `send.send` is bracketed by the `CounterAdvanced` and `TokenLifecycleChanged` rows it caused.
+
+Correlate rows by the ids inside `params`/`result`: `rowId` links a lifecycle event to the operation that caused it, `quoteId` links quote-state changes to a topup or melt.
+
+## What events never contain
+
+No event carries seed material or proof secrets. Token text _is_ proof secrets, so receipts arrive without their `tokenText`, `receive.receive` has empty `params`, melt and fee-probe params carry the mint but not the invoice, and a `QuoteLockingKey` never appears. Everything else — mint urls, amounts, quote ids, row ids, tagged errors — is in the clear; treat a persisted event log as sensitive metadata, not as secrets.
+
+## Consumers in the repo
+
+- **CLI** (`apps/linkshu-cli/src/stderrInspector.ts`): `--verbose` provides a layer that writes `[linkshu] <Tag> {…fields}` per event to stderr, so stdout stays the command's result (`send` prints the bare token). Try it: `bun run linkshu --verbose --data-dir /tmp/wallet balance`.
+- **Web app** (`apps/web-app/src/devtools/inspector/linkshuInspector.ts`): a layer that maps each event to one `cashu`-channel row for the app inspector, gated per event on the inspector setting. Open `#advanced/inspector/timeline` or the standalone `inspector.html` in dev to watch it.
+
+For tests, `recordingInspector()` from `src/testing/inspector.ts` collects events into an array; see [testing.md](./testing.md).
+
+## Emitting from a new vertical (contributors)
+
+Wrap the public operation in `inspectOperationWith(inspector, name, params, redactResult)` from `src/internal/operations.ts`; it emits `OperationSucceeded`/`OperationFailed` without altering the outcome. `redactResult` must strip anything a holder could spend — pass `redactReceipt` for anything carrying `tokenText`. `inspectOperation` is the shorthand when the result is already safe. Lifecycle and counter events come for free from `transitionRow`/`insertRowInState` and `advanceCounterTo`.
+
+Events are constructed with `disableValidation: true` so a bad field surfaces in the consumer, not as a failed wallet operation. Assert on `recordingInspector().events` in the vertical's unit test.
+
+## Related
+
+- [errors.md](./errors.md) — the tagged errors `OperationFailed` carries
+- [concepts.md](./concepts.md) — row states and counter reasons the events describe
+- [testing.md](./testing.md) — asserting on emitted events

--- a/packages/linkshu/docs/lightning-utilities.md
+++ b/packages/linkshu/docs/lightning-utilities.md
@@ -1,0 +1,129 @@
+# Lightning utilities
+
+Helpers that need no wallet runtime: preview a bolt11 invoice, size retry amounts, resolve LNURL-pay and lightning addresses, and fetch fiat rates. None of them use Effect; the network ones return Promises and throw plain `Error`s.
+
+## Quick example
+
+Prerequisites: none beyond network access; the result feeds [`Melt`](./melt.md), which needs a configured runtime.
+
+```ts
+import {
+  Bolt11Invoice,
+  fetchLnurlInvoiceForTarget,
+  getLightningInvoicePreview,
+  isLightningAddress,
+} from "@linky/linkshu";
+
+const invoiceFor = async (target: string, amountSat: number) => {
+  if (!isLightningAddress(target)) throw new Error("not a lightning address");
+  const { pr, successAction } = await fetchLnurlInvoiceForTarget(
+    target,
+    amountSat,
+    "from linky",
+  );
+  const preview = getLightningInvoicePreview(pr);
+  return {
+    invoice: Bolt11Invoice.make(pr), // the branded type MeltDraft takes
+    amountSat: preview?.amountSat ?? null,
+    successAction,
+  };
+};
+```
+
+`Bolt11Invoice.make` throws on text that does not start with `ln`; decode with `Schema.decodeUnknownOption(Bolt11Invoice)` when the text is untrusted.
+
+## Invoice preview (`invoice/preview.ts`)
+
+| Export                                           | Returns                           | Notes                                                                                                                                                      |
+| ------------------------------------------------ | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getLightningInvoicePreview(raw)`                | `LightningInvoicePreview \| null` | `{ amountSat, description, expiresAtSec, invoice }`; null unless the text starts with `lnbc`/`lntb`/`lnbcrt`. Missing expiry tag → 1 h after the timestamp |
+| `parseBolt11AmountMsat(invoice)`                 | `number \| null`                  | amount from the human-readable part, rounded up to whole msat                                                                                              |
+| `getLightningInvoiceDescriptionHashHex(invoice)` | `string \| null`                  | the `h` tag as hex; used to verify LNURL metadata                                                                                                          |
+
+These are permissive by design: they decode fields for display and never verify the signature or authorize a payment.
+
+## Amount fallback (`invoice/paymentAmountFallback.ts`)
+
+For LNURL targets, the app can re-fetch the invoice at a lower amount when the requested amount plus fees does not fit the balance. The package supplies the ladder; the retry loop stays app-side (`useLightningPaymentsDomain.ts`).
+
+| Export                                                          | Use                                                                                                                                     |
+| --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `buildPaymentAmountAttempts(requestedSat, availableSat)`        | `[requested]` normally; when the request equals the whole balance, a descending list leaving `0, 1, 2, 3, 5, 8, 13, 21` sat as fee room |
+| `buildPaymentFailureAmountAttempts(requestedSat, errorMessage)` | lower amounts to try after a retryable failure: first the parsed shortage, then the fee ladder                                          |
+| `isRetryablePaymentAmountFailure(errorMessage)`                 | matches "insufficient funds", "not enough funds", "amount out of lnurl range", …                                                        |
+| `getPaymentAmountShortage(errorMessage)`                        | parses `provided: X, needed: Y`, `need X, have Y`, or `fee: N`                                                                          |
+
+These work on error _messages_. `Melt` itself fails with a typed `InsufficientFunds` carrying `required`/`available`; render that (Linky's `describeTaggedCashuError` produces `need X, have Y`) before feeding it here.
+
+## LNURL-pay and withdraw (`lnurl/lnurlPay.ts`)
+
+| Export                                                                      | Use                                                                                                                    |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `isLnurlPayTarget(value)`                                                   | lightning address, bech32 `lnurl1…`, `lnurlp://`, or https URL                                                         |
+| `resolveLnurlPayRequestUrl(value)`                                          | the LUD-06 request URL; throws on invalid input                                                                        |
+| `getLnurlPayDisplayText(value)`                                             | short label for UI                                                                                                     |
+| `inferLightningAddressFromLnurlTarget(value)`                               | `user@host` when derivable                                                                                             |
+| `fetchLnurlPayPreview(target, fallback?)`                                   | `LnurlPayPreview`: `callback`, min/max sat and msat, `description`, `commentAllowed`, `metadataRaw`                    |
+| `fetchLnurlInvoiceForTarget(target, amountSat, comment?, fallback?)`        | `LnurlPayInvoiceResult { pr, lightningAddress, successAction }`; verifies the metadata hash and amount (LUD-06 step 7) |
+| `isLnurlWithdrawTarget`, `fetchLnurlWithdrawPreview`, `redeemLnurlWithdraw` | LUD-03 withdraw; recipe below                                                                                          |
+| `LnurlTagMismatchError`                                                     | thrown when the server's `tag` is not the expected one                                                                 |
+
+`fallback: LnurlFallback = (url) => Promise<Response>` is tried when the direct fetch fails — Linky routes through its `/api/lnurlp` proxy for CORS-blocked servers (`apps/web-app/src/lnurlPay.ts`). Fixed-amount LNURLs that re-quote in fiat are followed within 2 % drift.
+
+### LNURL-withdraw
+
+The withdrawing service pays an invoice you give it, so the invoice comes from a [topup](./topup.md): preview the offer, open a topup for an amount inside its range, hand the topup's invoice to the callback, and let the topup handle complete on its own.
+
+```ts
+import { fetchLnurlWithdrawPreview, redeemLnurlWithdraw } from "@linky/linkshu";
+import type { TopupHandle } from "@linky/linkshu";
+
+/** `startTopup` runs `Topup.start` on your runtime (see topup.md). */
+const withdraw = async (
+  target: string,
+  startTopup: (amountSat: number) => Promise<TopupHandle>,
+) => {
+  const preview = await fetchLnurlWithdrawPreview(target);
+  const handle = await startTopup(preview.amountSat);
+  await redeemLnurlWithdraw({
+    callback: preview.callback,
+    k1: preview.k1,
+    invoice: handle.quote.invoice,
+  });
+  return handle; // `handle.result` resolves once the service has paid
+};
+```
+
+`LnurlWithdrawPreview` also carries `minAmountSat`/`maxAmountSat` and `description` for an amount picker. `redeemLnurlWithdraw` resolves when the service accepted the request, not when the payment arrived; that is the topup's result.
+
+## Lightning address helpers (`lnurl/lightningAddress.ts`)
+
+`isLightningAddress`, `splitLightningAddress` → `{ user, domain } | null`, `stripLightningPrefix`, `getLightningAddressRequestUrl` (lowercases user and domain; LUD-16 servers reject mixed case). All four are on the main entry.
+
+The same file is also exported as **`@linky/linkshu/lightning-address`**. Use the subpath when the importing code must not pull cashu-ts or Effect into its bundle — the web app's `utils/lightningAddress.ts` and the site's serverless functions.
+
+## Fiat rates (`fiatRates.ts`)
+
+| Export                         | Use                                                                            |
+| ------------------------------ | ------------------------------------------------------------------------------ |
+| `FiatRates`                    | Schema/type: `chfPerBtc`, `czkPerBtc`, `eurPerBtc`, `usdPerBtc`, `fetchedAtMs` |
+| `fetchFiatRates(signal)`       | Coinbase BTC rates → `FiatRates \| null` (null on HTTP or shape errors)        |
+| `decodeFiatRates(raw)`         | parse a cached JSON string                                                     |
+| `isFiatRatesStale(rates)`      | older than `FIAT_RATES_TTL_MS` (10 min) or null                                |
+| `FIAT_RATES_CACHE_STORAGE_KEY` | storage key for the cached JSON                                                |
+
+`useFiatRates.ts` shows the loop: read cache → if stale, fetch → write cache → repeat every TTL.
+
+## Errors
+
+| Source                   | Failure shape                                                                               | What to do                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| preview / amount helpers | `null` or an empty array                                                                    | treat as "unknown"; never throw            |
+| LNURL fetchers           | thrown `Error` (message from the server's `reason` when present) or `LnurlTagMismatchError` | show the message; try the `fallback` proxy |
+| `fetchFiatRates`         | `null`, or a rejected promise on abort/network                                              | keep the last cached value                 |
+
+## Related
+
+- [melt.md](./melt.md)
+- [topup.md](./topup.md) — LNURL-withdraw redeems against a topup invoice
+- [errors.md](./errors.md) — why these are not tagged errors

--- a/packages/linkshu/docs/melt.md
+++ b/packages/linkshu/docs/melt.md
@@ -1,0 +1,113 @@
+# Melt
+
+`Melt` pays a bolt11 invoice from one mint's balance. Use it for "pay invoice" and for the invoice you fetched from an LNURL/lightning address. Quote first to show the price, then melt with the same invoice and the quote id.
+
+## Quick example
+
+Prerequisites: a configured runtime ([getting-started.md](./getting-started.md)) and a balance at `mint` covering the invoice plus fee reserve ([receive.md](./receive.md) or [topup.md](./topup.md)). Get the invoice from the user or from [lightning-utilities.md](./lightning-utilities.md).
+
+```ts
+import { Effect } from "effect";
+import { Melt, MeltDraft } from "@linky/linkshu";
+import type { Bolt11Invoice, MeltQuote, MintUrl } from "@linky/linkshu";
+
+// Step 1: price it. Touches no row; show `amount + feeReserve` to the user.
+const priceInvoice = (mint: MintUrl, invoice: Bolt11Invoice) =>
+  Effect.gen(function* () {
+    const melt = yield* Melt;
+    return yield* melt.quote(new MeltDraft({ mint, invoice }));
+  });
+
+// Step 2: once the user confirms, pay the priced quote.
+const payQuoted = (invoice: Bolt11Invoice, quote: MeltQuote) =>
+  Effect.gen(function* () {
+    const melt = yield* Melt;
+    return yield* melt.melt(
+      new MeltDraft({ mint: quote.mint, invoice, quoteId: quote.quoteId }),
+    );
+  });
+```
+
+The receipt carries `paidAmount`, `feePaid`, and `changeAmount`. Passing `quoteId` reuses the priced quote; omitting it makes `melt` request a fresh one (the CLI's `melt <invoice>` does that, `apps/linkshu-cli/src/commands.ts`). Keep the `MeltQuote` until the receipt arrives: it is what you need to recover an interrupted payment.
+
+## How it works
+
+`quote` costs nothing and touches no row. `melt` does the following, in order:
+
+1. **Price.** Fetch (or re-check) the melt quote. It must be `UNPAID` and not past `expiresAt`.
+2. **Select sources.** `accepted` rows at `mint`, NUT-07 filtered; fully spent rows are marked `error`. Needs `amount + feeReserve`, else `InsufficientFunds`.
+3. **Swap fee-inclusive.** Exactly `amount + feeReserve` (plus its own cashu input fee) is swapped out under the counter lock.
+4. **Persist before melting.** The remainder becomes an `accepted` row (`melt-keep`); the melt inputs become a `reserved` row; the consumed source rows are removed. Funds are never outside the store.
+5. **Melt and settle.**
+
+| Mint answer                       | Result                                                                                                              |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `PAID`                            | change proofs become an `accepted` row (`melt-change`); the `reserved` row is removed; receipt resolves             |
+| `UNPAID`                          | the `reserved` row flips back to `accepted`; `PaymentFailed`                                                        |
+| `PENDING`                         | polled briefly; `PAID`/`UNPAID` as above, still pending → `PaymentFailed` and the inputs **stay `reserved`**        |
+| response lost (`MintUnreachable`) | the quote is checked once; `PAID` finishes normally, otherwise `MintUnreachable` and the inputs **stay `reserved`** |
+| definitive rejection              | the `reserved` row flips back to `accepted`; `MintRejected`                                                         |
+
+`status(quote)` re-reads a quote's state (`"UNPAID" | "PENDING" | "PAID" | null`) without side effects.
+
+### Recovering an interrupted melt
+
+A `reserved` row means the mint may still hold the inputs. Do not pay the invoice again until you know what happened; `melt` with the same `quoteId` fails with `PaymentFailed` while the quote is not `UNPAID`. In order:
+
+1. Keep the `MeltQuote`. `PaymentFailed` also carries `quoteId` and `mint`.
+2. Find the row: `Tokens.list` filtered to `state === "reserved"`.
+3. Ask the mint with `status(quote)`:
+   - `PAID` — the payment went through. `Validation.checkRow(rowId)` marks the inputs `error` once the mint reports them spent; change the response never delivered is recovered by [`Restore`](./restore.md) at that mint.
+   - `UNPAID` — the mint reversed it. `checkRow` reports `live`; call `Tokens.returnToWallet(rowId)` to flip the row back to `accepted`, then decide whether to pay again with a new quote.
+   - `PENDING` or no answer — leave the row `reserved` and check again later.
+
+`checkAll` and `deleteSpent` skip `reserved` rows, so nothing else resolves them for you.
+
+## Inputs and outputs
+
+`MeltDraft` (`melt/domain.ts`):
+
+| Field     | Type                       | Notes                                                |
+| --------- | -------------------------- | ---------------------------------------------------- |
+| `mint`    | `MintUrl`                  | mint to pay from                                     |
+| `invoice` | `Bolt11Invoice`            | must start with `ln`                                 |
+| `quoteId` | `Schema.optional(QuoteId)` | reuse a quote from `quote`; must belong to `invoice` |
+
+`MeltQuote` (from `quote`):
+
+| Field        | Type                         | Notes                                   |
+| ------------ | ---------------------------- | --------------------------------------- |
+| `quoteId`    | `QuoteId`                    |                                         |
+| `mint`       | `MintUrl`                    |                                         |
+| `amount`     | `Amount`                     | invoice amount in sat                   |
+| `feeReserve` | `NonNegativeAmount`          | Lightning fee reserve the mint asks for |
+| `expiresAt`  | `Schema.NullOr(UnixSeconds)` | null when the mint sets none            |
+
+`MeltReceipt`:
+
+| Field          | Type                | Notes                                                          |
+| -------------- | ------------------- | -------------------------------------------------------------- |
+| `mint`         | `MintUrl`           |                                                                |
+| `quoteId`      | `QuoteId`           |                                                                |
+| `paidAmount`   | `Amount`            | the invoice amount                                             |
+| `feeReserve`   | `NonNegativeAmount` | what was reserved                                              |
+| `feePaid`      | `NonNegativeAmount` | actual Lightning fee, `inputs - paidAmount - change`; may be 0 |
+| `changeAmount` | `NonNegativeAmount` | returned as a fresh `accepted` row                             |
+
+## Errors
+
+| Tag                  | Kind               | When                                                                                                                    | What to do                                                                                                                       |
+| -------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `InsufficientFunds`  | definitive         | balance below `amount + feeReserve` (`required` carries the sum)                                                        | choose another mint or a lower amount; the app's LN-address ladder uses `required`/`available` to size the retry                 |
+| `QuoteExpired`       | definitive         | quote past `expiresAt`                                                                                                  | request a new quote                                                                                                              |
+| `PaymentFailed`      | definitive/pending | mint reported `UNPAID`, the quote was not `UNPAID` when melting started, or the payment stayed `PENDING`; read `detail` | inputs back in balance: you may pay again with a new quote. Inputs still `reserved`: follow the recovery steps above             |
+| `MintRejected`       | definitive         | malformed quote, quote/invoice mismatch, or mint rejection                                                              | surface `detail`; balance intact                                                                                                 |
+| `MintUnreachable`    | transient          | network/timeout/5xx                                                                                                     | no `reserved` row: you may retry. A `reserved` row exists: the melt call was sent; follow the recovery steps before paying again |
+| `CounterLockTimeout` | transient          | counter lease held elsewhere                                                                                            | you may retry                                                                                                                    |
+
+## Related
+
+- [fee-probe.md](./fee-probe.md) — estimate the fee before there is an invoice
+- [lightning-utilities.md](./lightning-utilities.md) — invoice preview, LNURL invoice fetch, amount ladder
+- [validation.md](./validation.md) — `checkRow` on `reserved` rows
+- [errors.md](./errors.md)

--- a/packages/linkshu/docs/mints.md
+++ b/packages/linkshu/docs/mints.md
@@ -1,0 +1,87 @@
+# Mints
+
+`Mints` answers "what do I know about this mint" and "which mints does this wallet have state for". Use `info` for the mint settings page (name, fees, multi-part payment support, icon) and `knownMints` when you need every mint the wallet has touched.
+
+## Quick example
+
+Prerequisites: a configured runtime ([getting-started.md](./getting-started.md)); `info` needs the mint reachable, `knownMints` works offline.
+
+Two fields need their units first. `inputFeePpk` is the mint's cashu input fee in parts per thousand per proof spent: spending 10 proofs at 100 ppk costs 1 sat. `supportsMpp` says the mint accepts multi-part Lightning payments (NUT-15), so one invoice can be paid in parts from several mints.
+
+```ts
+import { Effect } from "effect";
+import { Mints, parseMintUrl } from "@linky/linkshu";
+import type { MintUrl } from "@linky/linkshu";
+
+const describeMint = (raw: string) =>
+  Effect.gen(function* () {
+    const mint = parseMintUrl(raw);
+    if (mint === null) return null;
+    const mints = yield* Mints;
+    const info = yield* mints.info(mint);
+    const fee =
+      info.inputFeePpk === null ? "unknown" : `${info.inputFeePpk} ppk`;
+    return `${info.name ?? info.url}: input fee ${fee}, multi-part payments ${info.supportsMpp ? "yes" : "no"}`;
+  });
+
+const listMints: Effect.Effect<
+  ReadonlyArray<MintUrl>,
+  never,
+  Mints
+> = Effect.flatMap(Mints, (mints) => mints.knownMints);
+```
+
+Always go through `parseMintUrl` (or `MintUrl.make` on already-normalized input): the package compares mints by their normalized form without a trailing slash, and two spellings of one mint would fork its counters.
+
+## How it works
+
+`info(mint)` loads the mint's published info (NUT-06), keysets, and keys, and returns a `MintInfo` (`mint/domain.ts`):
+
+| Field             | Type                                                   | Meaning                                                                                                      |
+| ----------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `url`             | `MintUrl`                                              | normalized                                                                                                   |
+| `name`            | `Schema.NullOr(Schema.String)`                         | published `name`, or null                                                                                    |
+| `inputFeePpk`     | `Schema.NullOr(Schema.Int.pipe(Schema.nonNegative()))` | cashu input fee of the keyset the wallet spends from (lowest-fee active `sat` keyset); null when unpublished |
+| `supportsMpp`     | `Schema.Boolean`                                       | NUT-15 multi-part payments                                                                                   |
+| `isFakeLightning` | `Schema.Boolean`                                       | known test URL (`localhost`, `127.0.0.1`, `testnut.cashu.space`) or info text advertising a FakeWallet       |
+| `iconUrl`         | `Schema.NullOr(Schema.String)`                         | an icon URL found in the published info, resolved against the mint URL                                       |
+
+`inputFeePpk` is the **cashu** fee; the Lightning fee is a separate figure from [fee-probe.md](./fee-probe.md).
+
+### The known-mint set
+
+`knownMints` is the union of the mints named by stored rows (any state) and the _seen_ mints. There is no explicit "add" call: a mint is recorded as seen the first time any operation loads its wallet successfully — `Mints.info` included. So to register a mint, call `info` on it. Nothing removes a seen mint; `Restore.wipeSeedBoundState` leaves this set alone. Restore defaults to this set when you pass no `mints`.
+
+Successful wallet loads are cached for the runtime's lifetime; a failed load is evicted so the next call retries.
+
+### Icons (`mint/icons.ts`)
+
+Pure helpers, no runtime needed:
+
+| Export                               | Use                                                                          |
+| ------------------------------------ | ---------------------------------------------------------------------------- |
+| `GENERIC_MINT_ICON_DATA_URL`         | inline SVG fallback                                                          |
+| `getMintIconOverride(host)`          | hand-picked icon URLs for well-known mints, by host; null otherwise          |
+| `findMintInfoIconValue(value, seen)` | deep search of a NUT-06 info object for an icon-ish string; pass `new Set()` |
+| `isTestMintUrl(mint)`                | true for local/test hosts                                                    |
+
+## Inputs and outputs
+
+`info(mint: MintUrl)`: `Effect<MintInfo, MintUnreachable | MintRejected>` — fields above.
+
+`knownMints`: `Effect<ReadonlyArray<MintUrl>>`, sorted.
+
+## Errors
+
+| Tag               | Raised by | When                                                | What to do                                    |
+| ----------------- | --------- | --------------------------------------------------- | --------------------------------------------- |
+| `MintUnreachable` | `info`    | network/timeout/5xx during wallet load              | retry later; show cached info if you keep any |
+| `MintRejected`    | `info`    | the mint answered but its info/keysets are unusable | surface `detail`                              |
+
+`knownMints` never fails.
+
+## Related
+
+- [fee-probe.md](./fee-probe.md) — the Lightning side of fees
+- [restore.md](./restore.md) — consumer of `knownMints`
+- [ports.md](./ports.md)

--- a/packages/linkshu/docs/ports.md
+++ b/packages/linkshu/docs/ports.md
@@ -1,0 +1,170 @@
+# Ports
+
+How to implement the three platform ports so linkshu can run on your storage. You need this when bringing the package to a new platform, or when changing the web app's Evolu/localStorage adapters.
+
+## Overview
+
+A port is an Effect `Context.Tag`; you satisfy it with a `Layer` that builds the service object. Ports are deliberately dumb: they persist what they are given and decide nothing.
+
+| Port            | Tag                     | Layer helper                      | In-memory default       |
+| --------------- | ----------------------- | --------------------------------- | ----------------------- |
+| `KeyValueStore` | `linkshu/KeyValueStore` | `Layer.sync(KeyValueStore, make)` | `inMemoryKeyValueStore` |
+| `TokenStore`    | `linkshu/TokenStore`    | `Layer.sync(TokenStore, make)`    | `inMemoryTokenStore`    |
+| `CashuSeed`     | `linkshu/CashuSeed`     | `CashuSeed.fromBytes(bip39Seed)`  | none (always yours)     |
+
+`linkshuServices(config)` and `runLinkshu(config, …)` build `CashuSeed` from `config.bip39Seed` and fall back to the in-memory stores when you omit `keyValueStore`/`tokenStore`.
+
+Two complete, short implementations to copy from:
+
+- `apps/linkshu-cli/src/fileKeyValueStore.ts` and `fileTokenStore.ts` — one JSON file each, safe across processes.
+- `apps/web-app/src/platform/linkshu/localStorageKeyValueStore.ts` and `evoluTokenStore.ts` — the browser adapters.
+
+## `KeyValueStore`
+
+Durable string storage plus two lease primitives. Every method returns an `Effect` that must not fail (`Effect.Effect<…>` with `never` error); throw only for genuine storage corruption.
+
+| Method                        | Contract                                                                                                                       |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `get(key)`                    | Stored value or `null`.                                                                                                        |
+| `set(key, value)`             | Durable write.                                                                                                                 |
+| `remove(key)`                 | Delete; no-op if absent.                                                                                                       |
+| `listKeys(prefix)`            | All stored keys starting with `prefix`. Drives seed-bound wipes and pending-record scans.                                      |
+| `tryAcquireLease(key, ttlMs)` | Atomically claim `key` for `ttlMs`; return a fresh `LeaseId`, or `null` if a live lease is held. Expired leases are claimable. |
+| `releaseLease(key, lease)`    | Delete the lease only if `lease` is still the live one; otherwise no-op.                                                       |
+
+What the port must guarantee versus what the package handles:
+
+| Port guarantees                                                 | Package handles                                                |
+| --------------------------------------------------------------- | -------------------------------------------------------------- |
+| One `tryAcquireLease` wins when several race the same key       | Retrying acquisition and timing out                            |
+| A lease past its TTL is claimable                               | Choosing TTLs, which keys to lock, releasing on exit/interrupt |
+| A foreign `LeaseId` cannot release a lease                      | Mapping a timeout to `CounterLockTimeout`                      |
+| Values survive a restart (unless you are the in-memory default) | Key naming (`linkshu.` prefix) and value encoding              |
+
+Values never contain seed material. If your storage is shared with other data, namespace it on your side; `listKeys` must then only see this store's own entries.
+
+The atomic claim is the hard part. The CLI's `fileKeyValueStore.ts` keeps values and leases in one JSON file behind `makeJsonFile` (`apps/linkshu-cli/src/jsonFile.ts`), whose `file.modify(change)` is a locked read-modify-write: `change` gets the freshest contents and returns `[nextContents, result]`, and no other writer runs in between. `without(record, key)` is a local helper that drops one key. With those two, the lease primitives are:
+
+```ts
+tryAcquireLease: (key, ttlMs) =>
+  Effect.flatMap(Clock.currentTimeMillis, (now) =>
+    file.modify((state) => {
+      const held = state.leases[key];
+      if (held !== undefined && held.expiresAt > now) return [state, null];
+      const lease = LeaseId.make(crypto.randomUUID());
+      return [
+        { ...state, leases: { ...state.leases, [key]: { lease, expiresAt: now + ttlMs } } },
+        lease,
+      ];
+    }),
+  ),
+
+releaseLease: (key, lease) =>
+  file.modify((state) =>
+    state.leases[key]?.lease === lease
+      ? [{ ...state, leases: without(state.leases, key) }, undefined]
+      : [state, undefined],
+  ),
+```
+
+Read the clock through Effect's `Clock`, not `Date.now()`, so tests can drive time. When your storage has no compare-and-swap (localStorage), write then re-read and confirm your id won — see `localStorageKeyValueStore.ts`.
+
+Wiring a layer from your service object (skeleton, not compilable as-is: `makeMyKeyValueStore` must return all six methods):
+
+```ts
+import { KeyValueStore } from "@linky/linkshu";
+import type { KeyValueStoreService } from "@linky/linkshu";
+import { Layer } from "effect";
+
+declare const makeMyKeyValueStore: () => KeyValueStoreService;
+
+export const myKeyValueStore: Layer.Layer<KeyValueStore> = Layer.sync(
+  KeyValueStore,
+  makeMyKeyValueStore,
+);
+```
+
+## `TokenStore`
+
+A row store. The package holds no row cache: it calls `loadAll` before every decision, so `loadAll` must reflect your own earlier `insert`/`update`/`remove` calls immediately, even when the underlying database commits asynchronously (the web app's Evolu adapter keeps a write overlay for exactly this reason).
+
+| Method                | Contract                                                                                                        |
+| --------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `insert(NewTokenRow)` | Assign the `id` and `createdAt`, persist, return the `StoredTokenRow`. Ids may derive from `originalTokenText`. |
+| `update(id, patch)`   | Apply only the present fields of `TokenRowPatch` (`tokenText`, `state`, `error`). Unknown id: no-op.            |
+| `remove(id)`          | May be a soft delete; removed rows never reappear in `loadAll`.                                                 |
+| `loadAll`             | Every live row. An `Effect` value, not a function.                                                              |
+
+`StoredTokenRow`:
+
+| Field               | Type             | Notes                                                              |
+| ------------------- | ---------------- | ------------------------------------------------------------------ |
+| `id`                | `TokenRowId`     | Stable; the package refers to rows by it                           |
+| `originalTokenText` | `TokenText`      | Encoding the row was created from; dedup identity, never rewritten |
+| `tokenText`         | `TokenText`      | Current spendable encoding; rewritten by swaps and validation      |
+| `state`             | `TokenState`     | Written only by the package                                        |
+| `error`             | `string \| null` | Serialized tagged error; `null` outside `error`                    |
+| `createdAt`         | `UnixSeconds`    | Assigned on insert                                                 |
+
+**The platform never decides states.** Do not default, normalize, or "fix" a state on write. Do not delete rows on your own judgement (the web app's delete confirmation is the one exception and calls `remove` explicitly). If a legacy row cannot be represented — its text is not a cashu token — skip it in `loadAll` rather than invent one.
+
+The CLI's `fileTokenStore.ts` is the shortest real one: a JSON array of `StoredTokenRow`, written through the same `file.modify` as above:
+
+```ts
+insert: (row) =>
+  Effect.flatMap(Clock.currentTimeMillis, (millis) =>
+    file.modify((rows) => {
+      const stored = new StoredTokenRow({
+        id: TokenRowId.make(crypto.randomUUID()),
+        originalTokenText: row.originalTokenText,
+        tokenText: row.tokenText,
+        state: row.state,
+        error: row.error,
+        createdAt: UnixSeconds.make(Math.floor(millis / 1000)),
+      });
+      return [[...rows, stored], stored];
+    }),
+  ),
+```
+
+**Deterministic ids.** A store may derive `id` from `originalTokenText` (the web app's Evolu adapter does). Then inserting the same original text again is an upsert onto the same row — it overwrites, and revives a soft-deleted row — and updates to a removed row are ignored. The package is written for both id models; if yours is deterministic, run your flows against `deterministicIdTokenStore` from `src/testing` ([testing.md](./testing.md)) to see the same collisions.
+
+## `CashuSeed`
+
+```ts
+import { Bip39Seed, CashuSeed } from "@linky/linkshu";
+
+const seedLayer = (seedBytes: Uint8Array) =>
+  CashuSeed.fromBytes(Bip39Seed.make(seedBytes));
+```
+
+You only build this yourself when assembling layers by hand; `linkshuServices` does it from `config.bip39Seed`. The package is the trust boundary the seed exists for — never derive keys or counters on the platform side.
+
+## In-memory defaults and durability across runtimes
+
+`inMemoryKeyValueStore` and `inMemoryTokenStore` are `Layer.sync`, so every runtime built from them gets a fresh, empty store. To model a restart (two runtimes over one storage) create the instances once and wrap them with `Layer.succeed`:
+
+```ts
+import {
+  KeyValueStore,
+  makeInMemoryKeyValueStore,
+  makeInMemoryTokenStore,
+  TokenStore,
+} from "@linky/linkshu";
+import { Layer } from "effect";
+
+const kv = makeInMemoryKeyValueStore();
+const tokens = makeInMemoryTokenStore();
+const layers = {
+  keyValueStore: Layer.succeed(KeyValueStore, kv),
+  tokenStore: Layer.succeed(TokenStore, tokens),
+};
+```
+
+This is what `tests/integration/helpers.ts` calls `durableStorage()`.
+
+## Related
+
+- [concepts.md](./concepts.md) — row states and the counter lease
+- [testing.md](./testing.md) — port contract tests and the deterministic-id store
+- [getting-started.md](./getting-started.md) — passing the layers to `runLinkshu`/`linkshuServices`

--- a/packages/linkshu/docs/receive.md
+++ b/packages/linkshu/docs/receive.md
@@ -1,0 +1,76 @@
+# Receive
+
+`Receive` turns pasted, scanned, or message-borne text into an `accepted` row in the wallet. Use it whenever token text arrives from outside: a QR scan, a paste, a chat message, a URL, an npub.cash payout. One call parses, dedups, re-signs the proofs at the mint, and persists the result.
+
+## Quick example
+
+Prerequisites: a seed and, for anything but a throwaway wallet, durable stores — see [getting-started.md](./getting-started.md). The text comes from your scanner or paste handler.
+
+```ts
+import { Effect } from "effect";
+import { Receive, ReceiveDraft, runLinkshu } from "@linky/linkshu";
+import type { Bip39Seed, ReceiveReceipt } from "@linky/linkshu";
+
+const receiveText = (
+  bip39Seed: Bip39Seed,
+  text: string,
+): Promise<ReceiveReceipt> =>
+  runLinkshu(
+    { bip39Seed },
+    Effect.gen(function* () {
+      const receive = yield* Receive;
+      return yield* receive.receive(new ReceiveDraft({ text }));
+    }),
+  );
+```
+
+The receipt carries `amount`, `unit`, `mint`, and the `rowId` of the new `accepted` row. A failure rejects the promise with one of the tagged errors below; wrap the effect in `Effect.either` to get it as a value. In a long-lived app, run the same effect on your `ManagedRuntime` instead of `runLinkshu`.
+
+## How it works
+
+1. **Extract.** `extractTokenText` finds a token inside arbitrary text: bare `cashuA…`/`cashuB…`, `cashu:`/`web+cashu:`/`lightning:`/`nostr:` schemes, URLs carrying the token in a query parameter, hash, or path, and legacy cashu.me JSON bundles. Whitespace inside a token is compacted.
+2. **Dedup.** The extracted text is compared with every live row's `originalTokenText` and `tokenText`, in any state. A match fails with `TokenAlreadyKnown` and touches nothing. A re-paste of a token that already failed definitively therefore also reports "already known".
+3. **Persist `pending`.** A row is inserted with `originalTokenText = tokenText = extracted text` and state `pending` before the mint is contacted.
+4. **Swap.** Under the counter lock, the proofs are swapped for fresh deterministic outputs.
+5. **Persist `accepted`.** The row's `tokenText` is rewritten to the fresh encoding and the state moves to `accepted`. Only now does the receipt resolve.
+
+The package retries counter collisions at the mint automatically, so a receive on a fresh origin may take a few round-trips. If recovery fails, the last rejection surfaces as `MintRejected`.
+
+## Inputs and outputs
+
+`ReceiveDraft` (`receive/domain.ts`):
+
+| Field  | Type                    | Notes                                                   |
+| ------ | ----------------------- | ------------------------------------------------------- |
+| `text` | `Schema.NonEmptyString` | raw scanned/pasted text; the token is extracted from it |
+
+`ReceiveReceipt`:
+
+| Field       | Type           | Notes                                                              |
+| ----------- | -------------- | ------------------------------------------------------------------ |
+| `rowId`     | `TokenRowId`   | the `accepted` row                                                 |
+| `tokenText` | `TokenText`    | the re-signed encoding now stored on the row; never the input text |
+| `mint`      | `MintUrl`      | normalized (no trailing slash)                                     |
+| `unit`      | `CurrencyUnit` | from the token, `sat` when the encoding states none                |
+| `amount`    | `Amount`       | sum of the swapped proofs                                          |
+
+## Errors
+
+Transient failures (`MintUnreachable`, `CounterLockTimeout`) remove the `pending` row and leave nothing behind. Definitive failures leave an `error` row whose `error` column holds the serialized tagged error.
+
+| Tag                  | When                                                                                                                                           | Row left behind                       | What to do                                                                                                       |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `TokenParseFailed`   | no token in the text (`reason: "empty"` / `"no-token-found"`), or it does not decode or states no mint (`"undecodable"`, `detail` may explain) | none                                  | tell the user                                                                                                    |
+| `TokenAlreadyKnown`  | a row with this text exists, in any state                                                                                                      | the existing row (`rowId`), untouched | show that row                                                                                                    |
+| `TokenAlreadySpent`  | the mint reported the proofs spent (code `11001`)                                                                                              | `error`                               | nothing to recover, unless the token was only partially spent: `Tokens.returnToWallet` re-receives the live part |
+| `MintRejected`       | definitive mint rejection (`code` when known), malformed swap response, or collision recovery exhausted                                        | `error`                               | surface `detail`                                                                                                 |
+| `MintUnreachable`    | network, timeout, 5xx while loading the mint or swapping                                                                                       | none                                  | you may retry later                                                                                              |
+| `CounterLockTimeout` | another tab/process held the counter lease                                                                                                     | none                                  | you may retry                                                                                                    |
+
+## Related
+
+- [tokens.md](./tokens.md) — `returnToWallet` re-receives through the same flow; lifecycle states
+- [send.md](./send.md) — the reverse direction
+- [errors.md](./errors.md) — transient vs definitive classification
+- [inspector.md](./inspector.md) — the `receive.receive` operation and `TokenLifecycleChanged` rows
+- [../README.md](../README.md) — why dedup is by token text and why funds never leave the store

--- a/packages/linkshu/docs/restore.md
+++ b/packages/linkshu/docs/restore.md
@@ -1,0 +1,105 @@
+# Restore
+
+`Restore` recovers proofs from the seed (NUT-09) across mints and keysets. Use it on a fresh device, after a crash that lost rows, or whenever the balance looks lower than it should. It also owns `wipeSeedBoundState`, which you must call when the seed changes.
+
+## Quick example
+
+Prerequisites: a runtime built from the wallet's **original seed** ([getting-started.md](./getting-started.md)) — NUT-09 only finds proofs that seed derived. On a fresh device the store is empty and knows no mints, so pass every mint the wallet may have used.
+
+```ts
+import { Effect } from "effect";
+import { Restore, RestoreDraft } from "@linky/linkshu";
+import type { MintUrl } from "@linky/linkshu";
+
+const restoreFrom = (mints: ReadonlyArray<MintUrl>) =>
+  Effect.gen(function* () {
+    const restore = yield* Restore;
+    const report = yield* restore.restore(new RestoreDraft({ mints }));
+    console.log(report.restoredAmount, "sat in", report.rows.length, "rows");
+    return report.unavailableMints; // scan these again later
+  });
+```
+
+Omit `mints` to scan every mint the package knows (`Mints.knownMints`). Linky passes its own list (`useRestoreMissingTokens.ts`) because the app knows more candidates than the store — soft-deleted rows, the mint list, the default and main mints. Pass what you know.
+
+## How it works
+
+Per mint: load the wallet (failure → `unavailableMints`). Every `sat` keyset the mint lists now, plus every keyset it has shown this wallet before, is scanned under the counter lock:
+
+1. The secrets of every stored row (any state) are read, so nothing is imported twice.
+2. The positions just behind the counter are scanned first. If that finds nothing and the wallet has scanned this keyset before, the whole derivation tree is rescanned from zero.
+3. Only proofs that are not stored and that the mint explicitly reports `UNSPENT` are kept. A failed state check imports nothing.
+4. The proofs are persisted as `accepted` rows (`restore`), **then** the restore cursor and the deterministic counter advance past the last signature. A crash between the two costs a rescan, never the funds.
+
+A mint is either fully scanned (`scannedMints`) or reported as not scanned (`unavailableMints`) — one unreachable keyset puts the mint in the second list even if other keysets restored rows. A report can therefore carry both new `rows` and `unavailableMints`; the rows are kept, scan the listed mints again later.
+
+### What a fresh-device scan costs
+
+A seed-only recovery has no cursor, so it walks the full derivation tree of every keyset. Expect it to take noticeably longer than later restores, and to happen once; afterwards the cursor keeps later scans short.
+
+### How progress is reported
+
+`restore` returns one `RestoreReport` at the end. Live progress exists only as inspector rows: `TokenLifecycleChanged` per persisted row and `CounterAdvanced` with `reason: "restore"` per keyset. Wire the [inspector](./inspector.md) if you want a progress UI.
+
+### The seed-bound wipe
+
+Counters and cursors describe positions only the current seed can reproduce. Reusing them under a new seed would collide at the mint, so replacing or clearing the seed goes in this order: stop the old runtime, wipe over the **same durable `KeyValueStore`**, then start the new one.
+
+```ts
+import { Effect, Layer, ManagedRuntime } from "effect";
+import {
+  Inspector,
+  linkshuServices,
+  Restore,
+  runLinkshu,
+} from "@linky/linkshu";
+import type { Bip39Seed, KeyValueStore, TokenStore } from "@linky/linkshu";
+
+const switchSeed = async (
+  current: { dispose: () => Promise<void> },
+  nextSeed: Bip39Seed,
+  keyValueStore: Layer.Layer<KeyValueStore>,
+  tokenStore: Layer.Layer<TokenStore>,
+) => {
+  await current.dispose();
+  await runLinkshu(
+    { bip39Seed: nextSeed, keyValueStore },
+    Effect.flatMap(Restore, (restore) => restore.wipeSeedBoundState),
+  );
+  return ManagedRuntime.make(
+    linkshuServices({ bip39Seed: nextSeed, keyValueStore, tokenStore }).pipe(
+      Layer.provideMerge(Inspector.disabled),
+    ),
+  );
+};
+```
+
+The wipe leaves token rows, seen mints/keysets, pending topup/autoswap records, and the fee-probe cache alone. Linky runs it from `platform/linkshu/wipeLinkshuSeedBoundState.ts` whenever the cashu mnemonic changes.
+
+## Inputs and outputs
+
+`RestoreDraft` (`restore/domain.ts`):
+
+| Field   | Type                                     | Notes                        |
+| ------- | ---------------------------------------- | ---------------------------- |
+| `mints` | `Schema.optional(Schema.Array(MintUrl))` | defaults to every known mint |
+
+`RestoreReport`:
+
+| Field              | Type                       | Notes                   |
+| ------------------ | -------------------------- | ----------------------- |
+| `restoredAmount`   | `NonNegativeAmount`        | sum over new rows       |
+| `rows`             | `Schema.Array(TokenRowId)` | `accepted` rows created |
+| `scannedMints`     | `Schema.Array(MintUrl)`    | every keyset scanned    |
+| `unavailableMints` | `Schema.Array(MintUrl)`    | scan again later        |
+
+## Errors
+
+`restore` and `wipeSeedBoundState` never fail. Unreachable mints, lock timeouts, and rejected scans all land in `unavailableMints`.
+
+## Related
+
+- [topup.md](./topup.md) — interrupted claims reclaim through the same NUT-09 call
+- [validation.md](./validation.md)
+- [ports.md](./ports.md) — the `KeyValueStore` the wipe runs over
+- [../README.md](../README.md) — "Counters are sacred"

--- a/packages/linkshu/docs/send.md
+++ b/packages/linkshu/docs/send.md
@@ -1,0 +1,90 @@
+# Send
+
+`Send` swaps an exact amount out of one mint's balance and hands you an encoded token. Use it to show a QR, share a link, or attach a token to a message. The token's row starts in the state you ask for and stays in the store until the recipient claims it or you return it.
+
+## Quick example
+
+Prerequisites: a configured runtime ([getting-started.md](./getting-started.md)) and a funded balance at `mint` ([receive.md](./receive.md) or [topup.md](./topup.md)); pick the mint from `Tokens.balances.perMint`.
+
+```ts
+import { Effect } from "effect";
+import { Send, SendDraft } from "@linky/linkshu";
+import type { Amount, MintUrl } from "@linky/linkshu";
+
+const issueToken = (mint: MintUrl, amount: Amount) =>
+  Effect.gen(function* () {
+    const send = yield* Send;
+    const receipt = yield* send.send(
+      new SendDraft({ mint, amount, memo: "coffee", produceAs: "issued" }),
+    );
+    return receipt.tokenText; // show as QR / share
+  });
+```
+
+Run it with `runLinkshu` or on your `ManagedRuntime`.
+
+## How it works
+
+1. **Select sources.** Every `accepted` row at `mint` (unit `sat`) is decoded. One batched NUT-07 check drops proofs the mint reports spent; a row whose every proof is spent is marked `error` (`TokenAlreadySpent`) right away — that knowledge sticks even if the send fails afterwards.
+2. **Check funds.** `available < amount` fails with `InsufficientFunds` before any mint write.
+3. **Swap.** Under the counter lock, `amount` is swapped out into fresh send proofs plus change proofs. Counter collisions are retried by the package, as in [receive.md](./receive.md).
+4. **Persist change first.** The change proofs become a fresh `accepted` row (`send-change`).
+5. **Persist the send row** in `produceAs` state, then remove the consumed source rows. Funds are never outside the store, even if the process dies mid-flow.
+
+### Choosing `produceAs`
+
+| Value       | Use when                                                                             | Then                                                                                                         |
+| ----------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `"issued"`  | the token is shown to someone (QR, share sheet)                                      | watch it with `Validation.checkIssued`; the row is pruned once the mint reports it fully spent (= claimed)   |
+| `"pending"` | the token travels through a channel you confirm separately (chat message, HTTP POST) | on confirmed delivery drop the row with `TokenStore.remove`; on failed delivery call `Tokens.returnToWallet` |
+
+Linky's QR/share flow uses `issued`; contact payments over Nostr and payment-request POSTs use `pending`.
+
+### Fees
+
+Sends are exact-amount: the recipient receives `amount`. The mint's cashu input fee comes out of the change, so `receipt.feePaid = available - amount - changeAmount`. If the offered proofs cannot cover `amount` plus fees, the mint's own rejection is reported as `InsufficientFunds` (`required: amount`, `available`). There is no amount-degrade ladder in the package; the app decides whether to retry lower.
+
+### When the recipient never claims
+
+The `issued` row keeps the funds visible under "issued" but not in `balances`. To take them back, call `Tokens.returnToWallet(rowId)`: the encoding is re-received, so the copy the recipient holds dies at the mint. See [tokens.md](./tokens.md#returntowallet).
+
+## Inputs and outputs
+
+`SendDraft` (`send/domain.ts`):
+
+| Field       | Type                                     | Notes                                         |
+| ----------- | ---------------------------------------- | --------------------------------------------- |
+| `mint`      | `MintUrl`                                | the mint to spend at; sends never cross mints |
+| `amount`    | `Amount`                                 | positive integer sat                          |
+| `memo`      | `Schema.optional(Schema.NonEmptyString)` | embedded in the token                         |
+| `produceAs` | `"issued" \| "pending"`                  | starting state of the produced row            |
+
+`SendReceipt`:
+
+| Field          | Type                | Notes                                                           |
+| -------------- | ------------------- | --------------------------------------------------------------- |
+| `rowId`        | `TokenRowId`        | the send row, in `produceAs` state                              |
+| `tokenText`    | `TokenText`         | v4 encoding to hand out                                         |
+| `mint`         | `MintUrl`           |                                                                 |
+| `unit`         | `CurrencyUnit`      | always `sat`                                                    |
+| `amount`       | `Amount`            | equals the drafted amount                                       |
+| `changeAmount` | `NonNegativeAmount` | persisted as a fresh `accepted` row before the receipt resolved |
+| `feePaid`      | `NonNegativeAmount` | cashu input fee the swap cost                                   |
+
+## Errors
+
+On every failure, unspent sources remain available; rows the NUT-07 pre-check found fully spent have already been marked `error`, whatever happens next.
+
+| Tag                  | When                                                                                                        | What to do                                                      |
+| -------------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `InsufficientFunds`  | balance at `mint` (after the NUT-07 filter) is below `amount`, or the swap could not cover amount plus fees | pick another mint (`Tokens.balances.perMint`) or a lower amount |
+| `MintUnreachable`    | network/timeout/5xx while loading the mint, checking states, or swapping                                    | you may retry later                                             |
+| `MintRejected`       | definitive rejection, malformed swap proofs, or collision retries exhausted                                 | surface `detail`                                                |
+| `CounterLockTimeout` | the counter lease was held elsewhere                                                                        | you may retry                                                   |
+
+## Related
+
+- [tokens.md](./tokens.md) — `reserve`/`markIssued`/`markExternalized`, `returnToWallet`, balances
+- [validation.md](./validation.md) — `checkIssued` prunes claimed sends
+- [receive.md](./receive.md)
+- [errors.md](./errors.md)

--- a/packages/linkshu/docs/testing.md
+++ b/packages/linkshu/docs/testing.md
@@ -1,0 +1,160 @@
+# Testing
+
+How to test code that uses linkshu, and how the package tests itself. Consumers (an adapter, a CLI command, a wallet screen) need the first half; the second half is for changing the package.
+
+## Two kinds of tests
+
+| Suite       | Where                         | Mint                              | Run                                                |
+| ----------- | ----------------------------- | --------------------------------- | -------------------------------------------------- |
+| Unit        | `src/**/*.test.ts`            | `fakeWallet` (no network)         | `bun run --filter @linky/linkshu test`             |
+| Integration | `tests/integration/*.test.ts` | Docker Nutshell mints :3338/:3339 | `bun run --filter @linky/linkshu test:integration` |
+
+Both use vitest with globals (`describe`/`it`/`expect` without imports). Unit tests run in the root `bun run test`; the integration suite is separate and runs in CI as `linkshu-integration`.
+
+## Testing a consumer
+
+You have the public API and the in-memory ports; nothing else is exported for tests.
+
+**One clean wallet per runtime.** Omit the stores from `runLinkshu` (or provide `inMemoryKeyValueStore`/`inMemoryTokenStore`) and each runtime starts empty:
+
+```ts
+import { Bip39Seed, runLinkshu, TokenStore } from "@linky/linkshu";
+import { Effect } from "effect";
+
+const rowsOfFreshWallet = () =>
+  runLinkshu(
+    { bip39Seed: Bip39Seed.make(crypto.getRandomValues(new Uint8Array(64))) },
+    Effect.flatMap(TokenStore, (store) => store.loadAll),
+  );
+```
+
+**A restart is two runtimes over one storage.** The plain in-memory layers give every runtime an empty wallet, so keep the store instances and wrap them in `Layer.succeed` — the recipe is under "durability across runtimes" in [ports.md](./ports.md). Reads after an interrupted flow go through `TokenStore.loadAll`: `Tokens.balances` counts `accepted` only, so a `pending` or `reserved` row left behind is invisible there.
+
+**Adapters are tested against the port contract**, not against wallet flows: durability, lease ownership, immediate read-after-write visibility. The CLI's `apps/linkshu-cli/src/fileKeyValueStore.test.ts` includes a four-process lock race worth copying. If your ids derive from `originalTokenText`, also run the flows you care about against `deterministicIdTokenStore` (below) so the upsert semantics are exercised.
+
+**Real flows need a real mint.** Consumer tests cannot substitute the mint client, so anything that swaps, melts, or mints runs against the Docker mints. Copy the helpers from the integration suite below; they are plain functions over cashu-ts and the public API.
+
+## Testing package internals
+
+`src/testing` holds package-internal fixtures. They are excluded from the app build and not exported from the index; import them by relative path from a test inside the package.
+
+| Helper                          | File                           | For                                                                                                                                                                                      |
+| ------------------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fakeWallet(overrides)`         | `fakeWallet.ts`                | A `LoadedWallet` whose every method rejects; override only what the test exercises.                                                                                                      |
+| `proof(amount, secret)`         | `fakeWallet.ts`                | A NUT-00 proof on `KEYSET_HEX`, for building tokens with cashu-ts's `getEncodedToken`.                                                                                                   |
+| `answerProofStates(stateOf)`    | `fakeWallet.ts`                | A `checkProofsStates` implementation answering `stateOf(secret)` (default `UNSPENT`) for every proof.                                                                                    |
+| `recordingInspector()`          | `inspector.ts`                 | `{ events, layer }`; every emitted event lands in `events` in order.                                                                                                                     |
+| `seedRow(text, state?, error?)` | `rows.ts`                      | Inserts `text` as its own original encoding into the `TokenStore` in the environment.                                                                                                    |
+| `amountOf(row)`                 | `rows.ts`                      | The parsed amount of a stored row, or `undefined`.                                                                                                                                       |
+| `freshStorage()`                | `storage.ts`                   | `{ kv, tokens }` service instances that outlive one runtime; a second runtime over them models a restart.                                                                                |
+| `runOnTestClock(program, step)` | `clock.ts`                     | Forks `program` and keeps advancing `TestClock` by `step` until it finishes. Needs `TestContext.TestContext`.                                                                            |
+| `deterministicIdTokenStore`     | `deterministicIdTokenStore.ts` | A `TokenStore` layer with the Evolu adapter's observable semantics: ids derived from `originalTokenText`, insert-as-upsert, soft delete. Run flows that could collide on ids against it. |
+
+A unit harness for one vertical bypasses the network by providing the internal `WalletInstances` service with a fake wallet. The pattern from `src/receive/Receive.test.ts`:
+
+```ts
+import { Effect, Layer } from "effect";
+import { WalletInstances } from "../mint/internal/WalletInstances";
+import { inMemoryKeyValueStore } from "../ports/inMemoryKeyValueStore";
+import { inMemoryTokenStore } from "../ports/inMemoryTokenStore";
+import { fakeWallet, proof } from "../testing/fakeWallet";
+import { recordingInspector } from "../testing/inspector";
+import { Receive } from "../receive/Receive";
+
+const wallet = fakeWallet({
+  receive: () => Promise.resolve([proof(4, "rcv-a"), proof(1, "rcv-b")]),
+});
+const inspector = recordingInspector();
+
+const layer = Receive.DefaultWithoutDependencies.pipe(
+  Layer.provideMerge(
+    Layer.mergeAll(
+      Layer.succeed(
+        WalletInstances,
+        WalletInstances.make({ get: () => Effect.succeed(wallet) }),
+      ),
+      inMemoryKeyValueStore,
+      inMemoryTokenStore,
+      inspector.layer,
+    ),
+  ),
+);
+
+const run = <A, E>(program: Effect.Effect<A, E, Receive>) =>
+  Effect.runPromiseExit(program.pipe(Effect.provide(layer)));
+```
+
+`Service.DefaultWithoutDependencies` is the vertical's layer minus its `WalletInstances` dependency, which is what lets you substitute the fake. Assert on `inspector.events.map((event) => event._tag)` to check the lifecycle and counter movements a flow produced.
+
+Time-driven flows (topup polling, melt's pending wait) run under the Effect `TestClock`:
+
+```ts
+import { Effect, TestContext } from "effect";
+import { runOnTestClock } from "../testing/clock";
+
+const settleOnTestClock = <A, E>(program: Effect.Effect<A, E>) =>
+  Effect.runPromise(
+    runOnTestClock(Effect.either(program), "5 seconds").pipe(
+      Effect.provide(TestContext.TestContext),
+    ),
+  );
+```
+
+## The integration suite
+
+`tests/integration/*.test.ts` exercises the public API only, against two Nutshell FakeWallet mints from `docker-compose.dev.yml`:
+
+```bash
+docker compose -f docker-compose.dev.yml up -d --wait cashu-mint cashu-mint-target
+bun run --filter @linky/linkshu test:integration
+```
+
+Override the mints with `LINKSHU_MINT_URL` (source, default `http://localhost:3338`) and `LINKSHU_TARGET_MINT_URL` (target, default `http://localhost:3339`). Test timeout is 30 s per case.
+
+`tests/integration/helpers.ts`:
+
+| Helper                       | For                                                                                                     |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `mintUrl`, `targetMintUrl`   | The two mints as `MintUrl`.                                                                             |
+| `randomSeed()`               | A fresh `Bip39Seed` per run — counters live at the mint, so a reused seed starts inside a signed range. |
+| `fundToken(amountSat)`       | Mints fresh sats with a plain cashu-ts wallet and returns token text to receive.                        |
+| `fundProofs`, `tokenOf`      | The same in two steps, when the test needs the proofs.                                                  |
+| `invoiceFor(amountSat)`      | A payable bolt11 invoice from the **target** mint.                                                      |
+| `claimExternally(tokenText)` | Someone else spends the token at the mint.                                                              |
+| `acceptedTotalOf(rows)`      | Sum of `accepted` rows.                                                                                 |
+| `inputFee(proofCount)`       | `ceil(proofCount * 100 / 1000)`, the dev mint's input fee.                                              |
+| `durableStorage()`           | In-memory stores plus `layers` that survive across `runLinkshu` calls — a process restart.              |
+| `receiveOnce(seed, text)`    | One in-memory runtime: receive `text`, return the receipt and rows.                                     |
+
+A typical case, in a new file under `tests/integration/`:
+
+```ts
+import { Receive, ReceiveDraft, runLinkshu, Tokens } from "@linky/linkshu";
+import { Effect } from "effect";
+import { durableStorage, fundToken, randomSeed } from "./helpers";
+
+it("accepts a funded token net of the input fee", async () => {
+  const text = await fundToken(6);
+  const balances = await runLinkshu(
+    { bip39Seed: randomSeed(), ...durableStorage().layers },
+    Effect.gen(function* () {
+      yield* (yield* Receive).receive(new ReceiveDraft({ text }));
+      return yield* (yield* Tokens).balances;
+    }),
+  );
+  expect(balances.total).toBeLessThan(6);
+});
+```
+
+## Gotchas
+
+- **The dev mint is not fee-free.** It runs with `input_fee_ppk: 100`: every swap costs `ceil(inputs / 10)` sat. A received 6-sat token lands as 5. Use `inputFee(n)` in assertions instead of hard-coding.
+- **Rate limits are off** (`MINT_RATE_LIMIT=FALSE`). Nutshell's defaults (60 req/min, 20 transactions/min) would 429 partway through a run; do not point the suite at a mint with limits on.
+- **The source mint pays its own invoices.** FakeWallet settles every quote it issues, so a melt against a :3338 invoice races its own timer. Use `invoiceFor` (target mint) for anything that must be paid by a melt.
+- **Fresh seed per run.** Use `randomSeed()` every time; a reused seed makes the first swap collide with outputs the mint already signed and turns the test into a collision-recovery test.
+
+## Related
+
+- [ports.md](./ports.md) — the contracts your adapter tests should cover
+- [inspector.md](./inspector.md) — the events `recordingInspector` collects
+- [getting-started.md](./getting-started.md) — `runLinkshu` for one-shot runs

--- a/packages/linkshu/docs/tokens.md
+++ b/packages/linkshu/docs/tokens.md
@@ -1,0 +1,112 @@
+# Tokens
+
+`Tokens` is the read model over stored rows plus the lifecycle transitions callers are allowed to make. Use `list` and `balances` to render the wallet, the transition calls when a token changes hands, `returnToWallet` to take one back, and `deleteSpent` to clean up. The token codec exports in `token/codec.ts` are the pure functions behind all of it.
+
+## Quick example
+
+Prerequisites: a configured runtime ([getting-started.md](./getting-started.md)). Reads never fail; an empty wallet returns zero balances and no rows.
+
+```ts
+import { Effect } from "effect";
+import { Tokens } from "@linky/linkshu";
+
+const walletView = Effect.gen(function* () {
+  const tokens = yield* Tokens;
+  const balances = yield* tokens.balances;
+  const rows = yield* tokens.list;
+  return {
+    total: balances.total,
+    spendable: balances.spendable,
+    perMint: balances.perMint.map(
+      (entry) => [entry.mint, entry.amount] as const,
+    ),
+    issued: rows.filter((row) => row.state === "issued"),
+  };
+});
+```
+
+Reads are pull-based: re-run them when the store changes (Linky re-runs on every Evolu query change).
+
+## How it works
+
+### Read model
+
+- `list` — every row whose text still parses, enriched into `WalletToken`, newest first. Rows that no longer parse stay in the store but are omitted.
+- `balances` — `WalletBalances` over `accepted` rows only. `spendable` is the largest single-mint balance, because cashu cannot spend across mints in one operation.
+
+### Lifecycle
+
+States, their meanings, and the legal transitions are in [concepts.md](./concepts.md#token-rows-and-the-lifecycle). Only `accepted` counts as balance. Callers get three pure transitions, each `(rowId) => Effect<void, TokenRowNotFound | InvalidTokenTransition>`:
+
+| Call               | Meaning                                                              |
+| ------------------ | -------------------------------------------------------------------- |
+| `reserve`          | earmark an `accepted` row for a handover that has not happened yet   |
+| `markIssued`       | the token left as a QR/share; watch it with `Validation.checkIssued` |
+| `markExternalized` | the token was handed off outside the app entirely                    |
+
+Everything else (`pending` → `accepted`, `error` marking, removal of consumed sources) is done by the operation verticals. Platforms never write states themselves.
+
+### `returnToWallet`
+
+`returnToWallet(rowId)` brings a row back to `accepted` and returns a `ReceiveReceipt`. Its behavior depends on the state:
+
+| Row state                                    | What happens                                                                                                                                                                                |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accepted`                                   | `InvalidTokenTransition` — nothing to return                                                                                                                                                |
+| `reserved`                                   | released locally, without a mint check. For inputs of an interrupted melt, follow [the melt recovery procedure](./melt.md#recovering-an-interrupted-melt) first                             |
+| `issued`, `externalized`, `pending`, `error` | the row's text is **re-received** through the accept flow: a fresh `accepted` row gets swapped proofs, then the old row is removed. The copy someone else may hold is now spent at the mint |
+
+On a re-receive, dedup ignores the replaced row. A transient failure leaves it exactly as it was; a definitive failure (`TokenAlreadySpent`, `MintRejected`) lands on the replaced row as `error` where the state machine allows (an `externalized` row keeps its state). This is the recovery path for a `pending` message send that never confirmed, an unclaimed `issued` token, and an `error` row that still holds live proofs after a partial spend.
+
+### `deleteSpent`
+
+Removes rows the mints confirm fully spent and returns `DeletedSpentToken[]` (`rowId`, `amount`). It sweeps `accepted` and `error` rows only. It runs its own NUT-07 check: rows already carrying a recorded `TokenAlreadySpent` are re-confirmed, because a receive rejected over a _partially_ spent token records that error while the text still holds live proofs. An unreachable mint or an unanswered proof keeps every row.
+
+Rows in other states are never swept: `issued` rows are pruned by `Validation.checkIssued` once claimed; `externalized` rows come back only through `returnToWallet`; `reserved` and `pending` rows belong to an operation in flight.
+
+## Token codec
+
+Pure and total: malformed input yields `null`, never a throw. Import from `@linky/linkshu`.
+
+| Function                           | Use                                                                                                                    |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `extractTokenText(text)`           | find a token in arbitrary text (bare, `cashu:` schemes, URLs, embedded JSON) → `TokenText \| null`                     |
+| `normalizeTokenText(raw)`          | trim and normalize any supported encoding (legacy JSON becomes v3 text)                                                |
+| `parseTokenText(raw)`              | `ParsedToken` summary (`amount`, `mint`, `unit`, `memo`) without exposing proofs — for previews and dedup              |
+| `decodeTokenText(raw, keysetIds?)` | full `DecodedToken` (`mint`, `unit`, `memo`, `proofs`); pass the mint's keyset ids to expand short v2 ids in v4 tokens |
+| `encodeToken(decoded)`             | canonical v4 `TokenText`; round-trips with `decodeTokenText`                                                           |
+
+Supported formats: v3 (`cashuA`, base64url JSON), v4 (`cashuB`, base64url CBOR), and legacy cashu.me plain-JSON proof bundles (normalized to standard token text). `mint`/`unit` on `ParsedToken` are `null` when the encoding does not state them unambiguously.
+
+## Inputs and outputs
+
+`WalletToken` (`token/domain.ts`):
+
+| Field       | Type                           | Notes                                         |
+| ----------- | ------------------------------ | --------------------------------------------- |
+| `id`        | `TokenRowId`                   |                                               |
+| `state`     | `TokenState`                   |                                               |
+| `tokenText` | `TokenText`                    | current encoding                              |
+| `mint`      | `Schema.NullOr(MintUrl)`       |                                               |
+| `unit`      | `Schema.NullOr(CurrencyUnit)`  |                                               |
+| `amount`    | `Amount`                       |                                               |
+| `error`     | `Schema.NullOr(Schema.String)` | serialized tagged error; null outside `error` |
+| `createdAt` | `UnixSeconds`                  |                                               |
+
+`WalletBalances`: `total: NonNegativeAmount`, `spendable: NonNegativeAmount`, `perMint: Schema.Array(MintBalance)` with `MintBalance { mint: MintUrl, amount: NonNegativeAmount }`.
+
+## Errors
+
+| Tag                      | Raised by                        | When                                                     | What to do                             |
+| ------------------------ | -------------------------------- | -------------------------------------------------------- | -------------------------------------- |
+| `TokenRowNotFound`       | transitions, `returnToWallet`    | no row with that id                                      | drop the reference                     |
+| `InvalidTokenTransition` | transitions, `returnToWallet`    | the state machine forbids it (`from`, `to` in the error) | refresh the row and re-check the state |
+| `ReceiveError` members   | `returnToWallet` on a re-receive | see [receive.md](./receive.md#errors)                    | same handling as a receive             |
+
+`list`, `balances`, and `deleteSpent` never fail.
+
+## Related
+
+- [receive.md](./receive.md), [send.md](./send.md), [validation.md](./validation.md)
+- [concepts.md](./concepts.md#token-rows-and-the-lifecycle) — states and transitions
+- [ports.md](./ports.md) — `TokenStore`, `StoredTokenRow`, why ids may derive from `originalTokenText`

--- a/packages/linkshu/docs/topup.md
+++ b/packages/linkshu/docs/topup.md
@@ -1,0 +1,158 @@
+# Topup
+
+`Topup` receives over Lightning: it creates a mint quote, hands you the invoice to display, waits for it to be paid, and mints the proofs into an `accepted` row. Use it for "receive via Lightning", LNURL-withdraw, and (via `adopt`) invoices a lightning-address server paid on the wallet's behalf.
+
+## Quick example
+
+Prerequisites: a seed ([getting-started.md](./getting-started.md)) and the dev mint, which auto-pays its own invoices: `docker compose -f docker-compose.dev.yml up -d --wait cashu-mint`. Against a real mint, pay the printed invoice from another wallet.
+
+```ts
+import { Effect } from "effect";
+import { Amount, MintUrl, runLinkshu, Topup, TopupDraft } from "@linky/linkshu";
+import type { Bip39Seed } from "@linky/linkshu";
+
+const topupOnce = (bip39Seed: Bip39Seed) =>
+  runLinkshu(
+    { bip39Seed },
+    Effect.scoped(
+      Effect.gen(function* () {
+        const topup = yield* Topup;
+        const handle = yield* topup.start(
+          new TopupDraft({
+            mint: MintUrl.make("http://localhost:3338"),
+            amount: Amount.make(1000),
+          }),
+        );
+        console.log("pay this:", handle.quote.invoice);
+        const receipt = yield* handle.result; // resolves once paid and minted
+        return receipt.rowId;
+      }),
+    ),
+  );
+```
+
+`start` needs a `Scope`: polling runs as a fiber in that scope. Close the scope and polling stops; the persisted quote stays claimable through `resumePending`.
+
+## How it works
+
+1. **Quote.** `start` requests a bolt11 mint quote and persists it **before** returning the handle. Any invoice you can show is one the package can finish or resume.
+2. **Poll.** The quote is polled until the mint reports it paid. Transient failures are tolerated (the device may be offline); a long run of them ends the poll with `MintUnreachable`, and an unknown quote (`MintRejected`) ends it at once.
+3. **Mint under the counter lock.** If the mint says the quote was already issued (a lost response), the proofs are reclaimed via NUT-09 instead of minted twice; proofs already stored resolve to the existing row.
+4. **Persist.** The row is inserted as `accepted` (`topup`), then the record is removed. A crash in between costs one reclaim scan on resume, never funds.
+
+Expiry is decided only by the mint: a quote the mint still reports `UNPAID` after `expiresAt` (or 24 h after creation when the mint sets none) fails with `QuoteExpired`. The record is dropped unless minting had already begun.
+
+### `resumePending` — run it at startup
+
+Records outlive the process. Nothing polls them until you call `resumePending()`, which returns a handle for every record, even those past their deadline. Call it once when your runtime comes up and again whenever connectivity returns; duplicate handles for the same quote are safe.
+
+```ts
+import { Effect, Either } from "effect";
+import { Topup } from "@linky/linkshu";
+
+const resumeTopups = Effect.scoped(
+  Effect.gen(function* () {
+    const topup = yield* Topup;
+    for (const handle of yield* topup.resumePending()) {
+      const outcome = yield* Effect.either(handle.result);
+      if (Either.isRight(outcome)) {
+        console.log(
+          "minted",
+          outcome.right.amount,
+          "sat",
+          handle.quote.quoteId,
+        );
+      } else if (outcome.left._tag === "QuoteExpired") {
+        console.log("expired", handle.quote.quoteId);
+      } else {
+        // MintUnreachable, MintRejected, CounterLockTimeout: the record stays;
+        // the next resume picks it up.
+        console.log("not finished", handle.quote.quoteId, outcome.left._tag);
+      }
+    }
+  }),
+);
+```
+
+This waits for every handle inside one scope, which suits a CLI (`apps/linkshu-cli/src/commands.ts`, `topup` with no amount). In a long-lived app, extend the handles into a scope that outlives the call (`Scope.extend`) so polling survives UI unmounts, and close that scope before disposing the runtime; Linky does this in `useLinkshuComposition.ts`. Pass `{ lockingKey }` when the wallet adopts locked quotes (below).
+
+### `adopt` — a quote someone else paid
+
+A lightning-address server can create a mint quote for the wallet and pay its invoice. `adopt` mints such a quote from the server's paid-quote record, without polling: the mint is asked once.
+
+```ts
+import { Effect, Schema } from "effect";
+import { PaidQuoteDraft, QuoteLockingKey, Topup } from "@linky/linkshu";
+
+const decodePaidQuote = Schema.decodeUnknown(PaidQuoteDraft);
+
+/** `paid` is the server's record; `lockingKeyHex` unlocks a NUT-20 locked quote. */
+const adoptPaidQuote = (
+  paid: {
+    quoteId: string;
+    mint: string;
+    amount: number;
+    invoice: string;
+    expiresAt: number | null;
+    locked: boolean;
+  },
+  lockingKeyHex: string | null,
+) =>
+  Effect.gen(function* () {
+    const draft = yield* decodePaidQuote(paid);
+    const topup = yield* Topup;
+    return yield* topup.adopt(
+      draft,
+      lockingKeyHex === null
+        ? {}
+        : { lockingKey: QuoteLockingKey.make(lockingKeyHex) },
+    );
+  });
+```
+
+`locked` quotes (NUT-20) can only be minted with the secp256k1 secret they were locked to; the server tells you which key it used (Linky's npub.cash flow locks to the user's nostr key, so the nsec's hex form is the `lockingKey`). The key is passed to the mint call only, never persisted. `UNPAID` → `MintRejected`; already issued without a local record → `QuoteAlreadyIssued` (another wallet minted it).
+
+## Inputs and outputs
+
+`TopupDraft` (`topup/domain.ts`): `mint: MintUrl`, `amount: Amount`.
+
+`TopupHandle`: `quote: TopupQuote`, `result: Effect<TopupReceipt, TopupError>`.
+
+`TopupQuote`:
+
+| Field       | Type                         |
+| ----------- | ---------------------------- |
+| `quoteId`   | `QuoteId`                    |
+| `mint`      | `MintUrl`                    |
+| `amount`    | `Amount`                     |
+| `invoice`   | `Bolt11Invoice`              |
+| `expiresAt` | `Schema.NullOr(UnixSeconds)` |
+
+`PaidQuoteDraft` (for `adopt`): `quoteId`, `mint`, `amount`, `invoice`, `expiresAt`, `locked: boolean`. `TopupLockingOptions`: `{ lockingKey?: QuoteLockingKey }`.
+
+`TopupReceipt`:
+
+| Field       | Type         | Notes              |
+| ----------- | ------------ | ------------------ |
+| `rowId`     | `TokenRowId` | the `accepted` row |
+| `tokenText` | `TokenText`  | minted encoding    |
+| `mint`      | `MintUrl`    |                    |
+| `amount`    | `Amount`     |                    |
+| `quoteId`   | `QuoteId`    |                    |
+
+## Errors
+
+| Tag                  | Raised by                  | When                                                                                   | What to do                                                                                      |
+| -------------------- | -------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `MintUnreachable`    | `start`, `result`, `adopt` | mint down at quote time, or repeated poll failures                                     | for `result`: keep showing the invoice, the record persists; re-run `resumePending` when online |
+| `MintRejected`       | `start`, `result`, `adopt` | unknown quote, settled quote reported unpaid, locked quote without key, mint rejection | surface `detail`; a locked record stays pending for a resume that brings the key                |
+| `QuoteExpired`       | `result`                   | mint confirms `UNPAID` past the deadline                                               | offer a new topup                                                                               |
+| `QuoteAlreadyIssued` | `adopt`                    | mint already issued the quote and no local record claims it                            | nothing to mint here                                                                            |
+| `CounterLockTimeout` | `result`, `adopt`          | counter lease held elsewhere                                                           | the record persists; resume later                                                               |
+
+## Related
+
+- [autoswap.md](./autoswap.md) — same claim machinery, invoice paid by your own melt
+- [restore.md](./restore.md) — recovers proofs when a record was lost entirely
+- [lightning-utilities.md](./lightning-utilities.md) — LNURL-withdraw against a topup invoice
+- [inspector.md](./inspector.md) — `QuoteStateChanged` rows show the poll

--- a/packages/linkshu/docs/validation.md
+++ b/packages/linkshu/docs/validation.md
@@ -1,0 +1,84 @@
+# Validation
+
+`Validation` asks mints which stored proofs are still unspent (NUT-07) and updates rows accordingly. Use it to verify the balance, to check one token, and to notice when an issued token has been claimed. It performs no swap and costs no signatures.
+
+## Quick example
+
+Prerequisites: a configured runtime ([getting-started.md](./getting-started.md)). An empty wallet returns an empty report.
+
+```ts
+import { Effect } from "effect";
+import { Validation } from "@linky/linkshu";
+
+const checkWallet = Effect.gen(function* () {
+  const validation = yield* Validation;
+  const report = yield* validation.checkAll;
+  return {
+    spent: report.markedSpent.length,
+    merged: report.mergedRows.length,
+    offline: report.unavailableMints,
+  };
+});
+```
+
+## How it works
+
+One batched checkstate call per mint+unit group. Per row:
+
+| Mint's answer for the row                       | What happens                                                                   |
+| ----------------------------------------------- | ------------------------------------------------------------------------------ |
+| every proof `SPENT`                             | row → `error` with a serialized `TokenAlreadySpent`; reported in `markedSpent` |
+| some proofs `UNSPENT`                           | row keeps only the unspent proofs                                              |
+| any proof unanswered / unrecognized / truncated | nothing changes — a missing answer is never a guess                            |
+| mint unreachable or rejects the query           | whole group untouched; mint listed in `unavailableMints`                       |
+
+**Merge.** Surviving proofs of a mint group are collapsed into the first live row (its `tokenText` rewritten locally) and the sibling rows removed; their ids come back in `mergedRows`. The primary carries the merged proofs before any sibling is removed.
+
+### The three calls
+
+| Call              | Rows considered               | Returns                                                                                         |
+| ----------------- | ----------------------------- | ----------------------------------------------------------------------------------------------- |
+| `checkAll`        | `accepted` only (the balance) | `ValidationReport`                                                                              |
+| `checkRow(rowId)` | the supplied row, any state   | `RowCheckResult`; `"unavailable"` when the mint gave no usable answer or the row states no mint |
+| `checkIssued`     | `issued` only                 | `IssuedClaimReport`; fully spent rows are **removed** (the recipient claimed them)              |
+
+The batch calls skip `pending` and `reserved` rows; `checkRow` checks whatever row you give it. That is how `reserved` rows left by an interrupted melt are resolved (also not covered by `Tokens.deleteSpent`): run `checkRow` on each — fully spent flips it to `error`, live leaves it `reserved` for `Tokens.returnToWallet`. See [melt.md](./melt.md#recovering-an-interrupted-melt) for the order of steps. `externalized` and dead `error` rows are only reported, never re-marked.
+
+Validation never resurrects a row: an `error` row with live proofs comes back only through `Tokens.returnToWallet`.
+
+### When to run it
+
+- `checkAll`: on the user's "check all" action. Not on every render — each run is one request per mint.
+- `checkRow`: when opening a token's detail page.
+- `checkIssued`: after handing out an `issued` token, while the token is on screen, and periodically in the background. Avoid overlapping runs: share one in-flight call instead of starting another.
+- `Tokens.deleteSpent` (see [tokens.md](./tokens.md)) when the user wants spent rows gone.
+
+## Inputs and outputs
+
+`ValidationReport` (`validation/domain.ts`):
+
+| Field              | Type                             | Notes                                                          |
+| ------------------ | -------------------------------- | -------------------------------------------------------------- |
+| `checkedRows`      | `Schema.Int`                     | rows the mints actually answered about                         |
+| `markedSpent`      | `Schema.Array(SpentTokenReport)` | `{ rowId: TokenRowId, amount: Amount }` per row marked `error` |
+| `mergedRows`       | `Schema.Array(TokenRowId)`       | siblings removed after merging                                 |
+| `unavailableMints` | `Schema.Array(MintUrl)`          | rows left untouched                                            |
+
+`RowCheckResult`: `rowId: TokenRowId`, `status: "live" | "spent" | "unavailable"`.
+
+`IssuedClaimReport`: `claimed: Schema.Array(SpentTokenReport)`.
+
+## Errors
+
+| Tag                | Raised by  | When                | What to do         |
+| ------------------ | ---------- | ------------------- | ------------------ |
+| `TokenRowNotFound` | `checkRow` | no row with that id | drop the reference |
+
+`checkAll` and `checkIssued` never fail. `checkAll` reports unreachable mints in `unavailableMints`. `checkIssued` leaves rows untouched when it cannot verify them and does not say so: an empty `claimed` array does not prove every mint answered.
+
+## Related
+
+- [tokens.md](./tokens.md) — `deleteSpent`, `returnToWallet`, lifecycle
+- [send.md](./send.md) — `issued` rows come from here
+- [melt.md](./melt.md) — where `reserved` rows come from
+- [../README.md](../README.md) — "A missing NUT-07 answer is never a guess"

--- a/packages/linkstr-react/AGENTS.md
+++ b/packages/linkstr-react/AGENTS.md
@@ -1,0 +1,3 @@
+# @linky/linkstr-react
+
+This package is documented together with `@linky/linkstr`: `../linkstr/docs/react.md` is the usage guide, and each vertical guide in `../linkstr/docs/` has a React section for its fn atom. Changing an exported atom, hook, or testing helper is done only when those guides are updated in the same commit; see `../linkstr/AGENTS.md`.

--- a/packages/linkstr/AGENTS.md
+++ b/packages/linkstr/AGENTS.md
@@ -1,0 +1,7 @@
+# @linky/linkstr
+
+Usage guides for this package and for `@linky/linkstr-react` live in `docs/` (index: `docs/README.md`). Read the guide for a vertical before changing it; the guide states the wire kinds, delivery contract, and inbound event shapes callers rely on.
+
+## Keep the docs in sync
+
+Changing the public surface — anything exported from `src/index.ts` or `src/testing/index.ts` (drafts, receipts, inbound events, service methods, errors, config), or from `../linkstr-react/src/index.ts` (atoms, testing helpers) — or the behavior a guide describes, is done only when the matching `docs/*.md` file is updated in the same commit. Done means: every snippet in the touched guide still typechecks against the new surface, every table row still names a real field, event tag, or error tag, and a new vertical follows `docs/adding-a-vertical.md` and gets its own guide linked from `docs/README.md`.

--- a/packages/linkstr/README.md
+++ b/packages/linkstr/README.md
@@ -6,6 +6,14 @@ action it expects are defined here as Effect `Schema` types. Raw nostr events
 never cross the package boundary: callers hand in drafts and get receipts;
 listeners consume a tagged union of app-level facts.
 
+## Documentation
+
+Usage guides live in [`docs/`](./docs/README.md): start with
+[getting started](./docs/getting-started.md), the [React guide](./docs/react.md)
+for `@linky/linkstr-react`, then the guide for the vertical you need (chat,
+reactions, profiles, …). This README holds the design rules; the guides show
+how to call the package.
+
 ## Verticals
 
 Gift-wrapped (NIP-17/NIP-59, kind 1059 on the wire):

--- a/packages/linkstr/docs/README.md
+++ b/packages/linkstr/docs/README.md
@@ -1,0 +1,53 @@
+# @linky/linkstr guides
+
+How to use Linky's Nostr protocol library and its React binding `@linky/linkstr-react`. These are guides, not an API reference: the exported types are the reference, and the [package README](../README.md) holds the design rules and rationale.
+
+## Where to start
+
+1. [Getting started](./getting-started.md) — configure your key and relays, run one send and one receive, and learn the core concepts in one page. Read this first.
+2. [React](./react.md) if you are working in the web app: the config atom, the runtime, and the atom for each operation.
+3. The guide for the vertical you need, from the list below. Each one opens with a working example; jump to its Errors section when a send fails.
+
+[Concepts](./concepts.md) is the lookup behind all of them: drafts, receipts, and facts; gift-wrapped vs plain kinds; honest delivery; branded primitives; a short Effect primer.
+
+## Verticals
+
+Gift-wrapped (private, kind 1059 on the wire):
+
+- [Chat](./chat.md) — text, image, and Cashu-token messages plus edits
+- [Reactions](./reactions.md) — emoji reactions and retractions; the reference vertical
+- [Seen receipts](./seen-receipts.md) — read-receipt window cursors
+- [Payment notices](./payment-notices.md) — "you were paid" pings
+- [Payment telemetry](./payment-telemetry.md) — anonymous payment outcome reports
+- [Bank offers](./bank-offers.md) — proxy bank-payment offers
+
+Plain (public, signed and published unwrapped):
+
+- [Profiles](./profiles.md) — metadata and status, publish, fetch, search, and watch
+- [Relay lists](./relay-lists.md) — read and inbox relay lists as one operation
+- [Mute list](./mute-list.md) — the mute list
+
+Never published:
+
+- [HTTP auth](./http-auth.md) — signed events as HTTP credentials for Blossom, the push server, and NIP-98
+
+## Receiving, retries, and diagnostics
+
+- [Inbox](./inbox.md) — the single gift-wrap subscription, the event union, cursors, and one-shot fetch
+- [Outbox](./outbox.md) — the durable send queue with retry and backoff
+- [Identity and keys](./identity-and-keys.md) — key codecs and the identity service
+- [Push inbox](./push-inbox.md) — identity-free wrap routing for the push server
+- [Relay health](./relay-health.md) — per-relay status derived from traffic
+- [Inspector](./inspector.md) — diagnostics events and how to consume them
+
+## Working on the package
+
+- [Testing](./testing.md) — fakes and stubs for both packages, with full example tests
+- [Adding a vertical](./adding-a-vertical.md) — the four files, the registration points, and the tests to write
+
+## Finding your way
+
+- Looking for a type or method name? Open `src/index.ts` and follow the export; every guide names the file it documents.
+- Wondering what arrives on the wire? Each vertical guide states its kinds and whether it is gift-wrapped; [Inbox](./inbox.md) lists every inbound event tag in one table.
+- A send failed? The vertical guide's errors table says what each failure means; [Concepts](./concepts.md#honest-delivery) explains why "only my copy landed" is a failure.
+- Want a working consumer to copy from? The web app hooks named in [React](./react.md), the service worker for `runLinkstr`, and `apps/push` for the push inbox.

--- a/packages/linkstr/docs/adding-a-vertical.md
+++ b/packages/linkstr/docs/adding-a-vertical.md
@@ -1,0 +1,110 @@
+# Adding a vertical
+
+A vertical is one app-level protocol: its drafts and receipts, its wire codec, its send service, and its inbound facts. This is the checklist for adding one; read it before touching `WrapInbox` or `linkstrServices`.
+
+It assumes a **two-copy private vertical**: a gift-wrapped rumor sent to the peer and echoed to yourself, received through `WrapInbox`, with `reactions/` as the template. For the other shapes, copy a different template and skip the inbox steps that do not apply:
+
+- Single-copy private (no self copy, no own echo): `paymentNotices/` (`sendToRecipient`, has an inbox fact) or `paymentTelemetry/` (no inbox fact at all).
+- Plain public event (signed, published as-is, fetched or watched): `muteList/` is the smallest.
+
+## The four files
+
+Create `packages/linkstr/src/<vertical>/`:
+
+| File        | Holds                                                                                   | Reactions example                                              |
+| ----------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `domain.ts` | drafts (`Schema.Class`) and receipts (`Schema.TaggedClass`); brands for field types     | `ReactionDraft`, `RetractionDraft`, `ReactionReceipt`, `Emoji` |
+| `events.ts` | inbound facts (`Schema.TaggedClass`) and their `Schema.Union`                           | `ReactionAdded`, `OwnReactionConfirmed`, `ReactionInboxEvent`  |
+| `codec.ts`  | kind constants, `encode*Rumor`, `decode*Rumor`; the only file that knows tags and kinds | `REACTION_KIND`, `encodeReactionRumor`, `decodeReactionRumor`  |
+| `<Name>.ts` | the `Effect.Service` with the operations                                                | `Reactions` with `react`, `retract`                            |
+
+Conventions to keep:
+
+- Drafts take `to: Pubkey` plus optional `clientId` and `sentAt`; receipts carry `rumorId`, `clientId`, `sentAt`, and the `WrapDelivery` copies. Name the delivered rumor `rumorId`, never `<thing>Id`.
+- Facts come in pairs: a peer fact with `from` and an own echo with `clientId: NullOr(ClientId)`. The codec decides by comparing `rumor.pubkey` with `me`.
+- `decode*Rumor` returns `Either<Fact, DropReason>`. Add your reason(s) to `DropReason` in `inbox/events.ts` (`"invalid-reaction"` is the pattern) rather than reusing a foreign one.
+- Build rumors with `rumorWithHash` from `internal/nostrEvent.ts`; read tags with `firstTagValue` / `tagValues`.
+
+## The service
+
+Use the shared send skeleton so delivery, receipts, and inspector emission stay uniform:
+
+```ts
+import { Effect } from "effect";
+import type { NoRelayReachable, RecipientNotReached } from "../domain/errors";
+import { makeWrapSendContext, sendToPeer } from "../internal/wrapSend";
+import { encodeReactionRumor } from "./codec";
+import { ReactionReceipt, type ReactionDraft } from "./domain";
+
+export class Reactions extends Effect.Service<Reactions>()(
+  "linkstr/Reactions",
+  {
+    effect: Effect.gen(function* () {
+      const context = yield* makeWrapSendContext;
+      const react = (
+        draft: ReactionDraft,
+      ): Effect.Effect<
+        ReactionReceipt,
+        RecipientNotReached | NoRelayReachable
+      > =>
+        sendToPeer(context, "reactions.react", draft, {
+          encode: encodeReactionRumor,
+          receipt: (outcome) => new ReactionReceipt(outcome),
+        });
+      return { react } as const;
+    }),
+  },
+) {}
+```
+
+- `sendToPeer` is the two-copy NIP-17 send. Options: `pushMarkRecipientCopy` (chat text and images set it) and `order: "recipientFirst"` (bank offers, when the self copy must never outrun the peer copy).
+- `sendToRecipient` is the single-copy variant (payment notices, telemetry); it fails with `WrapNotDelivered`.
+- The string name (`"reactions.react"`) is the inspector operation name; keep it `<vertical>.<operation>`.
+- Plain-event verticals use `deliverPlainEvent` from `internal/plainDelivery.ts` and `fetchPlainEvents` from `internal/plainFetch.ts` instead; look at `muteList/MuteList.ts` for the smallest example.
+
+## Register it
+
+1. **Inbox dispatch** — `inbox/decodeWrapEvent.ts`, `routeRumor`: add a `case` for your kind that calls your `decode*Rumor` and wraps a `Left` in `WrapDropped`. This is the single dispatch point; until you add it, your kind surfaces as `WrapDropped("unsupported-kind")`.
+2. **Union** — `inbox/WrapInbox.ts`: add your `XInboxEvent` to `WrapInboxEvent`.
+3. **Composition** — `composition.ts`: add `X.Default` to `linkstrServices`. If sends must be durable, add an operation tag to `outbox/domain.ts` (`OutboxOperation`, `RumorFixedOperation`, `OutboxReceipt`), extend `normalizeOperation`, `encodeOperationRumor`, and `dispatch` in `outbox/Outbox.ts`, and list `X.Default` in the `Outbox.Default` provide list.
+4. **Exports** — `index.ts`: export `domain`, `events`, and the service; export codec constants only if a consumer needs the kind number.
+5. **React** — `packages/linkstr-react/src/<vertical>.ts`: one fn atom per **direct** operation, then `export * from "./<vertical>"` in `index.ts`. Operations that go through the outbox get no atom of their own: the app enqueues them with the existing `enqueueOutboxAtom` and observes them through `useOutboxResults` ([react.md](./react.md#outbox)), which is why there is a `retractReactionAtom` but no `reactAtom`.
+
+```ts
+import { Reactions } from "@linky/linkstr";
+import type { RetractionDraft } from "@linky/linkstr";
+import { Effect } from "effect";
+import { linkstrRuntimeAtom } from "./runtime";
+
+export const retractReactionAtom = linkstrRuntimeAtom.fn<RetractionDraft>()(
+  (draft) => Effect.flatMap(Reactions, (reactions) => reactions.retract(draft)),
+);
+```
+
+## Tests to write
+
+| Test                                           | Pattern to copy                                | What it proves                                                                              |
+| ---------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `codec.test.ts`                                | `reactions/codec.test.ts`                      | encode → decode roundtrips; own vs peer split; every drop reason                            |
+| `<Name>.test.ts`                               | `reactions/Reactions.test.ts`                  | two wraps published, same rumor id, `RecipientNotReached` on partial acceptance             |
+| `inbox/WrapInbox.test.ts` addition             | the `chatWrap` / `paymentNoticeWrap` helpers   | a real wrap of your kind routes to your fact                                                |
+| `inspector/inspectorEmission.test.ts` addition | existing cases                                 | `OperationSucceeded` carries your operation name                                            |
+| `linkstr-react/src/<vertical>.test.ts`         | `reactions.test.ts`                            | the fn atom delivers through the configured transport and fails with `LinkstrNotConfigured` |
+| Outbox tests, if queued                        | `outbox/Outbox.test.ts`, `OutboxStore.test.ts` | stored job decodes; the result carries your receipt                                         |
+
+Use `@linky/linkstr/testing` and `linkstr-react/src/testing` ([testing.md](./testing.md)).
+
+## Inspector events to emit
+
+Sends through `sendToPeer` / `sendToRecipient` already emit `OperationSucceeded` / `OperationFailed`, inbox routing already emits `InboxRouted`. You only add emission for a genuinely new kind of fact, and then you follow `.agents/skills/adding-inspector-events/`. On the app side, add the new operation name and tags to the inspector glossary so the timeline explains them.
+
+## Documentation
+
+Add `docs/<vertical>.md` next to the other vertical guides and, in the same commit, list it in the guide index [`docs/README.md`](./README.md), the vertical list in the [package README](../README.md), and the "Linkstr protocol package" section of the repo's `docs/architecture.md`.
+
+## Related
+
+- [concepts.md](./concepts.md)
+- [inbox.md](./inbox.md), [outbox.md](./outbox.md)
+- [reactions.md](./reactions.md) — the reference vertical's guide
+- [inspector.md](./inspector.md)

--- a/packages/linkstr/docs/bank-offers.md
+++ b/packages/linkstr/docs/bank-offers.md
@@ -1,0 +1,187 @@
+# Bank offers
+
+`BankOffers` carries the proxy-payment flow: you scanned a bank QR, and you offer contacts to pay it for you in exchange for sats. Every step is a **snapshot** of the offer — a kind 24135 rumor tagged `["linky", "bank_payment_offer"]`, gift-wrapped (kind 1059) to the counterparty and to yourself. Linkstr delivers snapshots and decodes them; which transitions are legal, who may send which status, and timers are app state (`useBankPaymentOffers`).
+
+## Quick example
+
+Prerequisites: a `NostrSecretKey`, relay urls, your own `Pubkey`, and the counterparty's `Pubkey` — see [getting-started.md](./getting-started.md).
+
+Headless — open a new offer:
+
+```ts
+import { Effect } from "effect";
+import {
+  BankOfferDraft,
+  BankOfferId,
+  BankOffers,
+  runLinkstr,
+  type NostrSecretKey,
+  type Pubkey,
+  type RelayUrl,
+} from "@linky/linkstr";
+
+const offer = (
+  secretKey: NostrSecretKey,
+  relays: ReadonlyArray<RelayUrl>,
+  me: Pubkey,
+  peer: Pubkey,
+) =>
+  runLinkstr(
+    { secretKey, readRelays: relays, writeRelays: relays },
+    Effect.gen(function* () {
+      const offers = yield* BankOffers;
+      return yield* offers.send(
+        new BankOfferDraft({
+          to: peer,
+          offerId: BankOfferId.make(crypto.randomUUID()),
+          offerer: me,
+          status: "offered",
+          amountText: "250 CZK",
+          text: "Can you pay this for me?",
+          amountSat: 4200,
+        }),
+      );
+    }),
+  );
+```
+
+The promise resolves with a `BankOfferReceipt` once a relay accepted the peer's copy; persist `receipt.content` as the offer's local state.
+
+React — advance an offer you received. Every snapshot carries the full state, so build the next draft from the stored one and change only `status` and `text`:
+
+```ts
+import {
+  BankOfferDraft,
+  type BankOfferSnapshotReceived,
+  type BankOfferStatus,
+} from "@linky/linkstr";
+import { sendBankOfferAtom, useAtomSet } from "@linky/linkstr-react";
+import { Exit } from "effect";
+
+const nextSnapshot = (
+  offer: BankOfferSnapshotReceived,
+  status: BankOfferStatus,
+  text: string,
+) =>
+  new BankOfferDraft({
+    to: offer.from,
+    offerId: offer.offerId,
+    offerer: offer.offerer,
+    status,
+    amountText: offer.amountText,
+    text,
+    ...(offer.amountSat === null ? {} : { amountSat: offer.amountSat }),
+    ...(offer.initiatedAtSec === null
+      ? {}
+      : { initiatedAtSec: offer.initiatedAtSec }),
+    ...(offer.bankPaidAtSec === null
+      ? {}
+      : { bankPaidAtSec: offer.bankPaidAtSec }),
+    ...(offer.expiresAtSec === null
+      ? {}
+      : { expiresAtSec: offer.expiresAtSec }),
+    ...(offer.extensionSec === null
+      ? {}
+      : { extensionSec: offer.extensionSec }),
+    ...(offer.spdPayload === null ? {} : { spdPayload: offer.spdPayload }),
+  });
+
+interface OfferStore {
+  /** Placeholder: store the accepted snapshot as the offer's local state. */
+  saveSnapshot: (offerId: string, content: string, rumorId: string) => void;
+}
+
+export const useAcceptOffer = (store: OfferStore) => {
+  const sendBankOffer = useAtomSet(sendBankOfferAtom, { mode: "promiseExit" });
+
+  return async (offer: BankOfferSnapshotReceived): Promise<boolean> => {
+    const exit = await sendBankOffer(
+      nextSnapshot(offer, "accepted", "I will pay it"),
+    );
+    if (Exit.isFailure(exit)) return false; // keep the previous local status
+    store.saveSnapshot(offer.offerId, exit.value.content, exit.value.rumorId);
+    return true;
+  };
+};
+```
+
+## The flow, as linkstr sees it
+
+Two roles: the **offerer** (who needs the bank payment made) and the counterparty. `offerer` is a field on every snapshot, independent of who authored it, because an offer goes to several contacts at once and both sides send statuses.
+
+| `BankOfferStatus`   | Typically sent by | Meaning                                               | Push-marked |
+| ------------------- | ----------------- | ----------------------------------------------------- | ----------- |
+| `offered`           | offerer           | new offer to this contact                             | yes         |
+| `accepted`          | counterparty      | I will pay it                                         | yes         |
+| `accepted_by_other` | offerer           | someone else took it (sent to the remaining contacts) | yes         |
+| `bank_details_sent` | offerer           | the payment details went out                          | yes         |
+| `bank_paid`         | counterparty      | I paid the bank                                       | yes         |
+| `declined`          | counterparty      | not taking it                                         | yes         |
+| `canceled`          | offerer           | offer withdrawn                                       | no          |
+| `settled`           | offerer           | sats sent, done                                       | no          |
+
+`shouldPushBankOfferStatus(status)` encodes the last column; `pushMark` on the draft overrides it.
+
+Delivery order is `recipientFirst`: the self copy is published only after a relay accepted the counterparty's copy, so your other devices never sync a status the peer did not get.
+
+## Sending
+
+`BankOfferDraft` fields are typed on the class; the ones with behaviour behind them:
+
+- `offerId` is a `BankOfferId` (branded non-empty string), the same for every snapshot of one offer. `offerer` is the role, not the author.
+- `amountText` is the display amount (`"250 CZK"`); `text` is display copy, which the app templates per status. `spdPayload` is the bank QR payload.
+- `initiatedAtSec` defaults to `sentAt` when `status` is `offered`; `bankPaidAtSec` defaults to `sentAt` when `status` is `bank_paid`.
+- `pushMark` overrides `shouldPushBankOfferStatus`; `clientId` is generated when omitted.
+
+Repeat every field on every snapshot: the wire carries the full state, not a diff. `statusUpdatedAtSec` is always the send time.
+
+`BankOfferReceipt` carries `rumorId`, `offerId`, `status`, `content: string`, `clientId`, `sentAt`, `selfCopy`, and `recipientCopy`. `content` is the encoded JSON snapshot; the app stores it as the message content of the offer row so the local view and the wire agree byte for byte. To produce that JSON without sending — for a local-only placeholder row — call `encodeBankOfferContent` with every field (`null` for absent ones); its parameter type is not exported, and `bankOfferContentFromSnapshot` in `apps/web-app/src/app/hooks/messages/inboxNotifications.ts` is a complete call.
+
+Direct only: offers are not outbox operations. A snapshot that fails is simply resent by the user or the app's timers.
+
+## Receiving
+
+Both facts carry the draft fields above as nullable values (`text`, `amountSat`, the timestamps, `extensionSec`, `spdPayload`, `clientId`), plus `snapshotId: RumorId`, `statusUpdatedAtSec`, and `sentAt`. They differ only in who authored the wrap:
+
+| Tag                             | Extra field    | Meaning                                    |
+| ------------------------------- | -------------- | ------------------------------------------ |
+| `BankOfferSnapshotReceived`     | `from: Pubkey` | a counterparty's snapshot                  |
+| `OwnBankOfferSnapshotConfirmed` | `to: Pubkey`   | your own snapshot echoed; `to` is the peer |
+
+```ts
+import type {
+  BankOfferInboxEvent,
+  Pubkey,
+  WrapInboxEvent,
+} from "@linky/linkstr";
+
+/** Placeholder: merge by (peer, offerId); the newest statusUpdatedAtSec wins. */
+type ApplySnapshot = (peer: Pubkey, snapshot: BankOfferInboxEvent) => void;
+
+export const bankOfferHandler =
+  (applySnapshot: ApplySnapshot) =>
+  (event: WrapInboxEvent): void => {
+    if (event._tag === "BankOfferSnapshotReceived")
+      applySnapshot(event.from, event);
+    if (event._tag === "OwnBankOfferSnapshotConfirmed")
+      applySnapshot(event.to, event);
+  };
+```
+
+`event.offerer === myPubkey` tells you whether the offer is outgoing. Backfill replays old snapshots, so the merge must be idempotent.
+
+Drop reason: `invalid-bank-offer` — wrong `linky` tag, not p-tagged to you, unparsable content, unknown `status`, or no valid offerer pubkey.
+
+## Errors
+
+| Tag                    | When                                                                                                              | What to do                            |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `NoRelayReachable`     | no relay accepted the counterparty's copy; the self copy was never attempted (`selfCopy` has empty relay lists)   | keep the previous local status; retry |
+| `RecipientNotReached`  | in the error type but not produced here: recipient-first delivery never publishes the self copy before the peer's | handle like `NoRelayReachable`        |
+| `LinkstrNotConfigured` | React only, logged out                                                                                            | do not send                           |
+
+## Related
+
+- [payment-notices.md](./payment-notices.md) — the notice sent with the sats (`context: "bank_payment_offer"`)
+- [chat.md](./chat.md) — the token message that settles the offer
+- [inbox.md](./inbox.md) — delivery phases

--- a/packages/linkstr/docs/chat.md
+++ b/packages/linkstr/docs/chat.md
@@ -1,0 +1,180 @@
+# Chat
+
+`Chat` sends one-to-one messages: text, an encrypted image or file, a cashu token, and edits of an earlier text message. Text, token, and edit messages are NIP-17 kind 14 rumors; image messages are kind 15. Every message is gift-wrapped (kind 1059) twice — one wrap to the peer, one to yourself — so your other devices see the echo. In the app, chat sends go through the outbox (durable, retried across reloads); call the service directly only from one-shot environments.
+
+## Quick example
+
+Prerequisites: a `NostrSecretKey`, relay urls, and the peer's `Pubkey` — see [getting-started.md](./getting-started.md).
+
+Headless (service worker, scripts):
+
+```ts
+import { Effect } from "effect";
+import {
+  Chat,
+  MessageText,
+  TextMessageDraft,
+  runLinkstr,
+  type NostrSecretKey,
+  type Pubkey,
+  type RelayUrl,
+} from "@linky/linkstr";
+
+const sendText = (
+  secretKey: NostrSecretKey,
+  relays: ReadonlyArray<RelayUrl>,
+  peer: Pubkey,
+  text: string,
+) =>
+  runLinkstr(
+    { secretKey, readRelays: relays, writeRelays: relays },
+    Effect.gen(function* () {
+      const chat = yield* Chat;
+      return yield* chat.sendText(
+        new TextMessageDraft({ to: peer, content: MessageText.make(text) }),
+      );
+    }),
+  );
+```
+
+The promise resolves with a `ChatMessageReceipt` once a relay accepted the peer's copy. `receipt.rumorId` is the message id every device agrees on.
+
+React — the app's path, through the outbox. There is no `sendTextAtom`; enqueue a `chat.*` operation with `enqueueOutboxAtom`. `ChatStore` stands in for your own persistence:
+
+```ts
+import {
+  ClientId,
+  MessageText,
+  OutboxRef,
+  TextMessageDraft,
+  type Pubkey,
+  type RumorId,
+} from "@linky/linkstr";
+import { enqueueOutboxAtom, useAtomSet } from "@linky/linkstr-react";
+import { Exit } from "effect";
+
+interface ChatStore {
+  /** Placeholder: insert an optimistic pending row and return its local id. */
+  insertPending: (
+    peer: Pubkey,
+    text: MessageText,
+    clientId: ClientId,
+  ) => string;
+}
+
+export const useSendText = (store: ChatStore) => {
+  const enqueueOutbox = useAtomSet(enqueueOutboxAtom, { mode: "promiseExit" });
+
+  return async (peer: Pubkey, text: string): Promise<RumorId | null> => {
+    const content = MessageText.make(text);
+    const clientId = ClientId.make(crypto.randomUUID());
+    const localRowId = store.insertPending(peer, content, clientId);
+    const exit = await enqueueOutbox({
+      op: {
+        _tag: "chat.text",
+        draft: new TextMessageDraft({ to: peer, content, clientId }),
+      },
+      ref: OutboxRef.make(`message:${localRowId}`),
+    });
+    return Exit.isSuccess(exit) ? exit.value.rumorId : null;
+  };
+};
+```
+
+Three separate facts, in this order:
+
+1. **Enqueued** — `Exit.isSuccess(exit)`. The job is persisted and `rumorId` is fixed; nothing has reached a relay yet.
+2. **Accepted by a relay** — arrives later on the outbox results stream (`useOutboxResults`) as a `ChatMessageReceipt` or `MessageEditReceipt` keyed by your `ref` ([outbox.md](./outbox.md)).
+3. **Processed by the peer** — only a [seen receipt](./seen-receipts.md) tells you that.
+
+## Sending
+
+| Draft               | Fields                                                                                                                     | Service     | Outbox op    |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------ |
+| `TextMessageDraft`  | `to: Pubkey`, `content: MessageText`, `replyTo?: RumorId`, `root?: RumorId`, `clientId?: ClientId`, `sentAt?: UnixSeconds` | `sendText`  | `chat.text`  |
+| `TokenMessageDraft` | `to`, `token: CashuTokenText`, `replyTo?`, `root?`, `clientId?`, `sentAt?`                                                 | `sendToken` | `chat.token` |
+| `ImageMessageDraft` | `to`, `image: PrivateImage`, `replyTo?`, `root?`, `clientId?`, `sentAt?`                                                   | `sendImage` | `chat.image` |
+| `EditMessageDraft`  | `to`, `editOf: RumorId`, `content: MessageText`, `clientId?`, `sentAt?`                                                    | `edit`      | `chat.edit`  |
+
+- `clientId` is generated when omitted. Pass your own when an optimistic local row already exists; the echo (`OwnChatMessageConfirmed.clientId`) and the outbox result carry it back.
+- `replyTo` alone marks a reply to a top-level message; add `root` when replying inside a thread. Edits carry no reply context.
+- `MessageText` is a non-empty trimmed string; `CashuTokenText` must parse with `parseCashuToken`. Both throw from `.make` on bad input, so decode user input with `Schema.decodeUnknownEither` instead.
+
+`ChatMessageReceipt` carries `rumorId`, `clientId`, `sentAt`, `selfCopy`, and `recipientCopy`; `MessageEditReceipt` adds `editOf`. Each `WrapDelivery` lists `acceptedBy` / `rejectedBy` relays, and `.accepted` is true when at least one relay took the wrap. A receipt only exists when the recipient copy was accepted.
+
+Push: `sendText` and `sendImage` tag the recipient's wrap with `["linky", "push"]` so the push server can notify. `sendToken` and `edit` do not; a token send is followed by a push-marked payment notice instead (see [payment-notices.md](./payment-notices.md)).
+
+### Images and files
+
+Linkstr neither encrypts nor uploads. Before building an `ImageMessageDraft`, encrypt the file with AES-GCM, upload the ciphertext to a Blossom server using `makeBlossomUploadAuthHeader` ([http-auth.md](./http-auth.md)), and record both hashes. The app's adapter for this is [`apps/web-app/src/app/lib/privateImageMessage.ts`](../../../apps/web-app/src/app/lib/privateImageMessage.ts); its output is a `PrivateImage`: the ciphertext `url`, MIME `fileType`, `key` and `nonce` as lowercase hex, `encryptedSha256` of the stored bytes and `originalSha256` of the plaintext, `encryptedSize`, `storageEncoding` (`"base64"` or `"raw"`), and optional `fileName` plus `width`/`height` (both or neither: images yes, PDFs no).
+
+### Cashu tokens
+
+`parseCashuToken(raw)` returns `{ amount, mint, unit }` for a standard `cashuA`/`cashuB` token, else `null`; `extractWholeCashuToken(text)` strips a `cashu:` / `web+cashu://` prefix and returns the token when the whole input is one token, else `null`. On the wire a token message is a plain kind 14 whose content is the token; the decoder classifies it as `TokenBody`.
+
+## Receiving
+
+Chat facts arrive on the wrap inbox ([inbox.md](./inbox.md)). Edits are not a separate event: both facts carry `editOf`.
+
+| Tag                       | Fields                                                                                                                                              | Meaning                                                   |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `ChatMessageReceived`     | `messageId: RumorId`, `from: Pubkey`, `body: MessageBody`, `replyTo: RumorId \| null`, `root: RumorId \| null`, `editOf: RumorId \| null`, `sentAt` | a peer's message; `editOf` set = a new version of that id |
+| `OwnChatMessageConfirmed` | `messageId`, `to: Pubkey`, `body`, `replyTo`, `root`, `editOf`, `clientId: ClientId \| null`, `sentAt`                                              | your own message seen on a relay (echo or another device) |
+
+`MessageBody` is `TextBody { text }`, `ImageBody { image: PrivateImage }`, or `TokenBody { token: CashuTokenText }`.
+
+```ts
+import type {
+  MessageBody,
+  Pubkey,
+  RumorId,
+  UnixSeconds,
+  WrapInboxEvent,
+} from "@linky/linkstr";
+
+interface ChatStore {
+  // Placeholders for your persistence layer.
+  insertIncoming: (id: RumorId, from: Pubkey, body: MessageBody) => void;
+  applyEdit: (editOf: RumorId, body: MessageBody, sentAt: UnixSeconds) => void;
+  markSent: (clientIdOrMessageId: string) => void;
+}
+
+export const chatHandler =
+  (store: ChatStore) =>
+  (event: WrapInboxEvent): void => {
+    switch (event._tag) {
+      case "ChatMessageReceived":
+        if (event.editOf !== null)
+          return store.applyEdit(event.editOf, event.body, event.sentAt);
+        return store.insertIncoming(event.messageId, event.from, event.body);
+      case "OwnChatMessageConfirmed":
+        return store.markSent(event.clientId ?? event.messageId);
+      default:
+        return;
+    }
+  };
+```
+
+What to do with `OwnChatMessageConfirmed` is your storage policy. The web app only reconciles — match a pending row by `clientId`, then by `messageId`, and drop an echo that matches nothing — because all of its devices share one Evolu database, so the sending device's row already reaches the others. A consumer without shared storage must instead insert unmatched echoes as messages sent from another device.
+
+Wraps that fail chat decoding surface as `WrapDropped` with one of: `invalid-message` (not addressed to you, or no peer p-tag on your own copy), `invalid-image`, `invalid-edit`, `empty-message`, `nested-payload` (the content is itself a NIP-44 ciphertext), `unsupported-kind`.
+
+## Errors
+
+| Tag                    | When                                                      | What to do                                                           |
+| ---------------------- | --------------------------------------------------------- | -------------------------------------------------------------------- |
+| `RecipientNotReached`  | your self copy landed, no relay accepted the peer's copy  | the peer will not see it; retry — the outbox does this for you       |
+| `NoRelayReachable`     | no relay accepted either wrap                             | offline or all write relays down; retry later                        |
+| `OutboxJobFailed`      | outbox terminal: `identity-changed` or `unexpected-error` | mark the local row failed; a delivery error never reaches this state |
+| `LinkstrNotConfigured` | React only: `linkstrConfigAtom` is null                   | user is logged out; do not send                                      |
+
+Both delivery errors carry `rumorId`, `clientId`, `sentAt`, `selfCopy`, and `recipientCopy`.
+
+## Related
+
+- [outbox.md](./outbox.md) — enqueue, results stream, `OutboxRef`
+- [inbox.md](./inbox.md) — opening the wrap inbox and delivery phases
+- [reactions.md](./reactions.md) — reacting to a `messageId`
+- [seen-receipts.md](./seen-receipts.md) — read cursors for a conversation
+- [http-auth.md](./http-auth.md) — Blossom upload auth for images
+- [../README.md](../README.md) — honest delivery and authenticated inbound

--- a/packages/linkstr/docs/concepts.md
+++ b/packages/linkstr/docs/concepts.md
@@ -1,0 +1,157 @@
+# Concepts
+
+The mental model behind every linkstr API: the words, what goes in, what comes out, how delivery is judged, and the little Effect you need to call it. Read it once before the vertical guides; come back when a type in a signature surprises you.
+
+## Vocabulary
+
+| Term                      | Meaning                                                                                                                                                                                                     |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Rumor                     | The inner, unsigned Nostr event that carries the content (a message, a reaction). Its id, `RumorId`, is the stable identity of the thing sent.                                                              |
+| Gift wrap                 | The encrypted, signed envelope (kind 1059) a rumor travels in, so relays see only ciphertext and a recipient tag. A fresh wrap is generated on every publish, so `WrapId` is transport-level identity only. |
+| Self copy, recipient copy | A private send wraps the same rumor twice: once addressed to you, once to the peer.                                                                                                                         |
+| Own echo                  | Your self copy coming back from a relay, or a send from another of your devices, surfaced as an `Own…Confirmed` fact. It is your reconciliation signal, never an incoming message.                          |
+| EOSE                      | "End of stored events": the marker a relay sends once it has replayed everything it stored for your subscription. Events before it are `backfill`, events after it `live`.                                  |
+| Plain event               | A signed Nostr event published as-is (profile, relay lists, mute list). Anyone can read it.                                                                                                                 |
+
+## Drafts in, receipts out, facts back
+
+Two-copy private verticals (chat, reactions, bank offers, seen receipts) have three shapes:
+
+| Shape   | Direction   | Example                                 | Where                  |
+| ------- | ----------- | --------------------------------------- | ---------------------- |
+| Draft   | you → wire  | `ReactionDraft`, `TextMessageDraft`     | `<vertical>/domain.ts` |
+| Receipt | wire → you  | `ReactionReceipt`, `ChatMessageReceipt` | `<vertical>/domain.ts` |
+| Fact    | relay → you | `ReactionAdded`, `ChatMessageReceived`  | `<vertical>/events.ts` |
+
+Drafts are `Schema.Class`es; build them with `new TextMessageDraft({ … })`. Optional `clientId` and `sentAt` are filled in when omitted; pass `clientId` when you already inserted an optimistic local row so the relay echo can be matched back.
+
+Receipts are `Schema.TaggedClass`es. Every wrap receipt names the delivered rumor as `rumorId`, so you never switch on receipt class to find the id.
+
+Facts arrive through `WrapInbox` as one tagged union, `WrapInboxEvent`. A two-copy vertical contributes a peer-authored fact and an own echo (`ReactionAdded` vs `OwnReactionConfirmed`, `ChatMessageReceived` vs `OwnChatMessageConfirmed`, …). Dispatch on `_tag`; see [inbox.md](./inbox.md).
+
+The other verticals bend this shape: [payment notices](./payment-notices.md) are single-copy, so they have a peer fact but no own echo; [payment telemetry](./payment-telemetry.md) is single-copy and has no inbox fact at all; the plain verticals ([profiles](./profiles.md), [relay lists](./relay-lists.md), [mute list](./mute-list.md)) are fetched or watched rather than received through the inbox.
+
+## Gift-wrapped vs plain
+
+| Family          | On the wire                         | Verticals                                                                                                 |
+| --------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Gift-wrapped    | kind 1059 around a rumor            | chat 14/15, reactions 7/5, payment notices 24133, telemetry 24134, bank offers 24135, seen receipts 24136 |
+| Plain           | signed event, published as-is       | profiles 0 and 30315, relay lists 10002 and 10050, mute list 10000                                        |
+| Never published | signed event used as an HTTP header | `httpAuth`: Blossom 24242, NIP-98 and push ownership proof 27235                                          |
+
+`WrapInbox` receives and authenticates the gift-wrapped verticals (seal signature, rumor author equals seal author, rumor id equals rumor hash), except telemetry: it has no inbox decoder, so a telemetry wrap addressed to you surfaces as `WrapDropped("unsupported-kind")`. Plain verticals are fetched or watched (`ProfileWatch`) and verified by their own signature.
+
+## Honest delivery
+
+A private send wraps the same rumor twice: once to yourself (cross-device echo) and once to the peer. The receipt carries both as `selfCopy` and `recipientCopy` (`WrapDelivery`: `wrapId`, `acceptedBy`, `rejectedBy`, `accepted`).
+
+| Outcome                                     | Result                 |
+| ------------------------------------------- | ---------------------- |
+| ≥1 relay accepted the recipient copy        | receipt                |
+| self copy accepted, recipient copy rejected | `RecipientNotReached`  |
+| nothing accepted                            | `NoRelayReachable`     |
+| single-copy send, nothing accepted          | `WrapNotDelivered`     |
+| plain event, nothing accepted               | `NoRelayAcceptedEvent` |
+
+"Only my self copy landed" is never reported as success. A relay accepting the copy is not the peer reading it; the peer's client still has to receive and decode it. The transport never retries; when you need retries, use the [outbox](./outbox.md).
+
+## Branded primitives
+
+All in `domain/primitives.ts`. Each is an effect `Schema` with a brand, so a plain `string` does not type-check where a `Pubkey` is expected.
+
+| Type             | Shape                          | Make one                                                                |
+| ---------------- | ------------------------------ | ----------------------------------------------------------------------- |
+| `Pubkey`         | 64 hex, on-curve               | `parsePubkey(str)`, `decodeNpub(str)`, `derivePubkey(key)`              |
+| `NostrSecretKey` | 32 bytes in curve order        | `decodeNsec(str)`                                                       |
+| `RumorId`        | 64 hex; identity of a message  | from receipts and facts                                                 |
+| `WrapId`         | 64 hex; one signed wrap        | from `WrapDelivery.wrapId`, push payloads                               |
+| `EventId`        | 64 hex; one signed plain event | from `PlainEventReceipt.eventId`                                        |
+| `ClientId`       | non-empty string               | `ClientId.make(localId)`                                                |
+| `RelayUrl`       | `ws://` or `wss://` with host  | `RelayUrl.make(str)` (throws) or `Schema.decodeUnknownOption(RelayUrl)` |
+| `UnixSeconds`    | positive integer               | `UnixSeconds.make(n)`                                                   |
+| `Emoji`          | trimmed, ≤32 chars             | `Emoji.make(str)`                                                       |
+
+`X.make(value)` validates and throws on failure. `Schema.is(X)` is a type guard; `Schema.decodeUnknownOption(X)` returns an `Option`. Rumor ids and wrap ids are different things: wraps are regenerated on every publish, rumor ids are stable.
+
+## Services and Layers
+
+Capabilities enter as Effect services and the composition root supplies them:
+
+| Service            | Provides                        | Layer                                             |
+| ------------------ | ------------------------------- | ------------------------------------------------- |
+| `LinkstrIdentity`  | `pubkey`, `secretKey`           | `LinkstrIdentity.fromSecretKey(key)`              |
+| `RelayPolicy`      | `readRelays`, `writeRelays`     | `RelayPolicy.fixed({ readRelays, writeRelays })`  |
+| `NostrTransport`   | `publish`, `subscribe`, `fetch` | `NostrTransportSimplePool` or a stub              |
+| `OutboxStore`      | durable job list                | `OutboxStore.inMemory`, `.fromStringStorage`      |
+| `InboxCursorStore` | persisted backfill cursor       | `InboxCursorStore.inMemory`, `.fromStringStorage` |
+| `Inspector`        | optional diagnostics bus        | `Inspector.live`, `.disabled`, or none            |
+| `RelayHealth`      | per-relay connection snapshot   | `RelayHealth.live`                                |
+
+Vertical services (`Reactions`, `Chat`, `WrapInbox`, …) are `Effect.Service` classes with a `.Default` layer. `linkstrServices(config)` assembles all of them; `runLinkstr` and the react runtime both call it. You only build layers by hand in tests.
+
+## Effect in five minutes
+
+You need exactly this much Effect to use the package.
+
+```ts
+import { Effect, Stream } from "effect";
+import { Reactions, WrapInbox } from "@linky/linkstr";
+
+// An Effect<A, E, R> is a description of a computation: success A,
+// typed failure E, required services R. Nothing runs until you run it.
+const program = Effect.gen(function* () {
+  const reactions = yield* Reactions; // yield* a service tag to get the service
+  const inbox = yield* WrapInbox;
+  return { reactions, inbox };
+});
+```
+
+- `Effect.gen(function* () { … })` lets you write sequential code; `yield*` unwraps an Effect (or a service tag) and propagates its failure.
+- Failures are values in the `E` channel. Handle them before the Promise boundary: `Effect.catchTags({ … })` handles named tags, `Effect.either` turns the result into `Either<A, E>`. `Effect.runPromise` rejects with anything you left unhandled, and the rejection is wrapped, so do not match on it as a tagged error.
+- A `Layer<S>` builds a service `S`; `Effect.provide(effect, layer)` satisfies `R`. `Layer.mergeAll` combines layers; `Layer.provide` feeds one layer's outputs into another's inputs.
+- A `Stream<A>` is a lazy sequence. Consume with `Stream.runForEach(stream, (a) => Effect…)`, or `Stream.take(n)` + `Stream.runCollect`.
+- A `Scope` owns resources. Anything typed `Effect<…, …, Scope.Scope>` (like `inbox.open`) must run inside `Effect.scoped(…)`; leaving the scope releases it. `Effect.forkScoped` runs a fiber that dies with the scope.
+- `Effect.timeoutOption("1 minute")` bounds an effect without failing it.
+
+In React you never run effects yourself; fn atoms do it and hand you a `Result` or an `Exit` ([react.md](./react.md)).
+
+## Errors are `Schema.TaggedError`
+
+Every failure is a class with a `_tag` and serializable fields. Match on `_tag`, and persist them as-is when you need to (the outbox stores them on job rows).
+
+```ts
+import { Effect, Either } from "effect";
+import { Reactions, type ReactionDraft } from "@linky/linkstr";
+
+const describeFailure = (draft: ReactionDraft) =>
+  Effect.flatMap(Reactions, (reactions) => reactions.react(draft)).pipe(
+    Effect.catchTags({
+      RecipientNotReached: (error) =>
+        Effect.succeed(
+          `peer copy rejected by ${error.recipientCopy.rejectedBy.length} relays`,
+        ),
+      NoRelayReachable: () => Effect.succeed("offline"),
+    }),
+  );
+
+// Or keep the failure as a value and decide at the call site.
+const reactOrExplain = (draft: ReactionDraft) =>
+  Effect.flatMap(Reactions, (reactions) => reactions.react(draft)).pipe(
+    Effect.either,
+    Effect.map(
+      Either.match({
+        onLeft: (error) => `failed: ${error._tag}`,
+        onRight: (receipt) => `sent ${receipt.rumorId}`,
+      }),
+    ),
+  );
+```
+
+Other tags you will meet: `WrapNotDelivered`, `NoRelayAcceptedEvent`, `AllRelaysUnreachable` (one-shot fetch reached nobody), `NoReadRelaysConfigured`, `RelayUnreachable` (transport level), and `LinkstrNotConfigured` from linkstr-react.
+
+## Related
+
+- [getting-started.md](./getting-started.md)
+- [inbox.md](./inbox.md) — the `WrapInboxEvent` union in full
+- [outbox.md](./outbox.md) — durable sends and retries
+- [../README.md](../README.md) — the rules and why they exist

--- a/packages/linkstr/docs/getting-started.md
+++ b/packages/linkstr/docs/getting-started.md
@@ -1,0 +1,173 @@
+# Getting started
+
+`@linky/linkstr` is Linky's Nostr protocol as a typed library: hand in a draft, get a receipt back, and consume everything inbound as one tagged union. Raw Nostr events never cross the package boundary. This page takes you from two keys to a delivered message and its inbox echo, in one file you run.
+
+## Core concepts
+
+- **Services per vertical.** Each protocol feature is an Effect service (`Chat`, `Reactions`, `Profiles`, `WrapInbox`, …): `yield* Chat`, then call a method.
+- **Drafts in, receipts out, facts back.** A send takes a draft (`TextMessageDraft`, `ReactionDraft`, …) and returns a receipt. Inbound arrives as `WrapInboxEvent`, a union you switch on by `_tag`.
+- **Gift-wrapped vs plain.** Private verticals (chat, reactions, receipts, notices, offers) travel encrypted inside kind-1059 gift wraps and are read through one `WrapInbox` subscription. Public verticals (profiles, relay lists, mute list) are plain signed events with their own fetch and watch calls.
+- **Honest delivery.** A private send publishes one copy to you and one to the peer, and succeeds only when a relay accepted the peer's copy; otherwise you get `RecipientNotReached` or `NoRelayReachable`. The [outbox](./outbox.md) adds retries when you want a queue.
+- **Branded types, typed errors.** Keys, pubkeys, relay urls, and ids are branded (`NostrSecretKey`, `Pubkey`, `RelayUrl`, `RumorId`) and built with exported codecs. Every failure is a tagged error you match on.
+
+[concepts.md](./concepts.md) defines the vocabulary (rumor, gift wrap, own echo, EOSE) and goes deeper on each point.
+
+## Import paths
+
+| Path                     | What you get                                                                                       |
+| ------------------------ | -------------------------------------------------------------------------------------------------- |
+| `@linky/linkstr`         | services, drafts, receipts, facts, key codecs, `runLinkstr`, `linkstrServices`                     |
+| `@linky/linkstr/testing` | `makeIdentity`, publish stubs, `FakeRelay`, `stubStorage`; tests only ([testing.md](./testing.md)) |
+| `@linky/linkstr-react`   | effect-atom bindings for the web app ([react.md](./react.md))                                      |
+
+Never import `nostr-tools` in consumer code; the codecs in [identity-and-keys.md](./identity-and-keys.md) cover keys and ids.
+
+## What you bring
+
+1. Your `NostrSecretKey`: `decodeNsec("nsec1…")`.
+2. The peer's `Pubkey`: `parsePubkey(str)` accepts `npub1…` or 64-hex.
+3. `RelayUrl`s: `Schema.is(RelayUrl)` narrows a string; `RelayUrl.make(str)` throws on a bad one.
+
+The two decoders return `null` on bad input instead of throwing. Check for it before you build a config; the script below stops on the first bad input.
+
+## First run
+
+You need two keys: yours and the peer's. Mint throwaway ones from the package directory. The testing helper is fine in a script you delete afterwards; never import it from app code.
+
+```bash
+cd packages/linkstr
+bun -e 'import { makeIdentity } from "@linky/linkstr/testing"; import { encodeNpub, encodeNsec } from "@linky/linkstr"; const id = makeIdentity(); console.log(encodeNsec(id.secretKey), encodeNpub(id.pubkey));'
+```
+
+Run it twice. Keep the first `nsec` as `NSEC` and the second `npub` as `PEER`. Save this as `packages/linkstr/firstRun.ts` (workspace imports resolve there):
+
+```ts
+import { Effect, Option, Schema, Stream } from "effect";
+import {
+  Chat,
+  decodeNsec,
+  MessageText,
+  parsePubkey,
+  RelayUrl,
+  runLinkstr,
+  TextMessageDraft,
+  UnixSeconds,
+  WrapInbox,
+  type WrapInboxEvent,
+} from "@linky/linkstr";
+
+const input = (name: string): string => {
+  const value = process.env[name];
+  if (!value) throw new Error(`set ${name}`);
+  return value;
+};
+
+const secretKey = decodeNsec(input("NSEC"));
+const peer = parsePubkey(input("PEER"));
+const relay = input("RELAY");
+if (secretKey === null) throw new Error("NSEC is not a valid nsec");
+if (peer === null) throw new Error("PEER is not an npub or a hex pubkey");
+if (!Schema.is(RelayUrl)(relay)) throw new Error("RELAY is not a ws(s):// url");
+
+const config = { secretKey, readRelays: [relay], writeRelays: [relay] };
+
+const sendHello = () =>
+  runLinkstr(
+    config,
+    Effect.gen(function* () {
+      const chat = yield* Chat;
+      const receipt = yield* chat.sendText(
+        new TextMessageDraft({
+          to: peer,
+          content: MessageText.make("hello from linkstr"),
+        }),
+      );
+      return `sent ${receipt.rumorId}: peer copy accepted by ${receipt.recipientCopy.acceptedBy.length} relay(s)`;
+    }).pipe(
+      Effect.catchTags({
+        RecipientNotReached: (error) =>
+          Effect.succeed(
+            `peer copy rejected by ${error.recipientCopy.rejectedBy.length} relay(s); nothing to retry automatically`,
+          ),
+        NoRelayReachable: () =>
+          Effect.succeed("no relay accepted anything; is RELAY up?"),
+      }),
+    ),
+  );
+
+const label = (event: WrapInboxEvent): string =>
+  event._tag === "OwnChatMessageConfirmed"
+    ? `${event._tag} ${event.messageId}`
+    : event._tag;
+
+const printFirstInboxEvent = () =>
+  runLinkstr(
+    config,
+    Effect.scoped(
+      Effect.gen(function* () {
+        const inbox = yield* WrapInbox;
+        const feed = yield* inbox.open({
+          since: UnixSeconds.make(Math.floor(Date.now() / 1000) - 60),
+        });
+        const first = yield* Stream.runHead(feed.events);
+        return Option.map(
+          first,
+          ({ delivery, event }) => `${delivery} ${label(event)}`,
+        );
+      }),
+    ).pipe(
+      Effect.timeoutOption("20 seconds"),
+      Effect.map((result) =>
+        Option.getOrElse(
+          Option.flatten(result),
+          () => "nothing arrived in 20 s",
+        ),
+      ),
+    ),
+  );
+
+console.log(await sendHello());
+console.log(await printFirstInboxEvent());
+```
+
+Start the local relay from the repo root and run the file:
+
+```bash
+docker compose -f docker-compose.dev.yml up -d --wait nostr-relay
+NSEC=nsec1… PEER=npub1… RELAY=ws://localhost:7777 bun run packages/linkstr/firstRun.ts
+```
+
+Expected output (ids shortened here; yours are 64 hex chars and match on both lines):
+
+```
+sent 9049fbe8…: peer copy accepted by 1 relay(s)
+backfill OwnChatMessageConfirmed 9049fbe8…
+```
+
+What happened:
+
+- `runLinkstr` built every service over the key and relays, ran the effect, and closed the relay pool. Two calls, two pools.
+- `Chat.sendText` wrapped the message twice, once to the peer and once to you, and the receipt reports both copies. `catchTags` turns the two delivery failures into strings; any other failure rejects the promise.
+- `WrapInbox.open` subscribed to kind 1059 for your pubkey. A `Scope` owns the subscription; leaving `Effect.scoped` closes it. The first event is your own copy coming back, an **own echo** tagged `OwnChatMessageConfirmed`, with the same rumor id the receipt gave you. `backfill` means the relay served it from storage, before its EOSE marker. See [inbox.md](./inbox.md).
+
+Point `RELAY` at a closed port and the lines become `no relay accepted anything; is RELAY up?` and `nothing arrived in 20 s`. A bad `NSEC` stops before any network call: `error: NSEC is not a valid nsec`.
+
+Delete `firstRun.ts` when you are done; it is not part of the package.
+
+## Two ways to run
+
+Both take `secretKey`, `readRelays`, and `writeRelays` (arrays of `RelayUrl`).
+
+- **`runLinkstr(config, effect)`**: one-shot, as above. Builds the services, runs the effect, tears down the pool. Use it in the service worker, scripts, and tests. `writeRelays` defaults to `[]` for read-only consumers; optional `outboxStore` and `transport` (test seam). The inbox cursor is in memory.
+- **`linkstrServices(config)`**: the same composition as a `Layer`, for a runtime that outlives one call. `writeRelays` and `transport` (normally `NostrTransportSimplePool`) are required; `outboxStore` and `inboxCursorStore` are optional and default to memory. In React do not use it by hand: `@linky/linkstr-react` builds this layer from `linkstrConfigAtom` and rebuilds it on identity change ([react.md](./react.md)).
+
+## Next
+
+Pick the guide for the vertical you need from the [guide index](./README.md). Each opens with a working example and ends with its error table.
+
+## Related
+
+- [concepts.md](./concepts.md) — vocabulary, the mental model, and a minimal Effect primer
+- [react.md](./react.md) — the atoms you use inside the web app
+- [testing.md](./testing.md) — stubs and fakes for unit tests
+- [../README.md](../README.md) — design rules and their rationale

--- a/packages/linkstr/docs/http-auth.md
+++ b/packages/linkstr/docs/http-auth.md
@@ -1,0 +1,177 @@
+# HTTP auth
+
+`httpAuth` turns your nostr key into HTTP credentials. Three pure codecs sign an event and hand you a header or an event object; none of them touches a relay or needs the runtime. Use them when a server wants proof of key ownership: Blossom uploads (kind 24242), NIP-98 `Authorization` headers (kind 27235), and the push server's subscribe/unsubscribe challenge proof (also kind 27235). These events are never published — they are only ever sent to the server that asked for them.
+
+## Quick example
+
+Prerequisites: a `NostrSecretKey` — see [getting-started.md](./getting-started.md). Every encoder takes `now` explicitly; the caller owns the clock.
+
+Blossom — upload already-encrypted bytes. `sha256` is the hash of the ciphertext you upload, `serverDomain` is the hostname only:
+
+```ts
+import {
+  UnixSeconds,
+  makeBlossomUploadAuthHeader,
+  type NostrSecretKey,
+} from "@linky/linkstr";
+
+const now = () => UnixSeconds.make(Math.floor(Date.now() / 1000));
+
+export const uploadToBlossom = async (
+  secretKey: NostrSecretKey,
+  serverDomain: string,
+  ciphertext: ArrayBuffer,
+  encryptedSha256: string,
+): Promise<string> => {
+  const response = await fetch(`https://${serverDomain}/upload`, {
+    method: "PUT",
+    headers: {
+      Authorization: makeBlossomUploadAuthHeader(
+        { sha256: encryptedSha256, serverDomain },
+        secretKey,
+        now(),
+      ),
+      "Content-Type": "text/plain;charset=UTF-8",
+    },
+    body: ciphertext,
+  });
+  if (!response.ok) throw new Error(`upload rejected: ${response.status}`);
+  return `https://${serverDomain}/${encryptedSha256}`;
+};
+```
+
+NIP-98 — sign the exact url and method you will request; add `payload` when the body is JSON:
+
+```ts
+import {
+  UnixSeconds,
+  makeNip98AuthHeader,
+  type NostrSecretKey,
+} from "@linky/linkstr";
+
+export const putMintPreference = async (
+  secretKey: NostrSecretKey,
+  mintUrl: string,
+): Promise<void> => {
+  const url = "https://npub.linky.fit/api/v1/info/mint";
+  const payload = { mintUrl };
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: {
+      Authorization: makeNip98AuthHeader(
+        { url, method: "PUT", payload },
+        secretKey,
+        UnixSeconds.make(Math.floor(Date.now() / 1000)),
+      ),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) throw new Error(`rejected: ${response.status}`);
+};
+```
+
+Push ownership — an event, not a header. First ask the push server for a challenge (`POST /auth/challenge` with `{ action, pubkey }`), then send the proof in the JSON body of the subscribe or unsubscribe request:
+
+```ts
+import {
+  UnixSeconds,
+  makePushOwnershipProof,
+  type NostrSecretKey,
+  type Pubkey,
+} from "@linky/linkstr";
+
+export const proveSubscribe = async (
+  pushServerUrl: string,
+  secretKey: NostrSecretKey,
+  pubkey: Pubkey,
+) => {
+  const challengeResponse = await fetch(`${pushServerUrl}/auth/challenge`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action: "subscribe", pubkey }),
+  });
+  if (!challengeResponse.ok) throw new Error("challenge refused");
+  const { challenge } = (await challengeResponse.json()) as {
+    challenge: string;
+  };
+  return makePushOwnershipProof(
+    { action: "subscribe", challenge },
+    secretKey,
+    UnixSeconds.make(Math.floor(Date.now() / 1000)),
+  );
+};
+```
+
+The app's version, with response decoding and the surrounding subscription flow, is `apps/web-app/src/utils/pushNotifications.ts`. No React atom exists for any of these: they are synchronous functions, so call them inside whatever hook already holds the secret key.
+
+## Codecs
+
+| Function                                             | Draft                                                                         | Returns                                                         |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `makeBlossomUploadAuthHeader(draft, secretKey, now)` | `BlossomUploadAuthDraft { sha256, serverDomain }`                             | `Authorization` header value; valid for 600 s                   |
+| `makeNip98AuthHeader(draft, secretKey, now)`         | `Nip98AuthDraft { url, method, payload?: Record<string, string> }`            | `Authorization` header value bound to that url and method       |
+| `makePushOwnershipProof(draft, secretKey, now)`      | `PushOwnershipProofDraft { action: "subscribe" \| "unsubscribe", challenge }` | `SignedPlainEvent` bound to the challenge and action            |
+| `verifyPushOwnershipProof(input)`                    | `unknown` (the parsed JSON)                                                   | `Either<VerifiedPushOwnershipProof, PushOwnershipProofFailure>` |
+
+- `secretKey` is a `NostrSecretKey`; get one with `decodeNsec` ([identity-and-keys.md](./identity-and-keys.md)). The helpers never log or return it.
+- NIP-98: the server compares the signed url with the request url, so sign what you actually send. The app signs the bare path and leaves query strings out where the server does (`npubCashUpstreamQuotes.ts`).
+- Blossom: the `sha256` in the header must match the uploaded bytes, or the server rejects the upload.
+
+## Server-side verification
+
+`verifyPushOwnershipProof` checks signature, kind, the exactly-once `challenge` / `action` / `pubkey` tags, that the `pubkey` tag equals the event author, and the content string. Everything about _your_ request is still yours to check. `apps/push/src/ownership.ts` does it like this:
+
+```ts
+import { verifyPushOwnershipProof } from "@linky/linkstr";
+import type { PushOwnershipProofFailure } from "@linky/linkstr";
+
+const failureStatus: Record<PushOwnershipProofFailure, number> = {
+  "malformed-event": 400,
+  "invalid-signature": 401,
+  "wrong-kind": 400,
+  "invalid-challenge": 400,
+  "invalid-action": 400,
+  "invalid-pubkey-tag": 400,
+  "invalid-pubkey": 401,
+  "wrong-content": 400,
+};
+
+interface ProofRequest {
+  body: { event: unknown }; // the parsed JSON body
+  pubkey: string; // the pubkey the client claims
+  action: "subscribe" | "unsubscribe"; // what this endpoint does
+  nowSeconds: number;
+  proofMaxAgeSeconds: number;
+  /** Placeholder: returns false unless the nonce was issued to this pubkey and is unused. */
+  consumeChallenge: (challenge: string, pubkey: string) => boolean;
+}
+
+/** Returns the HTTP status to reject with, or null when the proof is good. */
+export const checkProof = (request: ProofRequest): number | null => {
+  const decoded = verifyPushOwnershipProof(request.body.event);
+  if (decoded._tag === "Left") return failureStatus[decoded.left];
+  const { event, action, challenge } = decoded.right;
+
+  if (event.pubkey !== request.pubkey) return 401;
+  if (action !== request.action) return 401;
+  if (
+    Math.abs(request.nowSeconds - event.created_at) > request.proofMaxAgeSeconds
+  )
+    return 401;
+  if (!request.consumeChallenge(challenge, request.pubkey)) return 401;
+  return null;
+};
+```
+
+The four follow-up checks are what make the proof single-use and bound to this request: the pubkey the client claims, the action the endpoint performs, a freshness window, and a stored challenge nonce that is consumed on first use.
+
+## Errors
+
+The encoders do not fail; an invalid key cannot reach them because `NostrSecretKey` is validated at decode time. The verifier returns a `PushOwnershipProofFailure` string. `invalid-signature` and `invalid-pubkey` (the `pubkey` tag differs from the event author) mean a forged or foreign proof, so answer 401; every other value is a malformed request, so answer 400 — the table in the snippet above maps them.
+
+## Related
+
+- [identity-and-keys.md](./identity-and-keys.md) — `decodeNsec`, `NostrSecretKey`
+- [chat.md](./chat.md) — the image upload that uses the Blossom header
+- [push-inbox.md](./push-inbox.md) — the push server these proofs authorize

--- a/packages/linkstr/docs/identity-and-keys.md
+++ b/packages/linkstr/docs/identity-and-keys.md
@@ -1,0 +1,60 @@
+# Identity and keys
+
+How strings become keys and how keys become the `LinkstrIdentity` service. You need it at login, when parsing user-entered pubkeys, and when wiring a non-React runtime.
+
+## Codecs
+
+All in `identity/codec.ts`, exported from `@linky/linkstr`. Decoders return `null` on any bad input; nothing throws.
+
+| Function                         | In → Out                                         | Notes                            |
+| -------------------------------- | ------------------------------------------------ | -------------------------------- |
+| `decodeNsec(str)`                | `nsec1…` → `NostrSecretKey \| null`              | rejects keys outside curve order |
+| `encodeNsec(key)`                | `NostrSecretKey` → `nsec1…`                      |                                  |
+| `identityFromNsec(str)`          | `nsec1…` → `{ secretKey, pubkey } \| null`       | what login uses                  |
+| `derivePubkey(key)`              | `NostrSecretKey` → `Pubkey`                      |                                  |
+| `decodeNpub(str)`                | `npub1…` → `Pubkey \| null`                      |                                  |
+| `encodeNpub(pubkey)`             | `Pubkey` → `npub1…`                              |                                  |
+| `parsePubkey(str)`               | `npub1…` or 64-hex (any case) → `Pubkey \| null` | use for user input               |
+| `decodeNprofilePubkey(str)`      | `nprofile1…` → `Pubkey \| null`                  | relay hints are dropped          |
+| `encodeNprofile(pubkey, relays)` | → `nprofile1…`                                   | `relays` are plain strings       |
+
+```ts
+import { encodeNpub, identityFromNsec, parsePubkey } from "@linky/linkstr";
+
+const login = (nsec: string) => {
+  const identity = identityFromNsec(nsec.trim());
+  if (identity === null) throw new Error("not an nsec");
+  return { ...identity, npub: encodeNpub(identity.pubkey) };
+};
+
+const peerFromInput = (raw: string) => parsePubkey(raw.trim()); // Pubkey | null
+```
+
+## Validation
+
+The codecs validate cryptographic keys, not just their length: `parsePubkey`, `decodeNpub`, `Pubkey.make`, and `Schema.is(Pubkey)` all reject a 64-hex string that is not a valid public key, and `NostrSecretKey` requires bytes a public key can be derived from. If you keep pubkeys as plain strings in storage, revalidate them with `Schema.is(Pubkey)` before building a draft, so a corrupt value fails at the boundary rather than inside a send or an unwrap.
+
+## `LinkstrIdentity`
+
+The service every signing and unwrapping path reads: `{ pubkey, secretKey }`. Build it with `LinkstrIdentity.fromSecretKey(secretKey)`; `linkstrServices`, `runLinkstr`, and the react runtime do this for you from `config.secretKey`.
+
+```ts
+import { Effect } from "effect";
+import { LinkstrIdentity } from "@linky/linkstr";
+
+const whoAmI = Effect.map(LinkstrIdentity, (identity) => identity.pubkey);
+```
+
+Read `pubkey` from it when a vertical needs "me" (for example to tell an own echo from a peer fact). Do not copy `secretKey` anywhere else, and never put it, an nsec, or seed words into inspector events or logs ([inspector.md](./inspector.md#the-no-key-material-rule)).
+
+Identity is fixed for the lifetime of a runtime. To switch accounts, build a new runtime: `runLinkstr` does that per call, and linkstr-react rebuilds when `linkstrConfigAtom` changes ([react.md](./react.md#identity-switches)). The outbox refuses jobs stored under another pubkey ([outbox.md](./outbox.md)).
+
+## `nostr-tools` stays inside linkstr
+
+Consumers never import `nostr-tools`: the codecs above cover every key operation, the verticals cover every event, and `SignedPlainEvent` is exported for the HTTP-auth payloads that must be serialized. The [package README](../README.md) explains why.
+
+## Related
+
+- [concepts.md](./concepts.md#branded-primitives)
+- [http-auth.md](./http-auth.md) — signing events used as HTTP credentials
+- [testing.md](./testing.md) — `makeIdentity` for throwaway keys

--- a/packages/linkstr/docs/inbox.md
+++ b/packages/linkstr/docs/inbox.md
@@ -1,0 +1,171 @@
+# Inbox
+
+`WrapInbox` is the one kind-1059 subscription: it backfills from a persisted cursor, authenticates every gift wrap, and hands you typed facts on a single stream. You need it whenever your process should receive messages, reactions, notices, offers, or receipts, and for one-shot decoding when a push notification names a wrap. Terms like rumor, own echo, and EOSE are defined in [concepts.md](./concepts.md#vocabulary).
+
+## Open the feed
+
+Prerequisite: a configured runtime ([getting-started.md](./getting-started.md#first-run) shows one).
+
+```ts
+import { Effect, Stream } from "effect";
+import { UnixSeconds, WrapInbox } from "@linky/linkstr";
+
+/** Backfill window for a first session without a stored cursor. */
+const LOOKBACK_SECONDS = 3 * 24 * 60 * 60;
+
+const consume = Effect.scoped(
+  Effect.gen(function* () {
+    const inbox = yield* WrapInbox;
+    const feed = yield* inbox.open({
+      since: UnixSeconds.make(Math.floor(Date.now() / 1000) - LOOKBACK_SECONDS),
+    });
+    yield* Stream.runForEach(feed.events, ({ delivery, event }) =>
+      Effect.sync(() => console.log(delivery, event)),
+    );
+  }),
+);
+```
+
+- `open(options?)` returns `WrapInboxFeed` and requires a `Scope`. Leaving the scope closes every relay subscription and ends the stream.
+- Options: `since` (backfill start, used only when the cursor store is empty) and `resubscribeDelay` (base of the per-relay backoff, default 5s).
+- Fails with `NoReadRelaysConfigured` when `RelayPolicy.readRelays` is empty.
+- `feed.events` is `Stream<DeliveredInboxEvent>`: `{ delivery, event }`. It is **single-consumer**; if two parts of your app need it, consume once and fan out.
+- `delivery` is `"backfill"` until the delivering relay sends EOSE, its end-of-stored-events marker, then `"live"`. Interrupt the user (toast, notification) for live events only.
+
+## The event union
+
+`event` is a `WrapInboxEvent`. Dispatch on `_tag`:
+
+| Vertical        | Peer-authored fact                   | Own echo                                         |
+| --------------- | ------------------------------------ | ------------------------------------------------ |
+| Chat            | `ChatMessageReceived`                | `OwnChatMessageConfirmed`                        |
+| Reactions       | `ReactionAdded`, `ReactionRetracted` | `OwnReactionConfirmed`, `OwnRetractionConfirmed` |
+| Payment notices | `PaymentNoticeReceived`              | —                                                |
+| Bank offers     | `BankOfferSnapshotReceived`          | `OwnBankOfferSnapshotConfirmed`                  |
+| Seen receipts   | `SeenReceiptReceived`                | `OwnSeenReceiptConfirmed`                        |
+| (any)           | `WrapDropped`                        |                                                  |
+
+Own echoes carry `clientId` (nullable) so you can reconcile an optimistic local row; peer facts carry `from`.
+
+```ts
+import { Match } from "effect";
+import type { WrapInboxEvent } from "@linky/linkstr";
+
+const describe = (event: WrapInboxEvent): string =>
+  Match.value(event).pipe(
+    Match.tag("ChatMessageReceived", (e) => `${e.from}: ${e.body._tag}`),
+    Match.tag(
+      "OwnChatMessageConfirmed",
+      (e) => `echo of ${e.messageId} to ${e.to}`,
+    ),
+    Match.tag(
+      "ReactionAdded",
+      (e) => `${e.from} reacted ${e.emoji} to ${e.target}`,
+    ),
+    Match.tag("WrapDropped", (e) => `dropped ${e.wrapId ?? "?"}: ${e.reason}`),
+    Match.orElse((e) => e._tag),
+  );
+```
+
+A `switch (event._tag)` works the same way. Use `Match.tagsExhaustive` when you want the compiler to force a branch per tag. The web app's single consumer, `apps/web-app/src/app/hooks/messages/useLinkstrInboxSync.ts`, is a `switch` with grouped `case`s that hands each vertical to its own module; the React wiring is in [react.md](./react.md#inbox).
+
+## `WrapDropped`
+
+A wrap the inbox chose not to surface, with `wrapId` (null when the outer event was malformed) and a `reason`:
+
+| Reason                                                                                | Meaning                                                      |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `malformed-wrap`                                                                      | not a valid signed kind-1059 event                           |
+| `not-addressed-to-me`                                                                 | no `p` tag with our pubkey                                   |
+| `unwrap-failed`                                                                       | decryption failed                                            |
+| `invalid-seal`                                                                        | seal does not decode or its signature fails                  |
+| `sender-forged`                                                                       | rumor author ≠ seal author, or equals the ephemeral wrap key |
+| `malformed-rumor`, `forged-rumor-id`                                                  | rumor does not decode, or its id ≠ its hash                  |
+| `unsupported-kind`                                                                    | rumor kind has no vertical yet                               |
+| `invalid-reaction`, `invalid-retraction`                                              | reactions codec rejected it                                  |
+| `invalid-message`, `invalid-image`, `invalid-edit`, `empty-message`, `nested-payload` | chat codec rejected it                                       |
+| `invalid-notice`, `invalid-bank-offer`, `invalid-seen-receipt`                        | that vertical's codec rejected it                            |
+
+Drops are facts too: log them, count them, but never treat one as an error.
+
+## The cursor and `InboxCursorStore`
+
+The inbox tracks the newest authenticated wrap `created_at` (clamped to now) and checkpoints it to `InboxCursorStore` on every advance. Each subscription asks relays for `since = cursor - NIP59_BACKDATE_MARGIN_SECONDS` (two days), because gift-wrap timestamps are randomized into the past. So:
+
+- Restarts replay a bounded window. Dedupe and idempotency absorb it; your handlers must be idempotent by rumor id.
+- `open({ since })` only seeds a session whose store is empty. Once a cursor is saved, `since` is ignored.
+- Without a cursor and without `since`, the first subscription has no `since` at all and relays return whatever they keep.
+
+Supply the store through `linkstrServices({ inboxCursorStore })` or `LinkstrConfig.inboxCursorStore`; `runLinkstr` and the default are in-memory.
+
+```ts
+import { InboxCursorStore, type Pubkey } from "@linky/linkstr";
+
+// web: one key per identity, so switching accounts never reuses a cursor
+const cursorStoreFor = (pubkey: Pubkey) =>
+  InboxCursorStore.fromStringStorage(
+    localStorage,
+    `linky.inbox_cursor.${pubkey}`,
+  );
+```
+
+`fromStringStorage` takes any `{ getItem, setItem }` (`StringStorage`); an unreadable value loads as "no cursor".
+
+## `fetchWrapEvent` for notification opens
+
+A push payload names a wrap by id and lists relay hints ([push-inbox.md](./push-inbox.md)). Validate the id first; it came over the network.
+
+```ts
+import { Effect, Schema } from "effect";
+import {
+  runLinkstr,
+  WrapId,
+  WrapInbox,
+  type NostrSecretKey,
+  type RelayUrl,
+  type WrapInboxEvent,
+} from "@linky/linkstr";
+
+const isWrapId = Schema.is(WrapId);
+
+const decodePushed = (
+  secretKey: NostrSecretKey,
+  readRelays: ReadonlyArray<RelayUrl>,
+  outerEventId: string,
+  relayHints: ReadonlyArray<RelayUrl>,
+): Promise<WrapInboxEvent | null> => {
+  if (!isWrapId(outerEventId)) return Promise.resolve(null);
+  return runLinkstr(
+    { secretKey, readRelays },
+    Effect.flatMap(WrapInbox, (inbox) =>
+      inbox.fetchWrapEvent(outerEventId, {
+        extraRelays: relayHints,
+        timeout: "8 seconds",
+      }),
+    ).pipe(
+      Effect.catchTags({
+        AllRelaysUnreachable: () => Effect.succeed(null),
+        NoReadRelaysConfigured: () => Effect.succeed(null),
+      }),
+    ),
+  );
+};
+```
+
+- Fetches `ids: [wrapId]` from the read relays unioned with `extraRelays`, authenticates, routes, and returns the same `WrapInboxEvent`, or `null` when nothing matched.
+- With `timeout`, a slow fan-out resolves `null` instead of failing. Pass one when the caller has its own deadline, as a push event does.
+- Fails with `AllRelaysUnreachable` (no relay answered) or `NoReadRelaysConfigured`.
+- On `null` or a failure, show a generic "new message" notification; the running app receives the real fact through its inbox once it opens. That is what `apps/web-app/src/sw.ts` does.
+- No `delivery` phase; it is not a subscription.
+
+## Dedup guarantees
+
+- Wraps are deduped across relays by wrap id while the id is in a bounded cache (the last 4096 authenticated wraps). Only authenticated wraps enter it, so a tampered copy from one relay cannot suppress the honest copy from another.
+- Duplicates are suppressed only while their wrap ids stay cached: cache eviction, resubscribes, and restarts can replay the same rumor. Every fact is idempotent by its rumor id (`messageId`, `reactionId`, `snapshotId`, `receiptId`), so apply "insert if absent" and reconcile own echoes by `clientId`.
+
+## Related
+
+- [concepts.md](./concepts.md) — why facts are a tagged union
+- [react.md](./react.md) — mounting the inbox in the app
+- [push-inbox.md](./push-inbox.md) — the identity-free sibling for the push server
+- [testing.md](./testing.md) — driving the inbox with `FakeRelay`

--- a/packages/linkstr/docs/inspector.md
+++ b/packages/linkstr/docs/inspector.md
@@ -1,0 +1,134 @@
+# Inspector
+
+`Inspector` is an optional diagnostics bus: verticals and the transport tap emit typed events into it, and one consumer streams them out. Turn it on when you want a timeline of what linkstr does on the wire (the web app's inspector page). When it is off, every emission site goes through a no-op and costs nothing.
+
+## Consuming in React
+
+Set `LinkstrConfig.inspector: true`, register a handler, and mount the events atom:
+
+```tsx
+import type { InspectorEvent } from "@linky/linkstr";
+import {
+  inspectorEventsAtom,
+  inspectorHandlerAtom,
+  useAtomMount,
+  useAtomSet,
+} from "@linky/linkstr-react";
+import React from "react";
+
+export const useInspectorBridge = (
+  enabled: boolean,
+  report: (event: InspectorEvent) => void,
+) => {
+  const setHandler = useAtomSet(inspectorHandlerAtom);
+  useAtomMount(inspectorEventsAtom);
+  React.useEffect(() => {
+    if (!enabled) return;
+    setHandler({ onEvent: report });
+    return () => setHandler(null);
+  }, [enabled, report, setHandler]);
+};
+```
+
+The web app's `apps/web-app/src/devtools/inspector/useLinkstrInspectorBridge.ts` does this and converts each event to an inspector row with `linkstrEventToRow`, wrapped in a `try` so a mapping bug cannot kill the feed fiber. With `inspector: false` the atom mounts but emits nothing. The runtime atom already taps the transport, so no further wiring is needed.
+
+## Consuming in Effect
+
+Provide `Inspector.live` to the services, tap the transport, and consume `events` from a fiber forked in the same scope. Leaving the scope stops the consumer and releases the bus.
+
+```ts
+import { Effect, Layer, Stream } from "effect";
+import {
+  Inspector,
+  inspectTransport,
+  linkstrServices,
+  NostrTransportSimplePool,
+  observeTransport,
+  Reactions,
+  type NostrSecretKey,
+  type ReactionDraft,
+  type RelayUrl,
+} from "@linky/linkstr";
+
+const inspectedServices = (
+  secretKey: NostrSecretKey,
+  relays: ReadonlyArray<RelayUrl>,
+  enabled: boolean,
+) =>
+  linkstrServices({
+    secretKey,
+    readRelays: relays,
+    writeRelays: relays,
+    transport: inspectTransport(observeTransport(NostrTransportSimplePool)),
+  }).pipe(Layer.provideMerge(enabled ? Inspector.live : Inspector.disabled));
+
+const reactWithTimeline = (draft: ReactionDraft) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const inspector = yield* Inspector;
+      yield* Effect.forkScoped(
+        Stream.runForEach(inspector.events, (event) =>
+          Effect.sync(() => console.log(event._tag, event)),
+        ),
+      );
+      const reactions = yield* Reactions;
+      return yield* reactions.react(draft);
+    }),
+  );
+```
+
+Run `reactWithTimeline(draft)` with `Effect.provide(inspectedServices(...))`. The stream is single-consumer; fan out downstream if several views need it.
+
+## The port
+
+| Member               | Meaning                                                                                               |
+| -------------------- | ----------------------------------------------------------------------------------------------------- |
+| `Inspector.live`     | real bus: sliding queue of 1024 events; old rows drop when nobody consumes                            |
+| `Inspector.disabled` | no-op service, for roots that must provide the tag unconditionally                                    |
+| `Inspector.orNoop`   | what emitters use: the service if provided, else a no-op                                              |
+| `emit(build)`        | sync and lazy; `build` runs only when a real bus exists, and a throwing builder is logged and dropped |
+| `events`             | single-consumer `Stream<InspectorEvent>`                                                              |
+
+## Tapping the transport
+
+`inspectTransport(transportLayer)` decorates any `NostrTransport` layer with the wire events below; it passes through when no `Inspector` is provided. Compose it with `observeTransport` (relay health) in the same place, as in `inspectedServices` above; `linkstrRuntimeAtom` does the same for React.
+
+## Event families
+
+All classes live in `inspector/events.ts`. They fall into three groups:
+
+| Group           | Event                                                                                                 | Fired when                                               |
+| --------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Operations      | `OperationSucceeded` (`name`, `params`, `rumorId`, `clientId`, `sentAt`, `selfCopy`, `recipientCopy`) | a wrap vertical finished a send, e.g. `reactions.react`  |
+| Operations      | `OperationFailed` (`name`, `params`, `error`)                                                         | any vertical's send failed                               |
+| Operations      | `PlainOperationSucceeded` (`name`, `params`, `eventIds`, `result`)                                    | a plain publish, a fetch, `outbox.enqueue`, `outbox.job` |
+| Inbox and watch | `InboxRouted` (`wrapId`, `rumorKind`, `delivery`, `event`)                                            | the inbox produced a fact, including `WrapDropped`       |
+| Inbox and watch | `InboxWrapDeduped` (`wrapId`)                                                                         | a cross-relay duplicate was skipped                      |
+| Inbox and watch | `ProfileWatchRouted` (`eventId`, `kind`, `event`)                                                     | `ProfileWatch` routed or dropped a plain event           |
+| Wire            | `WirePublished` (`wrapId`, `wrap`, `results`)                                                         | one signed wrap pushed to the write relays               |
+| Wire            | `WirePlainPublished` (`eventId`, `kind`, `event`, `results`)                                          | one signed plain event pushed                            |
+| Wire            | `WireSubscribed`, `WireSubscriptionEnded`, `WireEventReceived`                                        | subscription lifecycle and raw arrivals, per relay       |
+| Wire            | `WireFetched` (`relay`, `filter`, `events`, `detail`)                                                 | one one-shot fetch answered or failed                    |
+
+Operation and wire rows correlate through shared ids: `OperationSucceeded.selfCopy.wrapId` and `recipientCopy.wrapId` match two `WirePublished.wrapId`s; `rumorId`/`clientId` tie a send to its `InboxRouted` echo and to outbox rows. `InboxRouted.rumorKind` is how an unknown kind shows up before a vertical exists. The web app maps operation and inbox rows onto its `nostr.operation` channel and wire rows onto `nostr.wire` in `apps/web-app/src/devtools/inspector/linkstrRows.ts`.
+
+## The no-key-material rule
+
+The rule: no identity key material in any inspector event, in any field. Not an nsec, not seed words, not a derived `NostrSecretKey`, not inside `params`, `error`, or `event`. Decrypted message content is acceptable by design; the settings copy discloses it.
+
+What is emitted today, so you know what a captured timeline contains:
+
+- `params` is the draft or argument object exactly as the caller passed it. For `chat.sendImage`, and for `outbox.enqueue` / `outbox.job` rows of a queued `chat.image`, that includes `image.key` and `image.nonce`, the attachment's AES-GCM key. `InboxRouted.event` likewise carries a received `ImageBody` with its key. A captured timeline can therefore decrypt attachments, not only read text.
+- Identity key material is not emitted anywhere. Telemetry passes `{ draft, recipient }` and keeps the per-attempt signing key out of the event; `WirePublished.wrap` and `WireEventReceived.event` are ciphertext.
+
+Keep it that way when you add an emission point: pass drafts, receipts, ids, and errors, never the identity service or a config object.
+
+## Adding an emission point
+
+Sends already emit through `sendToPeer` / `sendToRecipient` (`inspectOperation`) and plain operations through `inspectPlainOperation`; a new vertical gets both for free by using those skeletons. Event classes are constructed with `disableValidation` so an off-brand field is shown rather than dropped. For anything else, follow the repo skill `.agents/skills/adding-inspector-events/` before adding a class: it covers channel naming, which ids go in `links` versus `context`, wire-format stability, and the glossary entry the viewer needs.
+
+## Related
+
+- [relay-health.md](./relay-health.md) — the production-facing sibling tap
+- [react.md](./react.md#relay-health-and-inspector)
+- [adding-a-vertical.md](./adding-a-vertical.md)

--- a/packages/linkstr/docs/mute-list.md
+++ b/packages/linkstr/docs/mute-list.md
@@ -1,0 +1,106 @@
+# Mute list
+
+`MuteList` publishes your NIP-51 mute list: a kind 10000 event with one `p` tag per blocked pubkey. It is a plain signed event, not gift-wrapped, and replaces the previous list on relays. Publish it whenever the local block list changes so other clients on the same key honour it.
+
+Publishing does not block anyone by itself. Muting is enforced on receive by you, not by linkstr: `WrapInbox` still delivers wraps from muted senders, so check `from` against your block list in the inbox handler (see [Loading and enforcing the list](#loading-and-enforcing-the-list)).
+
+## Quick example
+
+Prerequisites: a `NostrSecretKey`, relay urls, and the `Pubkey`s to block — see [getting-started.md](./getting-started.md).
+
+Headless:
+
+```ts
+import { Effect } from "effect";
+import {
+  MuteList,
+  runLinkstr,
+  type NostrSecretKey,
+  type Pubkey,
+  type RelayUrl,
+} from "@linky/linkstr";
+
+const publishBlocked = (
+  secretKey: NostrSecretKey,
+  relays: ReadonlyArray<RelayUrl>,
+  blocked: ReadonlyArray<Pubkey>,
+) =>
+  runLinkstr(
+    { secretKey, readRelays: relays, writeRelays: relays },
+    Effect.gen(function* () {
+      const muteList = yield* MuteList;
+      return yield* muteList.publishMuteList(blocked);
+    }),
+  );
+```
+
+The promise resolves with a `PlainEventReceipt`; `receipt.accepted` is true when at least one write relay took the event.
+
+React — block locally first, then publish the whole list. A failed publish keeps the local block and leaves the list to be republished on the next change:
+
+```ts
+import { Pubkey } from "@linky/linkstr";
+import { publishMuteListAtom, useAtomSet } from "@linky/linkstr-react";
+import { Exit, Schema } from "effect";
+
+interface BlockStore {
+  // Placeholders for your local storage.
+  add: (pubkey: Pubkey) => void;
+  all: () => ReadonlyArray<string>;
+  markUnpublished: () => void;
+}
+
+export const useBlock = (store: BlockStore) => {
+  const publishMuteList = useAtomSet(publishMuteListAtom, {
+    mode: "promiseExit",
+  });
+
+  return async (pubkey: Pubkey): Promise<void> => {
+    store.add(pubkey);
+    const exit = await publishMuteList(store.all().filter(Schema.is(Pubkey)));
+    if (Exit.isFailure(exit)) store.markUnpublished();
+  };
+};
+```
+
+The app keeps the source of truth in local storage and publishes the merged list after each block without waiting on the result; the next block republishes everything anyway.
+
+## Sending
+
+There is no draft class: `publishMuteList(pubkeys: ReadonlyArray<Pubkey>)` takes the complete list. Send everything, not the delta — kind 10000 is replaceable, so the newest event is the list.
+
+`PlainEventReceipt` carries `eventId`, `kind` (10000), `sentAt`, `results: RelayPublishResult[]`, and `.accepted`.
+
+Direct only. The content is empty; muted pubkeys are public `p` tags. Linkstr does not encrypt a private section.
+
+## Loading and enforcing the list
+
+There is no fetch of your own mute list and no watch. Load the list from your own storage (the app treats local storage as authoritative and never reads kind 10000 back) and apply it in the inbox handler:
+
+```ts
+import type { Pubkey, WrapInboxEvent } from "@linky/linkstr";
+
+export const dropBlocked =
+  (
+    isBlocked: (pubkey: Pubkey) => boolean,
+    next: (event: WrapInboxEvent) => void,
+  ) =>
+  (event: WrapInboxEvent): void => {
+    if ("from" in event && isBlocked(event.from)) return;
+    next(event);
+  };
+```
+
+Facts about your own sends (`Own*Confirmed`) carry `to` instead of `from`; check that against the list too if you block a conversation entirely, as the app does for bank offers.
+
+## Errors
+
+| Tag                    | When                              | What to do                                     |
+| ---------------------- | --------------------------------- | ---------------------------------------------- |
+| `NoRelayAcceptedEvent` | no write relay accepted the event | the local block still applies; republish later |
+| `LinkstrNotConfigured` | React only, logged out            | keep the local list                            |
+
+## Related
+
+- [inbox.md](./inbox.md) — where to apply the block
+- [profiles.md](./profiles.md), [relay-lists.md](./relay-lists.md) — the other plain-event verticals

--- a/packages/linkstr/docs/outbox.md
+++ b/packages/linkstr/docs/outbox.md
@@ -1,0 +1,137 @@
+# Outbox
+
+`Outbox` is the send queue: enqueue a job, get a deterministic rumor id back immediately, and let a background worker deliver it with retries until a relay accepts it. Use it for user-visible sends that must survive offline periods and reloads; send directly for everything else.
+
+## Storage and lifetime first
+
+Two things decide whether the queue is actually durable:
+
+- **The store.** The job list lives behind the `OutboxStore` port. The default, `OutboxStore.inMemory`, is lost on reload; pass `OutboxStore.fromStringStorage(storage, key)` (one JSON array under `key`; the web app uses `localStorage` and `"linky.outbox"`) through `linkstrServices({ outboxStore })`, `runLinkstr`, or `LinkstrConfig.outboxStore`. An unreadable stored value decodes as an empty list; two older receipt generations still decode, so upgrading never drops queued jobs.
+- **The runtime.** The delivery worker is scoped to the `Outbox` service. When the runtime that built it closes, the worker stops; queued jobs stay in the store and resume when the next runtime builds the service. A `runLinkstr` call that enqueues and returns therefore delivers nothing by itself.
+
+## One runtime: enqueue, deliver, observe
+
+Prerequisite: a key and relays ([getting-started.md](./getting-started.md#what-you-bring)). Keep one long-lived runtime, mount the results consumer once, and enqueue through the same runtime:
+
+```ts
+import { Effect, ManagedRuntime, Stream } from "effect";
+import {
+  linkstrServices,
+  MessageText,
+  NostrTransportSimplePool,
+  Outbox,
+  OutboxRef,
+  OutboxStore,
+  TextMessageDraft,
+  type NostrSecretKey,
+  type OutboxResult,
+  type Pubkey,
+  type RelayUrl,
+  type StringStorage,
+} from "@linky/linkstr";
+
+/** App callback placeholder: write the outcome to the row named by `result.ref`. */
+declare const persistResult: (result: OutboxResult) => Promise<void>;
+
+export const startOutbox = (
+  secretKey: NostrSecretKey,
+  relays: ReadonlyArray<RelayUrl>,
+  storage: StringStorage,
+) => {
+  const runtime = ManagedRuntime.make(
+    linkstrServices({
+      secretKey,
+      readRelays: relays,
+      writeRelays: relays,
+      transport: NostrTransportSimplePool,
+      outboxStore: OutboxStore.fromStringStorage(storage, "linky.outbox"),
+    }),
+  );
+
+  // Persist each completed result, then ack it. Mount exactly once per runtime.
+  runtime.runFork(
+    Effect.flatMap(Outbox, (outbox) =>
+      Stream.runForEach(outbox.results, (result) =>
+        Effect.promise(() => persistResult(result)).pipe(
+          Effect.andThen(outbox.ack(result.jobId)),
+        ),
+      ),
+    ),
+  );
+
+  const queueText = (to: Pubkey, text: string, rowId: string) =>
+    runtime.runPromise(
+      Effect.flatMap(Outbox, (outbox) =>
+        outbox.enqueue(
+          {
+            _tag: "chat.text",
+            draft: new TextMessageDraft({
+              to,
+              content: MessageText.make(text),
+            }),
+          },
+          OutboxRef.make(`message:${rowId}`),
+        ),
+      ),
+    );
+
+  return { queueText, stop: () => runtime.dispose() };
+};
+```
+
+In React the runtime is `linkstrRuntimeAtom`, the consumer is `useOutboxResults`, and enqueueing is `enqueueOutboxAtom` ([react.md](./react.md#outbox)).
+
+`enqueue(operation, ref)` returns an `EnqueueReceipt` at once: `{ jobId, ref, rumorId, clientId, sentAt }`. The rumor is encoded at enqueue time, so `rumorId` is the exact id every retry publishes; write it to your local row now. Enqueue success means the job is stored, not that any relay accepted it and not that the peer processed it.
+
+| Operation `_tag`   | `draft`                               | Delivered by                               |
+| ------------------ | ------------------------------------- | ------------------------------------------ |
+| `chat.text`        | `TextMessageDraft`                    | `Chat.sendText`                            |
+| `chat.token`       | `TokenMessageDraft`                   | `Chat.sendToken`                           |
+| `chat.image`       | `ImageMessageDraft`                   | `Chat.sendImage`                           |
+| `chat.edit`        | `EditMessageDraft`                    | `Chat.edit`                                |
+| `reaction`         | `ReactionDraft`                       | `Reactions.react`                          |
+| `paymentTelemetry` | `PaymentTelemetryDraft` + `recipient` | `PaymentTelemetry.publishPaymentTelemetry` |
+
+`enqueueTelemetry(draft, recipient, ref)` is separate and returns only an `OutboxJobId`: telemetry is signed by a fresh key per attempt, so there is no rumor id to precompute.
+
+`ref` is an opaque `OutboxRef` you choose (the app uses `message:<rowId>` and `reaction:<rowId>`). It comes back unchanged on the result and is the only link between a completed result and your row.
+
+## When to use it
+
+| Send                             | Path                       | Why                                                                                                      |
+| -------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Chat text, image, token, edit    | `Outbox.enqueue`           | must not be lost while offline; the optimistic row waits for the result                                  |
+| Reaction (add)                   | `Outbox.enqueue`           | same                                                                                                     |
+| Payment telemetry                | `Outbox.enqueueTelemetry`  | fire-and-forget but must eventually land                                                                 |
+| Reaction retraction              | `Reactions.retract` direct | UX tolerates a failed undo                                                                               |
+| Seen receipts                    | `SeenReceipts.send` direct | every receipt supersedes the previous one; a retried stale cursor would move the peer's marker backwards |
+| Payment notices, bank offers     | direct                     | single-copy or ordered sends the app manages itself                                                      |
+| Profiles, relay lists, mute list | direct                     | plain events; the caller re-publishes on demand                                                          |
+
+A direct send fails at once with the error its guide lists (for example [chat.md](./chat.md), [reactions.md](./reactions.md), [profiles.md](./profiles.md)); a queued send never fails on a delivery error, it retries.
+
+## Retry and ordering rules
+
+- Delivery is **strictly FIFO**: one job at a time, in enqueue order. A job that keeps failing blocks the ones behind it.
+- Delivery errors (`RecipientNotReached`, `NoRelayReachable`, `WrapNotDelivered`) are retried automatically: sleep 1s, doubling to a 60s cap, forever. You never retry a queued job yourself.
+- A new enqueue and the browser `online` event both cut the current sleep short.
+- Only two things end a job without success: an unexpected defect (`OutboxJobFailed` with `reason: "unexpected-error"`) and a job enqueued under another pubkey found at startup (`reason: "identity-changed"`). Jobs are never sent under a different key than they were enqueued with.
+- A completed job stays stored as `awaiting-ack` until you `ack(jobId)`. Rebuilding the service re-emits every unacked result (at-least-once), so result handlers must be idempotent.
+
+## Results
+
+`outbox.results` is a single-consumer `Stream<OutboxResult>` of completed jobs only, success or permanent failure:
+
+| Result               | Fields                                                                                                                     |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `OutboxJobSucceeded` | `jobId`, `ref`, `receipt` (`ChatMessageReceipt` \| `MessageEditReceipt` \| `ReactionReceipt` \| `PaymentTelemetryReceipt`) |
+| `OutboxJobFailed`    | `jobId`, `ref`, `reason`, `detail`                                                                                         |
+
+Persist the outcome, then ack, as in the example above. `OutboxJobSucceeded` means a relay accepted the recipient copy ([concepts.md](./concepts.md#honest-delivery)); the peer's own inbox still has to receive it. The web app's handler, `applyOutboxResult` in `apps/web-app/src/app/hooks/messages/outboxResults.ts`, parses the `ref` prefix and marks the row `sent` with `receipt.rumorId` (or `receipt.editOf` for edits) and `receipt.selfCopy.wrapId`; a failure is only logged.
+
+## Related
+
+- [react.md](./react.md#outbox) — `enqueueOutboxAtom`, `useOutboxResults`
+- [chat.md](./chat.md), [reactions.md](./reactions.md), [payment-telemetry.md](./payment-telemetry.md) — the verticals that go through the queue
+- [seen-receipts.md](./seen-receipts.md) — why receipts bypass it
+- [concepts.md](./concepts.md#honest-delivery)

--- a/packages/linkstr/docs/payment-notices.md
+++ b/packages/linkstr/docs/payment-notices.md
@@ -1,0 +1,124 @@
+# Payment notices
+
+`PaymentNotices` tells a peer "I just paid you" so their device can wake up and ingest the cashu token that travelled in chat. A notice is a kind 24133 rumor tagged `["linky", "payment_notice"]`, gift-wrapped (kind 1059) to the recipient, and the wrap is push-marked, so the push server delivers a notification even though the token message itself was not push-marked. Send one after the token message's outbox job was enqueued; the token may still be awaiting delivery when the notice lands.
+
+## Quick example
+
+Prerequisites: a `NostrSecretKey`, relay urls, and the peer's `Pubkey` — see [getting-started.md](./getting-started.md).
+
+Headless:
+
+```ts
+import { Effect } from "effect";
+import {
+  PaymentNoticeDraft,
+  PaymentNotices,
+  runLinkstr,
+  type NostrSecretKey,
+  type Pubkey,
+  type RelayUrl,
+} from "@linky/linkstr";
+
+const notifyPaid = (
+  secretKey: NostrSecretKey,
+  relays: ReadonlyArray<RelayUrl>,
+  peer: Pubkey,
+) =>
+  runLinkstr(
+    { secretKey, readRelays: relays, writeRelays: relays },
+    Effect.gen(function* () {
+      const notices = yield* PaymentNotices;
+      return yield* notices.send(new PaymentNoticeDraft({ to: peer }));
+    }),
+  );
+```
+
+The promise resolves with a `PaymentNoticeReceipt` once a relay accepted the wrap; `receipt.recipientCopy.wrapId` is what the push server will deliver.
+
+React — called after the token message was enqueued:
+
+```ts
+import { PaymentNoticeDraft, type Pubkey } from "@linky/linkstr";
+import { sendPaymentNoticeAtom, useAtomSet } from "@linky/linkstr-react";
+import { Exit } from "effect";
+
+export const useNotifyPaid = () => {
+  const sendPaymentNotice = useAtomSet(sendPaymentNoticeAtom, {
+    mode: "promiseExit",
+  });
+
+  return async (peer: Pubkey, offerId?: string): Promise<boolean> => {
+    const exit = await sendPaymentNotice(
+      new PaymentNoticeDraft({
+        to: peer,
+        ...(offerId === undefined
+          ? {}
+          : { context: "bank_payment_offer", offerId }),
+      }),
+    );
+    // On failure only the wake-up is lost; the token job stays in the outbox.
+    return Exit.isSuccess(exit);
+  };
+};
+```
+
+The app calls this from `publishCashuMessagePayment` once at least one `chat.token` job was enqueued successfully, and does not retry a failed notice.
+
+## Sending
+
+| Draft                | Fields                                                                                                         |
+| -------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `PaymentNoticeDraft` | `to: Pubkey`, `context?: "bank_payment_offer"`, `offerId?: string` (non-empty, trimmed), `clientId?: ClientId` |
+
+- `context` and `offerId` link the notice to a bank offer; leave both out for a plain contact payment.
+- No `sentAt`: the notice is always stamped now.
+
+`PaymentNoticeReceipt` carries `rumorId`, `clientId`, `sentAt`, and `recipientCopy: WrapDelivery`.
+
+Single copy, direct, push-marked. There is no `selfCopy` because nothing is wrapped to you: a notice is a signal, not state your other devices need. It is not an outbox operation; if the send fails the payment itself is unaffected.
+
+## Receiving
+
+| Tag                     | Fields                                                                                                                         | Meaning         |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------ | --------------- |
+| `PaymentNoticeReceived` | `noticeId: RumorId`, `from: Pubkey`, `context: "bank_payment_offer" \| null`, `offerId: string \| null`, `sentAt: UnixSeconds` | `from` paid you |
+
+The notice carries no token. The token arrives on the same inbox as a `ChatMessageReceived` with a `TokenBody` ([chat.md](./chat.md#cashu-tokens)), and that handler is where you ingest it. Treat the notice as a wake-up: make sure the inbox is open so the token message can arrive, and show a notification unless a matching token message is already stored.
+
+```ts
+import type { InboxDelivery, Pubkey, WrapInboxEvent } from "@linky/linkstr";
+
+interface PaymentUi {
+  // Placeholders for your app.
+  hasTokenFrom: (peer: Pubkey) => boolean;
+  showPaidToast: (peer: Pubkey, offerId: string | null) => void;
+}
+
+export const paymentNoticeHandler =
+  (ui: PaymentUi) =>
+  (event: WrapInboxEvent, delivery: InboxDelivery): void => {
+    if (event._tag !== "PaymentNoticeReceived") return;
+    if (delivery !== "live" || ui.hasTokenFrom(event.from)) return;
+    ui.showPaidToast(event.from, event.offerId);
+  };
+```
+
+The service worker takes the same fact from `WrapInbox.fetchWrapEvent` to decide the notification title for a pushed wrap (see [push-inbox.md](./push-inbox.md)).
+
+Drop reason: `invalid-notice` — wrong `linky` tag, not p-tagged to you, or authored by you.
+
+## Errors
+
+| Tag                    | When                              | What to do                                   |
+| ---------------------- | --------------------------------- | -------------------------------------------- |
+| `WrapNotDelivered`     | no relay accepted the single wrap | log it; the token job is still in the outbox |
+| `LinkstrNotConfigured` | React only, logged out            | do not send                                  |
+
+`WrapNotDelivered` carries `rumorId`, `clientId`, `sentAt`, `recipientCopy`.
+
+## Related
+
+- [chat.md](./chat.md) — the token messages a notice announces
+- [bank-offers.md](./bank-offers.md) — `context: "bank_payment_offer"`
+- [push-inbox.md](./push-inbox.md) — how the push marker is consumed
+- [inbox.md](./inbox.md) — delivery phases (`live` vs `backfill`)

--- a/packages/linkstr/docs/payment-telemetry.md
+++ b/packages/linkstr/docs/payment-telemetry.md
@@ -1,0 +1,152 @@
+# Payment telemetry
+
+`PaymentTelemetry` reports the outcome of a payment attempt to Linky's analytics pubkey without saying who reported it. A report is a kind 24134 rumor tagged `["linky", "payment_telemetry"]`, gift-wrapped (kind 1059) to the recipient only and signed by a fresh ephemeral key per attempt. Each attempt uses a new signing key; retries of the same draft keep its report id. The app records events locally first and hands them to the outbox in batches.
+
+## Quick example
+
+Prerequisites: a `NostrSecretKey` and relay urls — see [getting-started.md](./getting-started.md). The recipient is the exported analytics npub.
+
+Build a report once; both send paths below take it as input. The app derives every value in `apps/web-app/src/app/lib/paymentTelemetry.ts`; the literals here are examples:
+
+```ts
+import {
+  ClientId,
+  PaymentTelemetryDraft,
+  UnixSeconds,
+  decodeNpub,
+  PAYMENT_ANALYTICS_RECIPIENT_NPUB,
+} from "@linky/linkstr";
+
+const recipient = decodeNpub(PAYMENT_ANALYTICS_RECIPIENT_NPUB);
+if (recipient === null) throw new Error("bad analytics npub");
+
+const report = new PaymentTelemetryDraft({
+  id: ClientId.make(crypto.randomUUID()),
+  createdAtSec: UnixSeconds.make(Math.floor(Date.now() / 1000)),
+  direction: "out",
+  status: "ok",
+  method: "lightning_invoice",
+  phase: "complete",
+  mint: "https://mint.example",
+  amountBucket: "lte_1000",
+  feeBucket: "lte_5",
+  errorCode: null,
+  errorDetail: null,
+  appHost: "app.linky.fit",
+  devicePlatform: "android",
+  appRuntime: "pwa",
+  appVersion: "26.9.3",
+});
+```
+
+Headless — one attempt:
+
+```ts
+import { Effect } from "effect";
+import {
+  PaymentTelemetry,
+  runLinkstr,
+  type NostrSecretKey,
+  type PaymentTelemetryDraft,
+  type Pubkey,
+  type RelayUrl,
+} from "@linky/linkstr";
+
+const publishReport = (
+  secretKey: NostrSecretKey,
+  relays: ReadonlyArray<RelayUrl>,
+  draft: PaymentTelemetryDraft,
+  recipient: Pubkey,
+) =>
+  runLinkstr(
+    { secretKey, readRelays: relays, writeRelays: relays },
+    Effect.gen(function* () {
+      const telemetry = yield* PaymentTelemetry;
+      return yield* telemetry.publishPaymentTelemetry(draft, recipient);
+    }),
+  );
+```
+
+React — durable, through the outbox:
+
+```ts
+import {
+  OutboxRef,
+  type PaymentTelemetryDraft,
+  type Pubkey,
+} from "@linky/linkstr";
+import { enqueuePaymentTelemetryAtom, useAtomSet } from "@linky/linkstr-react";
+import { Exit } from "effect";
+
+export const useEnqueueReport = () => {
+  const enqueuePaymentTelemetry = useAtomSet(enqueuePaymentTelemetryAtom, {
+    mode: "promiseExit",
+  });
+
+  return async (
+    draft: PaymentTelemetryDraft,
+    recipient: Pubkey,
+  ): Promise<boolean> => {
+    const exit = await enqueuePaymentTelemetry({
+      draft,
+      recipient,
+      ref: OutboxRef.make(`telemetry:${draft.id}`),
+    });
+    return Exit.isSuccess(exit); // enqueued, not yet delivered
+  };
+};
+```
+
+Enqueue success means the job is persisted; drop the event from your local queue only then. Relay acceptance arrives later as an `OutboxJobSucceeded` carrying the `PaymentTelemetryReceipt` ([outbox.md](./outbox.md)).
+
+## Sending
+
+`PaymentTelemetryDraft` fields that need explanation (the union literals for `direction`, `status`, `method`, `phase`, `devicePlatform`, and `appRuntime` are on the exported types):
+
+| Field                          | Note                                                   |
+| ------------------------------ | ------------------------------------------------------ |
+| `id: ClientId`                 | random; also the `client` tag and the id retries share |
+| `createdAtSec`                 | when the payment event happened, not when it was sent  |
+| `mint`                         | normalized mint url or `null`                          |
+| `amountBucket`, `feeBucket`    | bucket labels, never the amount                        |
+| `errorCode`                    | from `classifyPaymentErrorCode`                        |
+| `errorDetail`                  | short, truncated message                               |
+| `appHost`                      | host name only                                         |
+| `devicePlatform`, `appRuntime` | from `detectTelemetryEnvironment`                      |
+
+Direct vs outbox: `publishPaymentTelemetry(draft, recipient)` is one attempt and returns a `PaymentTelemetryReceipt` (`rumorId`, `clientId`, `sentAt`, `recipientCopy`). `Outbox.enqueueTelemetry(draft, recipient, ref)` retries with backoff and returns the `OutboxJobId` rather than an `EnqueueReceipt`: each attempt mints a new author and so a new rumor id, while `draft.id` stays the same.
+
+### Helpers
+
+- `classifyPaymentErrorCode(message)` maps a raw error string to a stable code (`offline`, `timeout`, `insufficient`, … or `null` for empty input). Put the code in `errorCode`, not the message.
+- `detectTelemetryEnvironment(facts)` takes `TelemetryEnvironmentFacts` gathered by the host (`userAgent`, `maxTouchPoints`, standalone flags, `nativePlatform`) and returns `{ devicePlatform, appRuntime }`. It is pure.
+- `PAYMENT_ANALYTICS_RECIPIENT_NPUB` (`defaults.ts`) is the recipient; decode it with `decodeNpub`.
+- `PAYMENT_TELEMETRY_KIND` / `PAYMENT_TELEMETRY_VALUE` are exported for tests and inspectors.
+
+### Anonymity you must preserve
+
+Linkstr guarantees the transport side: ephemeral author, no self copy, no push marker, and the wrap is addressed to the analytics key only. The draft is the only channel left, so:
+
+- `id` must be random. Never derive it from your pubkey, owner id, or a message id.
+- Report buckets, not amounts or fees. Bucketing lives in the app (`app/lib/paymentTelemetry.ts`).
+- `errorDetail` must not contain invoices, token text, npubs, or contact names. The app truncates to 500 characters after classification.
+- Do not add fields. The wire is `v: 1`; a new field is a schema change and a review of what it leaks.
+- Through the outbox the draft is persisted in the `OutboxStore` until acked. It is stored under your pubkey for the `identity-changed` check, but that pubkey never leaves the device.
+
+## Receiving
+
+Nothing. `WrapInbox` has no decoder for kind 24134 and drops it as `WrapDropped("unsupported-kind")`; the analytics recipient reads reports with its own tooling.
+
+## Errors
+
+| Tag                    | When                                     | What to do                                             |
+| ---------------------- | ---------------------------------------- | ------------------------------------------------------ |
+| `WrapNotDelivered`     | direct send: no relay accepted the wrap  | keep the event in your local queue and retry later     |
+| `OutboxJobFailed`      | `identity-changed` or `unexpected-error` | drop the item; a delivery error never terminates a job |
+| `LinkstrNotConfigured` | React only, logged out                   | keep buffering locally                                 |
+
+## Related
+
+- [outbox.md](./outbox.md) — `enqueueTelemetry` and the results stream
+- [identity-and-keys.md](./identity-and-keys.md) — `decodeNpub`
+- [payment-notices.md](./payment-notices.md) — the other single-copy vertical

--- a/packages/linkstr/docs/profiles.md
+++ b/packages/linkstr/docs/profiles.md
@@ -1,0 +1,179 @@
+# Profiles
+
+`Profiles` publishes and fetches public profile data: kind 0 metadata (name, picture, lightning address, …) and kind 30315 status in the `d=general` slot. `ProfileWatch` is the long-lived subscription for a set of pubkeys. These are plain signed events — not gift-wrapped — so anyone can read them. Use `Profiles` for one-shot needs (onboarding publish, contact search, previews) and `ProfileWatch` for everything on screen.
+
+## Quick example
+
+Prerequisites: a `NostrSecretKey` and relay urls; fetching also needs the peer's `Pubkey` — see [getting-started.md](./getting-started.md).
+
+Headless:
+
+```ts
+import { Effect } from "effect";
+import {
+  ProfileMetadata,
+  Profiles,
+  runLinkstr,
+  type NostrSecretKey,
+  type Pubkey,
+  type RelayUrl,
+} from "@linky/linkstr";
+
+const publishThenFetch = (
+  secretKey: NostrSecretKey,
+  relays: ReadonlyArray<RelayUrl>,
+  peer: Pubkey,
+) =>
+  runLinkstr(
+    { secretKey, readRelays: relays, writeRelays: relays },
+    Effect.gen(function* () {
+      const profiles = yield* Profiles;
+      yield* profiles.publishProfile(
+        new ProfileMetadata({ name: "dave", lud16: "npub1…@linky.fit" }),
+      );
+      return yield* profiles.fetchProfile(peer);
+    }),
+  );
+```
+
+The result is a `ProfileFetchResult`: `result.profile?.metadata.displayName`, `result.status?.content`, each `null` when the peer has none.
+
+React — a publish handler:
+
+```ts
+import { ProfileMetadata, StatusDraft } from "@linky/linkstr";
+import {
+  publishProfileAtom,
+  publishStatusAtom,
+  useAtomSet,
+} from "@linky/linkstr-react";
+import { Exit } from "effect";
+
+export const usePublishProfile = () => {
+  const publishProfile = useAtomSet(publishProfileAtom, {
+    mode: "promiseExit",
+  });
+  const publishStatus = useAtomSet(publishStatusAtom, { mode: "promiseExit" });
+
+  return async (name: string, status: string): Promise<boolean> => {
+    const profile = await publishProfile(new ProfileMetadata({ name }));
+    const statusExit = await publishStatus(
+      new StatusDraft({ content: status }),
+    );
+    return Exit.isSuccess(profile) && Exit.isSuccess(statusExit);
+  };
+};
+```
+
+React — a watch hook that lives as long as the session. `onEvent` is read through a ref so a new callback does not reopen the subscriptions:
+
+```ts
+import type { ProfileWatchEvent, Pubkey } from "@linky/linkstr";
+import {
+  profileWatchAtom,
+  profileWatchHandlerAtom,
+  useAtomMount,
+  useAtomSet,
+  watchedProfilesAtom,
+} from "@linky/linkstr-react";
+import { useEffect, useRef } from "react";
+
+export const useProfileWatch = (
+  pubkeys: ReadonlyArray<Pubkey>,
+  onEvent: (event: ProfileWatchEvent) => void,
+): void => {
+  const latest = useRef(onEvent);
+  useEffect(() => {
+    latest.current = onEvent;
+  });
+  const setWatched = useAtomSet(watchedProfilesAtom);
+  const setHandler = useAtomSet(profileWatchHandlerAtom);
+  useAtomMount(profileWatchAtom);
+  useEffect(() => {
+    setWatched(pubkeys);
+    setHandler({ onEvent: (event) => latest.current(event) });
+    return () => {
+      setHandler(null);
+      setWatched([]);
+    };
+  }, [pubkeys, setHandler, setWatched]);
+};
+```
+
+Changing `watchedProfilesAtom` resubscribes without rebuilding the runtime. Swapping the handler object also reopens the subscriptions, which is why the hook keeps it stable.
+
+## Sending
+
+| Draft             | Fields                                                                                       | Method           |
+| ----------------- | -------------------------------------------------------------------------------------------- | ---------------- |
+| `ProfileMetadata` | all optional strings: `name`, `displayName`, `picture`, `lud16`, `lud06`, `nip05`, `about`   | `publishProfile` |
+| `StatusDraft`     | `content: string` (empty string clears), `expiresAt?: UnixSeconds` (NIP-40 `expiration` tag) | `publishStatus`  |
+
+Both return a `PlainEventReceipt`: `eventId`, `kind`, `sentAt`, `results: RelayPublishResult[]` (`relay`, `accepted`, `detail`), and `.accepted`. Success means at least one write relay accepted the event.
+
+Wire notes: `displayName` is written as `display_name`; empty strings are omitted. Status content is opaque to linkstr — Linky's conventions (currency list on the last line) live in `apps/web-app/src/nostrStatus.ts`.
+
+## Fetching
+
+| Method                             | Returns                                                      | Options                                                                                                               |
+| ---------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `fetchProfile(pubkey)`             | `ProfileFetchResult { profile, status }` (each nullable)     |                                                                                                                       |
+| `fetchProfiles(pubkeys)`           | `ProfileFetchEntry[]` — `{ pubkey, profile, status }`        | authors are chunked per relay filter                                                                                  |
+| `discoverActiveProfiles(options?)` | `DiscoveredProfile[]` — `{ pubkey, lastActiveAt, metadata }` | `activityKinds` (default 0, 1, 6, 7, 9735, 30315), `activeWindowSeconds` (45 days), `authorScanLimit` (64)            |
+| `searchProfiles(query, options?)`  | `ProfileSearchHit[]` — `{ pubkey, metadata, updatedAt }`     | `limit` (6), `searchRelays` (NIP-50 relays; read relays when empty), `deadline` (2.5 s), `preferredDomains`, `onHits` |
+
+`profile` and `status` are the same `ProfileUpdated` / `StatusUpdated` facts the watch emits — newest event per kind, expired statuses excluded. React atoms: `fetchProfileAtom`, `fetchProfilesAtom`, `discoverActiveProfilesAtom`, `searchProfilesAtom` (takes `{ query, options? }`).
+
+Search streams ranked matches through `onHits` each time a relay answers, until the deadline; `preferredDomains` ranks profiles whose `nip05` or `lud16` ends in one of those domains first. Matching is accent- and case-insensitive on every query word.
+
+## Receiving
+
+`ProfileWatch.watch(pubkeys, options?)` returns a scoped `Stream<ProfileWatchEvent>`; closing the scope tears down the relay subscriptions. Newest wins per `(pubkey, kind)` within the session; older or expired events are dropped and only visible to the inspector as `ProfileEventDropped`.
+
+| Tag              | Fields                                                                                       | Meaning                               |
+| ---------------- | -------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `ProfileUpdated` | `pubkey: Pubkey`, `metadata: ProfileMetadata`, `updatedAt: UnixSeconds`                      | a newer kind 0 than seen this session |
+| `StatusUpdated`  | `pubkey`, `content: string` (empty = cleared), `expiresAt: UnixSeconds \| null`, `updatedAt` | a newer `d=general` kind 30315        |
+
+```ts
+import type { ProfileWatchEvent, Pubkey, UnixSeconds } from "@linky/linkstr";
+
+/** Placeholder: your cache; compare updatedAt with what you have before overwriting. */
+type Save = (pubkey: Pubkey, updatedAt: UnixSeconds, value: string) => void;
+
+export const profileHandler =
+  (saveName: Save, saveStatus: Save) =>
+  (event: ProfileWatchEvent): void => {
+    switch (event._tag) {
+      case "ProfileUpdated":
+        return saveName(
+          event.pubkey,
+          event.updatedAt,
+          event.metadata.name ?? "",
+        );
+      case "StatusUpdated":
+        return saveStatus(event.pubkey, event.updatedAt, event.content);
+    }
+  };
+```
+
+Linkstr persists nothing. The watch is newest-wins per session, not per device, so your cache must do its own `updatedAt` comparison.
+
+Headless: `ProfileWatch.watch([peer])` inside `Effect.scoped` has the same shape as the inbox example in [getting-started.md](./getting-started.md); it runs until the scope closes.
+
+## Errors
+
+| Tag                      | When                                        | What to do                                              |
+| ------------------------ | ------------------------------------------- | ------------------------------------------------------- |
+| `NoRelayAcceptedEvent`   | publish: no write relay accepted the event  | show the per-relay `results`; retry                     |
+| `AllRelaysUnreachable`   | fetch/search/discover: every relay failed   | keep cached results, show an offline state, retry later |
+| `NoReadRelaysConfigured` | fetch or watch with an empty read-relay set | configure relays first                                  |
+| `LinkstrNotConfigured`   | React only, logged out                      | read from cache only                                    |
+
+A fetch that reached some relays but not others succeeds with what arrived.
+
+## Related
+
+- [relay-lists.md](./relay-lists.md) — the other plain-event vertical
+- [identity-and-keys.md](./identity-and-keys.md) — `decodeNpub`, `parsePubkey`
+- [inspector.md](./inspector.md) — seeing `ProfileEventDropped`

--- a/packages/linkstr/docs/push-inbox.md
+++ b/packages/linkstr/docs/push-inbox.md
@@ -1,0 +1,108 @@
+# Push inbox
+
+`PushInbox` watches kind-1059 traffic for a server that has no keys: it verifies outer wraps, extracts the recipient and relay hints, and tells you whether each arrival is backfill or live. You need it only when building push infrastructure like `apps/push`; app code uses [`WrapInbox`](./inbox.md). Gift wrap, EOSE, and backfill are defined in [concepts.md](./concepts.md#vocabulary).
+
+## The `["linky", "push"]` marker
+
+Senders opt a wrap into push by adding a `["linky", "push"]` tag to the recipient copy. Chat text and images, payment notices, and pushable bank-offer statuses set it; token messages, reactions, and seen receipts do not. The subscription filter is only `{ kinds: [1059], since }`, because relays do not reliably index multi-letter tags; the codec checks the marker client-side and silently ignores wraps without it.
+
+## `watchPushInbox`
+
+The Promise-facing entry for long-lived services. No identity is needed. Keep the subscription handle and close it from your shutdown path:
+
+```ts
+import { RelayUrl, watchPushInbox } from "@linky/linkstr";
+
+/** App callback placeholder: look up subscriptions for `recipient` and send the push. */
+declare const notify: (
+  recipient: string,
+  wrapId: string,
+  relayHints: ReadonlyArray<string>,
+) => void;
+
+const subscription = watchPushInbox(
+  {
+    readRelays: ["wss://relay.damus.io", "wss://nos.lol"].map((url) =>
+      RelayUrl.make(url),
+    ),
+    lookbackSeconds: 3 * 24 * 60 * 60,
+    onInvalidWrap: (failure) => console.warn("invalid push wrap", failure),
+    onRelayStatus: (event) =>
+      event.type === "eose"
+        ? console.info("caught up", event.relay)
+        : console.warn("attempt ended", event.relay, event.reason),
+    onFatal: (message) => {
+      console.error("push watcher stopped", message);
+      process.exit(1); // let the process supervisor restart it
+    },
+  },
+  ({ delivery, wrap }) => {
+    if (delivery === "backfill") return;
+    notify(wrap.recipient, wrap.wrapId, wrap.relayHints);
+  },
+);
+
+process.on("SIGTERM", () => {
+  void subscription.close().then(() => process.exit(0));
+});
+```
+
+| Config             | Meaning                                                                    |
+| ------------------ | -------------------------------------------------------------------------- |
+| `readRelays`       | relays to subscribe on; one reconnecting subscription each                 |
+| `lookbackSeconds`  | `since = now - lookback` on every (re)subscription                         |
+| `refreshInterval`  | force a fresh REQ this often (default 10 min) to detect deaf subscriptions |
+| `resubscribeDelay` | base backoff after an attempt ends (default 5s)                            |
+| `transport`        | test seam; defaults to `NostrTransportSimplePool`                          |
+| `onInvalidWrap`    | called for every failure except `missing-push-marker`                      |
+| `onRelayStatus`    | `{ type: "eose", relay }` or `{ type: "attempt-ended", relay, reason }`    |
+| `onFatal`          | the whole watcher died with a non-interrupt cause                          |
+
+Each `DeliveredPushWrap` is `{ delivery, wrap }` with `wrap: PushWrap = { wrapId, recipient, createdAt, relayHints }`.
+
+Per-relay reconnects are automatic and never reach `onFatal`. `onFatal` means the watcher fiber itself died and nothing restarts it: either call `watchPushInbox` again from the callback or exit and let the process supervisor restart the service, as above. `apps/push` only logs it, so a fatal there stays down until the process is restarted.
+
+## Backfill vs live, and dedupe
+
+- Every subscription attempt starts in `backfill`; the first EOSE from that relay flips it to `live`. After a reconnect the relay replays its window, so those arrivals are backfill again.
+- Live wraps are deduped across relays by wrap id (a bounded cache of the last 4096 authenticated wraps), so you see each live wrap once while it stays cached.
+- Backfill wraps are **re-emitted per copy**. Suppress them yourself and do not record them, so a later live copy of the same wrap is still delivered. `apps/push` does exactly that and keeps a SQLite ledger only of wraps it attempted to deliver.
+
+## The push codec
+
+`decodePushWrap(raw)` returns `Either<PushWrap, PushWrapFailure>`:
+
+| Failure                      | Cause                                                       |
+| ---------------------------- | ----------------------------------------------------------- |
+| `missing-push-marker`        | no `["linky","push"]` tag (not reported to `onInvalidWrap`) |
+| `malformed-event`            | not a signed wrap                                           |
+| `wrong-kind`                 | kind ≠ 1059                                                 |
+| `invalid-signature`          | outer signature fails                                       |
+| `unexpected-recipient-count` | not exactly one distinct `p` pubkey                         |
+
+The outer signature authenticates the id, tags, and ciphertext for routing and dedupe. The server never decrypts anything.
+
+## In `apps/push`
+
+`RelayWatcher` in `apps/push/src/relayWatcher.ts` is the only consumer. Its notification payload gives the client what it needs to decrypt the message itself:
+
+| Field             | Value                        |
+| ----------------- | ---------------------------- |
+| `type`            | `"nostr_inbox"`              |
+| `outerEventId`    | `wrap.wrapId`                |
+| `recipientPubkey` | `wrap.recipient`             |
+| `recipientNpub`   | `encodeNpub(wrap.recipient)` |
+| `createdAt`       | `wrap.createdAt`             |
+| `relayHints`      | `wrap.relayHints`            |
+
+The client calls `WrapInbox.fetchWrapEvent(outerEventId, { extraRelays: relayHints })` ([inbox.md](./inbox.md#fetchwrapevent-for-notification-opens)).
+
+## Proving ownership of a subscription
+
+Subscribing a pubkey to push requires a signed kind-27235 proof. The client builds it with `makePushOwnershipProof({ action, challenge }, secretKey, now)`; the server checks it with `verifyPushOwnershipProof(event)`, which returns the `action` and `challenge` or a `PushOwnershipProofFailure`. Details in [http-auth.md](./http-auth.md).
+
+## Related
+
+- [inbox.md](./inbox.md) — the decrypting sibling
+- [http-auth.md](./http-auth.md)
+- [testing.md](./testing.md) — `FakeRelay` is how the push inbox tests drive relays

--- a/packages/linkstr/docs/react.md
+++ b/packages/linkstr/docs/react.md
@@ -1,0 +1,226 @@
+# React
+
+`@linky/linkstr-react` is the effect-atom binding: one config atom, one runtime atom built from it, and a fn atom per operation. Use it for every linkstr call made from a component or hook in the web app; never build layers by hand there.
+
+## Configure
+
+`linkstrConfigAtom` holds a `LinkstrConfig | null`. Set it when an identity is available; set it to `null` on logout. While it is null, every fn atom fails with `LinkstrNotConfigured`. The minimum is a key and relays:
+
+```tsx
+import { identityFromNsec, RelayUrl } from "@linky/linkstr";
+import {
+  linkstrConfigAtom,
+  useAtomSet,
+  type LinkstrConfig,
+} from "@linky/linkstr-react";
+import { Schema } from "effect";
+import React from "react";
+
+const isRelayUrl = Schema.is(RelayUrl);
+
+const buildConfig = (
+  nsec: string | null,
+  relayUrls: readonly string[],
+): LinkstrConfig | null => {
+  const identity = nsec === null ? null : identityFromNsec(nsec.trim());
+  if (identity === null) return null;
+  const relays = relayUrls.filter(isRelayUrl);
+  return {
+    secretKey: identity.secretKey,
+    readRelays: relays,
+    writeRelays: relays,
+  };
+};
+
+/** Mount once near the root; `nsec` is null while logged out. */
+export const useLinkstrConfigSync = (
+  nsec: string | null,
+  relayUrls: readonly string[],
+) => {
+  const setConfig = useAtomSet(linkstrConfigAtom);
+  React.useEffect(() => {
+    setConfig(buildConfig(nsec, relayUrls));
+  }, [nsec, relayUrls, setConfig]);
+};
+```
+
+## Call an operation
+
+Every operation is a `linkstrRuntimeAtom.fn` atom. `useAtomSet(atom, { mode: "promiseExit" })` returns a function that resolves with an `Exit`; call it from a handler. The web app sends reactions through the outbox, so that is the first button:
+
+```tsx
+import {
+  Emoji,
+  OutboxRef,
+  ReactionDraft,
+  type Pubkey,
+  type RumorId,
+} from "@linky/linkstr";
+import { enqueueOutboxAtom, useAtomSet } from "@linky/linkstr-react";
+import { Cause, Exit } from "effect";
+
+interface ReactButtonProps {
+  peer: Pubkey;
+  messageId: RumorId;
+}
+
+export const ReactButton = ({ peer, messageId }: ReactButtonProps) => {
+  const enqueue = useAtomSet(enqueueOutboxAtom, { mode: "promiseExit" });
+
+  const onClick = async () => {
+    const draft = new ReactionDraft({
+      to: peer,
+      target: messageId,
+      targetKind: "text",
+      targetAuthor: peer,
+      emoji: Emoji.make("🔥"),
+    });
+    const exit = await enqueue({
+      op: { _tag: "reaction", draft },
+      ref: OutboxRef.make(`reaction:${messageId}`),
+    });
+    if (Exit.isFailure(exit)) {
+      console.warn(Cause.pretty(exit.cause)); // LinkstrNotConfigured while logged out
+      return;
+    }
+    console.log("queued rumor", exit.value.rumorId);
+  };
+
+  return <button onClick={() => void onClick()}>🔥</button>;
+};
+```
+
+`enqueue` resolves as soon as the job is stored; delivery happens in the background and reports through the outbox results ([Outbox](#outbox) below). With the minimal config the queue lives in memory and is lost on reload; the next section adds storage.
+
+`mode: "promise"` resolves with the value and rejects on failure; the default mode returns `void` and you read the atom's `Result` with `useAtomValue`. Prefer `promiseExit` in event handlers: failures are typed values, not thrown.
+
+| Atom                                               | Input                                         | Success value                            |
+| -------------------------------------------------- | --------------------------------------------- | ---------------------------------------- |
+| `enqueueOutboxAtom`                                | `{ op: RumorFixedOperation, ref: OutboxRef }` | `EnqueueReceipt`                         |
+| `enqueuePaymentTelemetryAtom`                      | `{ draft, recipient, ref }`                   | `OutboxJobId`                            |
+| `retractReactionAtom`                              | `RetractionDraft`                             | `RetractionReceipt`                      |
+| `sendSeenReceiptAtom`                              | `SeenReceiptDraft`                            | `SeenReceiptSendReceipt`                 |
+| `sendPaymentNoticeAtom`                            | `PaymentNoticeDraft`                          | `PaymentNoticeReceipt`                   |
+| `sendBankOfferAtom`                                | `BankOfferDraft`                              | `BankOfferReceipt`                       |
+| `publishProfileAtom`, `publishStatusAtom`          | `ProfileMetadata`, `StatusDraft`              | `PlainEventReceipt`                      |
+| `fetchProfileAtom`, `fetchProfilesAtom`            | `Pubkey`, `ReadonlyArray<Pubkey>`             | `ProfileFetchResult`, entries            |
+| `discoverActiveProfilesAtom`, `searchProfilesAtom` | options, `{ query, options? }`                | discovered profiles                      |
+| `publishRelayListsAtom`, `fetchOwnRelayListsAtom`  | `RelayListsDraft`, `void`                     | `RelayListsReceipt`, `FetchedRelayLists` |
+| `publishMuteListAtom`                              | `ReadonlyArray<Pubkey>`                       | `PlainEventReceipt`                      |
+| `fetchWrapEventAtom`                               | `{ wrapId, extraRelays? }`                    | `WrapInboxEvent \| null`                 |
+
+Chat sends and reaction adds go through `enqueueOutboxAtom` ([outbox.md](./outbox.md)); there is no `sendTextAtom`.
+
+## Persistence and inspector
+
+Once the first button works, add three optional fields to the config so the queue and the inbox cursor survive reloads and the diagnostics feed can be switched on:
+
+- `outboxStore: OutboxStore.fromStringStorage(localStorage, "linky.outbox")`
+- ``inboxCursorStore: InboxCursorStore.fromStringStorage(localStorage, `linky.inbox_cursor.${pubkey}`)``, keyed by pubkey so switching accounts never reuses a cursor
+- `inspector: boolean`, from the Advanced → Inspector toggle ([inspector.md](./inspector.md#consuming-in-react))
+
+`apps/web-app/src/app/hooks/useLinkstrConfigSync.ts` is the app's version of `buildConfig` with all three. `transport` is a test seam and stays unset in the app.
+
+## Identity switches
+
+`linkstrRuntimeAtom` is built from `linkstrConfigAtom`. Any config change (new key, new relay list, inspector toggled) closes the previous runtime with its relay pool and subscriptions, then starts new ones. Treat it as a full restart of linkstr; stream atoms restart with it.
+
+## Inbox
+
+Register a handler, then keep `wrapInboxAtom` mounted. The inbox opens when both a runtime and a handler exist and closes when either goes away.
+
+```tsx
+import {
+  UnixSeconds,
+  type InboxDelivery,
+  type WrapInboxEvent,
+} from "@linky/linkstr";
+import {
+  useAtomMount,
+  useAtomSet,
+  wrapInboxAtom,
+  wrapInboxHandlerAtom,
+} from "@linky/linkstr-react";
+import React from "react";
+
+/** Backfill window for a first session without a stored cursor. */
+const LOOKBACK_SECONDS = 3 * 24 * 60 * 60;
+
+export const useInboxSync = (
+  onEvent: (event: WrapInboxEvent, delivery: InboxDelivery) => void,
+) => {
+  const latest = React.useRef(onEvent);
+  React.useEffect(() => {
+    latest.current = onEvent;
+  });
+  const setHandler = useAtomSet(wrapInboxHandlerAtom);
+  useAtomMount(wrapInboxAtom);
+
+  React.useEffect(() => {
+    setHandler({
+      since: UnixSeconds.make(Math.floor(Date.now() / 1000) - LOOKBACK_SECONDS),
+      onEvent: (event, delivery) => latest.current(event, delivery),
+    });
+    return () => setHandler(null);
+  }, [setHandler]);
+};
+```
+
+Rules that follow from the atom design:
+
+- Run **one** sync loop per app. The feed is single-consumer; fan out inside your handler (the web app's `useLinkstrInboxSync` switches on `_tag`).
+- Every new handler object reopens the relay subscriptions. Register once per identity session and reach per-render state through refs, as above.
+- `onEvent` may return a promise; the next event waits for it.
+- `since` only matters on a first session with an empty cursor store ([inbox.md](./inbox.md#the-cursor-and-inboxcursorstore)).
+
+`fetchWrapEventAtom` is the one-shot counterpart for notification opens.
+
+## Outbox
+
+`useOutboxResults(handler)` mounts the results stream for the component's lifetime. A job is acked only after your handler resolves; a rejection leaves it to be re-delivered on the next runtime build. Mount it once, high in the tree, inside a hook that owns the app callbacks:
+
+```tsx
+import type { OutboxRef, RumorId } from "@linky/linkstr";
+import { useOutboxResults } from "@linky/linkstr-react";
+
+interface OutboxSyncCallbacks {
+  /** App callback: mark the local row named by `ref` as sent. */
+  markSent: (ref: OutboxRef, rumorId: RumorId) => Promise<void>;
+  /** App callback: record the permanent failure on the row. */
+  logFailure: (ref: OutboxRef, reason: string, detail: string) => Promise<void>;
+}
+
+export const useOutboxSync = ({
+  markSent,
+  logFailure,
+}: OutboxSyncCallbacks) => {
+  useOutboxResults(async (result) => {
+    if (result._tag === "OutboxJobSucceeded") {
+      await markSent(result.ref, result.receipt.rumorId);
+      return;
+    }
+    await logFailure(result.ref, result.reason, result.detail);
+  });
+};
+```
+
+The web app's version is `applyOutboxResult` in `apps/web-app/src/app/hooks/messages/outboxResults.ts`; [outbox.md](./outbox.md) explains results and acks.
+
+## Profile watch
+
+`watchedProfilesAtom` (the pubkey set), `profileWatchHandlerAtom`, and `profileWatchAtom` follow the inbox pattern; changing the set resubscribes without rebuilding the runtime. See [profiles.md](./profiles.md) and `apps/web-app/src/app/hooks/useLinkstrProfileSync.ts`.
+
+## Relay health and inspector
+
+- `relayHealthAtom`: `Result<ReadonlyMap<string, RelayHealthState>>`, read with `useAtomValue` and `Result.isSuccess` ([relay-health.md](./relay-health.md#reading-it-in-react)).
+- `inspectorHandlerAtom` + `inspectorEventsAtom`: set `{ onEvent }` and mount the atom; it streams only when `config.inspector` is true ([inspector.md](./inspector.md#consuming-in-react)).
+
+## Testing
+
+`packages/linkstr-react/src/testing` exports `configWith`, `settle`, `fakeTransport`, `fakeTransportLayer`, `relayA`, `relayB`, and re-exports `makeIdentity` (relative import; there is no `@linky/linkstr-react/testing` subpath). Tests use a bare `Registry.make()` instead of rendering; see [testing.md](./testing.md#linkstr-react-helpers).
+
+## Related
+
+- [getting-started.md](./getting-started.md)
+- [inbox.md](./inbox.md), [outbox.md](./outbox.md)
+- [testing.md](./testing.md)

--- a/packages/linkstr/docs/reactions.md
+++ b/packages/linkstr/docs/reactions.md
@@ -1,0 +1,187 @@
+# Reactions
+
+`Reactions` adds an emoji to a chat message and takes it back. A reaction is a NIP-25 kind 7 rumor; a retraction is a NIP-09 kind 5 rumor listing the reaction ids. Both are gift-wrapped (kind 1059) to the peer and to yourself. In the app, `react` goes through the outbox and `retract` sends direct.
+
+## Quick example
+
+Prerequisites: a `NostrSecretKey`, relay urls, the peer's `Pubkey`, and the `RumorId` of a message you received — see [getting-started.md](./getting-started.md) and [chat.md](./chat.md).
+
+Headless:
+
+```ts
+import { Effect } from "effect";
+import {
+  Emoji,
+  ReactionDraft,
+  Reactions,
+  runLinkstr,
+  type NostrSecretKey,
+  type Pubkey,
+  type RelayUrl,
+  type RumorId,
+} from "@linky/linkstr";
+
+const react = (
+  secretKey: NostrSecretKey,
+  relays: ReadonlyArray<RelayUrl>,
+  peer: Pubkey,
+  messageId: RumorId,
+) =>
+  runLinkstr(
+    { secretKey, readRelays: relays, writeRelays: relays },
+    Effect.gen(function* () {
+      const reactions = yield* Reactions;
+      return yield* reactions.react(
+        new ReactionDraft({
+          to: peer,
+          target: messageId,
+          targetKind: "text",
+          targetAuthor: peer,
+          emoji: Emoji.make("👍"),
+        }),
+      );
+    }),
+  );
+```
+
+The promise resolves with a `ReactionReceipt` once a relay accepted the peer's copy; `receipt.rumorId` is the reaction id a retraction refers to.
+
+React — the app's split: react through the outbox, retract directly. `ReactionStore` stands in for your own persistence; the rumor id saved after enqueue is what you read back to retract:
+
+```ts
+import {
+  ClientId,
+  OutboxRef,
+  ReactionDraft,
+  RetractionDraft,
+  type Emoji,
+  type Pubkey,
+  type RumorId,
+} from "@linky/linkstr";
+import {
+  enqueueOutboxAtom,
+  retractReactionAtom,
+  useAtomSet,
+} from "@linky/linkstr-react";
+import { Exit } from "effect";
+
+interface ReactionStore {
+  // Placeholders for your persistence layer, keyed by your local row id.
+  insertPending: (target: RumorId, emoji: Emoji, clientId: ClientId) => string;
+  saveRumorId: (localRowId: string, rumorId: RumorId) => void;
+  takeRumorId: (localRowId: string) => RumorId | null; // reads it back and removes the row
+}
+
+export const useReactions = (store: ReactionStore) => {
+  const enqueueOutbox = useAtomSet(enqueueOutboxAtom, { mode: "promiseExit" });
+  const retract = useAtomSet(retractReactionAtom, { mode: "promiseExit" });
+
+  const react = async (peer: Pubkey, target: RumorId, emoji: Emoji) => {
+    const clientId = ClientId.make(crypto.randomUUID());
+    const localRowId = store.insertPending(target, emoji, clientId);
+    const draft = new ReactionDraft({
+      to: peer,
+      target,
+      targetKind: "text",
+      targetAuthor: peer,
+      emoji,
+      clientId,
+    });
+    const enqueued = await enqueueOutbox({
+      op: { _tag: "reaction", draft },
+      ref: OutboxRef.make(`reaction:${localRowId}`),
+    });
+    if (Exit.isSuccess(enqueued))
+      store.saveRumorId(localRowId, enqueued.value.rumorId);
+  };
+
+  const unreact = async (peer: Pubkey, localRowId: string) => {
+    const reactionId = store.takeRumorId(localRowId);
+    if (reactionId === null) return false;
+    const retracted = await retract(
+      new RetractionDraft({ to: peer, reactionIds: [reactionId] }),
+    );
+    // A failed direct send queues nothing: offer a retry, or the peer keeps the reaction.
+    return Exit.isSuccess(retracted);
+  };
+
+  return { react, unreact };
+};
+```
+
+Enqueue success only means the job is persisted and `rumorId` is fixed. Relay acceptance arrives later on the outbox results stream as a `ReactionReceipt` keyed by your `ref` ([outbox.md](./outbox.md)).
+
+## Sending
+
+`ReactionDraft` takes `to`, `target`, `targetKind` (`"text"` | `"image"`), `targetAuthor`, `emoji`, and optional `clientId` / `sentAt`. `RetractionDraft` takes `to`, `reactionIds` (non-empty), and optional `clientId`.
+
+- `target` is the message's rumor id (`ChatMessageReceived.messageId` or the `rumorId` from your own send). `targetKind` becomes the `k` tag (`14` or `15`).
+- `to` is always the conversation peer. `targetAuthor` is p-tagged so foreign clients attribute the reaction: the peer for their message, your own pubkey for yours.
+- `Emoji` is a non-empty trimmed string of at most 32 characters.
+- One reaction per user per message is app policy, not linkstr's: the app retracts its previous reaction before sending a new one.
+
+`ReactionReceipt` and `RetractionReceipt` both carry `rumorId`, `clientId`, `sentAt`, `selfCopy: WrapDelivery`, and `recipientCopy: WrapDelivery`. Neither wrap is push-marked: reactions never wake the push server.
+
+Direct vs outbox: `Reactions.react` is available directly, but the app enqueues it (`{ _tag: "reaction", draft }`) so a reaction tapped offline is delivered later. Retractions stay direct: the app removes the local row immediately, and when the send fails nothing is queued — the user's next tap sends a fresh retraction.
+
+## Receiving
+
+| Tag                      | Fields                                                                                          | Meaning                                          |
+| ------------------------ | ----------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `ReactionAdded`          | `reactionId: RumorId`, `target: RumorId`, `from: Pubkey`, `emoji: Emoji`, `sentAt: UnixSeconds` | a peer reacted to `target`                       |
+| `OwnReactionConfirmed`   | `reactionId`, `target`, `emoji`, `clientId: ClientId \| null`, `sentAt`                         | your reaction echoed (self copy or other device) |
+| `ReactionRetracted`      | `reactionIds: NonEmptyArray<RumorId>`, `from: Pubkey`, `sentAt`                                 | a peer removed those reactions                   |
+| `OwnRetractionConfirmed` | `retractionId: RumorId`, `reactionIds`, `clientId: ClientId \| null`, `sentAt`                  | your retraction echoed                           |
+
+```ts
+import type { Pubkey, RumorId, WrapInboxEvent } from "@linky/linkstr";
+
+interface ReactionStore {
+  // Placeholders for your persistence layer.
+  upsert: (id: RumorId, target: RumorId, from: Pubkey, emoji: string) => void;
+  confirm: (clientIdOrReactionId: string) => void;
+  remove: (ids: ReadonlyArray<RumorId>, author: Pubkey) => void;
+}
+
+export const reactionHandler =
+  (store: ReactionStore, me: Pubkey) =>
+  (event: WrapInboxEvent): void => {
+    switch (event._tag) {
+      case "ReactionAdded":
+        return store.upsert(
+          event.reactionId,
+          event.target,
+          event.from,
+          event.emoji,
+        );
+      case "OwnReactionConfirmed":
+        return store.confirm(event.clientId ?? event.reactionId);
+      case "ReactionRetracted":
+        return store.remove(event.reactionIds, event.from);
+      case "OwnRetractionConfirmed":
+        return store.remove(event.reactionIds, me);
+      default:
+        return;
+    }
+  };
+```
+
+Two things the app handles that linkstr leaves to you: a reaction may arrive before its target message (the app defers it and retries when messages change), and a retraction only applies to reactions authored by the retractor — `ReactionRetracted.from` is the authorship scope.
+
+Drop reasons: `invalid-reaction` (no `e` tag, a `k` tag other than `14`/`15`, or an invalid emoji) and `invalid-retraction` (no `e` tag that is a rumor id). A kind 5 with a mix of rumor ids and foreign ids keeps the rumor ids.
+
+## Errors
+
+| Tag                    | When                                                 | What to do                                     |
+| ---------------------- | ---------------------------------------------------- | ---------------------------------------------- |
+| `RecipientNotReached`  | self copy accepted, peer's copy accepted by no relay | retry; through the outbox this happens for you |
+| `NoRelayReachable`     | no relay accepted anything                           | offline; retry later                           |
+| `OutboxJobFailed`      | `identity-changed` or `unexpected-error` terminal    | mark the local row failed                      |
+| `LinkstrNotConfigured` | React only, logged out                               | do not send                                    |
+
+## Related
+
+- [chat.md](./chat.md) — the messages you react to
+- [outbox.md](./outbox.md) — `enqueueOutboxAtom`, results, refs
+- [inbox.md](./inbox.md) — where the facts come from
+- [adding-a-vertical.md](./adding-a-vertical.md) — this is the reference vertical the template is based on

--- a/packages/linkstr/docs/relay-health.md
+++ b/packages/linkstr/docs/relay-health.md
@@ -1,0 +1,99 @@
+# Relay health
+
+`RelayHealth` is an always-on, per-relay connection status folded from the traffic linkstr actually produces; nothing is probed. You need it for any "is this relay working" UI, and you need `observeTransport` in a composition root that wants the snapshot filled. EOSE, the relay's end-of-stored-events marker, is defined in [concepts.md](./concepts.md#vocabulary).
+
+## What a snapshot holds
+
+`RelayHealthSnapshot` is `ReadonlyMap<RelayUrl, RelayHealthState>`:
+
+| Field         | Meaning                                                                      |
+| ------------- | ---------------------------------------------------------------------------- |
+| `state`       | `"connecting"` \| `"connected"` \| `"unreachable"`                           |
+| `detail`      | last close or error reason; meaningful while `unreachable`                   |
+| `lastSeenAt`  | last proof the relay served us (event, EOSE, fetch result, accepted publish) |
+| `lastErrorAt` | last failure timestamp                                                       |
+| `lastPublish` | `{ at, accepted, detail }` of the most recent publish, or null               |
+
+A relay appears in the map only after some traffic touched it. Write-only relays may never subscribe, so their freshest signal is `lastPublish`; show its timestamp.
+
+## Transitions
+
+| Traffic                                              | Effect on state                                                                                |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| subscribe attempt starts                             | `connecting` (unless already `connected`)                                                      |
+| event received, EOSE, fetch result                   | `connected`, `detail` cleared, `lastSeenAt` updated                                            |
+| accepted publish                                     | `connected` plus `lastPublish`                                                                 |
+| rejected publish                                     | only `lastPublish` and `lastErrorAt`; state untouched (a policy rejection is not a dead relay) |
+| subscription ended, `RelayUnreachable`, fetch failed | `unreachable` with the reason                                                                  |
+
+The verticals' resubscribe loops (exponential backoff from a 5s base, capped at 12×, jittered) flip an unreachable relay back to `connecting` on the next attempt. Value-equal transitions are skipped, so a flood costs at most one write per relay per second.
+
+## Composing it
+
+`observeTransport` is a transparent tap over any `NostrTransport` layer. It reports to `RelayHealth` when that service is present and passes through otherwise.
+
+```ts
+import { Layer } from "effect";
+import {
+  inspectTransport,
+  linkstrServices,
+  NostrTransportSimplePool,
+  observeTransport,
+  RelayHealth,
+} from "@linky/linkstr";
+
+const services = linkstrServices({
+  secretKey,
+  readRelays,
+  writeRelays,
+  transport: inspectTransport(observeTransport(NostrTransportSimplePool)),
+}).pipe(Layer.provideMerge(RelayHealth.live));
+```
+
+This is what the linkstr-react runtime does. Both taps wrap the same raw transport; order does not matter for correctness. `runLinkstr` composes neither, so headless runs have an empty snapshot.
+
+## Reading it in Effect
+
+```ts
+import { Effect, Stream } from "effect";
+import { RelayHealth } from "@linky/linkstr";
+
+const logHealth = Effect.gen(function* () {
+  const health = yield* RelayHealth;
+  const now = yield* health.current;
+  console.log([...now.entries()]);
+  yield* Stream.runForEach(health.changes, (snapshot) =>
+    Effect.sync(() => console.log("changed", snapshot.size)),
+  );
+});
+```
+
+`current` is the snapshot; `changes` emits the current snapshot on subscription and again on every change.
+
+## Reading it in React
+
+`relayHealthAtom` mirrors `changes` as a `Result<ReadonlyMap<string, RelayHealthState>>`, keyed by plain string so UI code can look up its own relay list. It resets when the runtime is rebuilt.
+
+```tsx
+import type { RelayHealthState } from "@linky/linkstr";
+import { relayHealthAtom, Result, useAtomValue } from "@linky/linkstr-react";
+
+const EMPTY: ReadonlyMap<string, RelayHealthState> = new Map();
+
+export const useRelayHealth = () => {
+  const result = useAtomValue(relayHealthAtom);
+  return Result.isSuccess(result) ? result.value : EMPTY;
+};
+
+export const RelayDot = ({ url }: { url: string }) => {
+  const state = useRelayHealth().get(url)?.state ?? "connecting";
+  return <span className={`relay-dot relay-dot-${state}`} title={url} />;
+};
+```
+
+The web app's `app/hooks/useRelayHealth.ts` adds `relayDotState`, `countConnectedRelays`, and `overallRelayStatus` on top of this map; treat a missing entry as "checking".
+
+## Related
+
+- [inspector.md](./inspector.md) — the sibling tap and how the two compose
+- [react.md](./react.md) — the runtime that wires both

--- a/packages/linkstr/docs/relay-lists.md
+++ b/packages/linkstr/docs/relay-lists.md
@@ -1,0 +1,119 @@
+# Relay lists
+
+`RelayLists` publishes where you can be reached: the NIP-65 relay list (kind 10002) and the NIP-17 DM inbox relay list (kind 10050), always together as one operation with one receipt per event. It also fetches your own current lists so a new device can adopt them. Plain signed events, not gift-wrapped.
+
+## Quick example
+
+Headless:
+
+```ts
+import { Effect, Schema } from "effect";
+import {
+  DEFAULT_NOSTR_RELAYS,
+  RelayListEntry,
+  RelayLists,
+  RelayListsDraft,
+  RelayUrl,
+  runLinkstr,
+} from "@linky/linkstr";
+
+const relays = DEFAULT_NOSTR_RELAYS.filter(Schema.is(RelayUrl));
+
+const lists = await runLinkstr(
+  { secretKey, readRelays: relays, writeRelays: relays },
+  Effect.gen(function* () {
+    const relayLists = yield* RelayLists;
+    yield* relayLists.publishRelayLists(
+      new RelayListsDraft({
+        relays: relays.map(
+          (relay) => new RelayListEntry({ relay, marker: null }),
+        ),
+        dmRelays: relays,
+      }),
+    );
+    return yield* relayLists.fetchOwnRelayLists();
+  }),
+);
+lists.relays?.map((entry) => entry.relay);
+```
+
+React:
+
+```ts
+import { RelayListEntry, RelayListsDraft } from "@linky/linkstr";
+import {
+  fetchOwnRelayListsAtom,
+  publishRelayListsAtom,
+  useAtomSet,
+} from "@linky/linkstr-react";
+import { Exit } from "effect";
+
+const publishRelayLists = useAtomSet(publishRelayListsAtom, {
+  mode: "promiseExit",
+});
+const fetchOwnRelayLists = useAtomSet(fetchOwnRelayListsAtom, {
+  mode: "promiseExit",
+});
+
+const published = await publishRelayLists(
+  new RelayListsDraft({
+    relays: relays.map((relay) => new RelayListEntry({ relay, marker: null })),
+    dmRelays: relays,
+  }),
+);
+if (Exit.isFailure(published)) throw new Error("relay list publish failed");
+
+const fetched = await fetchOwnRelayLists();
+if (Exit.isSuccess(fetched)) {
+  const urls =
+    fetched.value.relays?.map((entry) => entry.relay) ??
+    fetched.value.dmRelays ??
+    [];
+  applyRelayUrls(urls);
+}
+```
+
+The app does this in `useRelayDomain`: it prefers the kind 10002 list, falls back to 10050, and keeps a cached copy keyed by `relaysUpdatedAt` so a relay serving stale events cannot roll the configuration back.
+
+## Sending
+
+| Draft             | Fields                                                                                                       |
+| ----------------- | ------------------------------------------------------------------------------------------------------------ |
+| `RelayListsDraft` | `relays: RelayListEntry[]` (kind 10002), `dmRelays: RelayUrl[]` (kind 10050)                                 |
+| `RelayListEntry`  | `relay: RelayUrl`, `marker: "read" \| "write" \| null` — `null` means both, and is written as a bare `r` tag |
+
+| Receipt             | Fields                                                           |
+| ------------------- | ---------------------------------------------------------------- |
+| `RelayListsReceipt` | `relayList: PlainEventReceipt`, `dmRelayList: PlainEventReceipt` |
+
+Both events are signed with the configured identity and published to every write relay concurrently. Both publishes always run to completion; if either was accepted by no relay the operation fails with that event's `NoRelayAcceptedEvent`, the other may still have landed. Direct only — relay lists are not outbox operations.
+
+`RelayUrl` is a branded `ws://` / `wss://` url with a host. Validate user input with `Schema.is(RelayUrl)` or `Schema.decodeUnknownEither(RelayUrl)`. `DEFAULT_NOSTR_RELAYS` (`defaultRelays.ts`) is a plain string array; filter it through the brand as above before handing it to the config.
+
+## Fetching
+
+`fetchOwnRelayLists()` queries every read relay for your kinds 10002 and 10050 (8 s per relay) and returns `FetchedRelayLists`:
+
+| Field               | Type                       | Note                                  |
+| ------------------- | -------------------------- | ------------------------------------- |
+| `relays`            | `RelayListEntry[] \| null` | `null` = no kind 10002 found anywhere |
+| `relaysUpdatedAt`   | `UnixSeconds \| null`      | `created_at` of that event            |
+| `dmRelays`          | `RelayUrl[] \| null`       | `null` = no kind 10050 found          |
+| `dmRelaysUpdatedAt` | `UnixSeconds \| null`      |                                       |
+
+Entries whose value is not a relay url are dropped, not rejected. There is no receiving stream: relay lists are read on demand, not watched.
+
+## Errors
+
+| Tag                      | When                                          | What to do                          |
+| ------------------------ | --------------------------------------------- | ----------------------------------- |
+| `NoRelayAcceptedEvent`   | publish: one of the two events landed nowhere | inspect `kind` and `results`; retry |
+| `AllRelaysUnreachable`   | fetch: no read relay answered                 | keep the cached lists               |
+| `NoReadRelaysConfigured` | fetch with an empty read-relay set            | seed from `DEFAULT_NOSTR_RELAYS`    |
+| `LinkstrNotConfigured`   | React only, logged out                        | do nothing                          |
+
+## Related
+
+- [relay-health.md](./relay-health.md) — status of the relays you configured
+- [profiles.md](./profiles.md) — the other plain-event vertical
+- [getting-started.md](./getting-started.md) — `readRelays` / `writeRelays` in the config

--- a/packages/linkstr/docs/seen-receipts.md
+++ b/packages/linkstr/docs/seen-receipts.md
@@ -1,0 +1,119 @@
+# Seen receipts
+
+`SeenReceipts` tells a peer how far you have read their messages. A receipt is a kind 24136 rumor tagged `["linky", "seen_receipt"]`, gift-wrapped (kind 1059) to the peer and to yourself. It carries a **window cursor**, not per-message state: "I have seen your messages in `(sinceSec, seenUpToSec]`". Send one whenever the read cursor of an open conversation advances.
+
+## Quick example
+
+Headless:
+
+```ts
+import { Effect } from "effect";
+import {
+  SeenReceiptDraft,
+  SeenReceipts,
+  UnixSeconds,
+  runLinkstr,
+} from "@linky/linkstr";
+
+await runLinkstr(
+  { secretKey, readRelays, writeRelays },
+  Effect.gen(function* () {
+    const receipts = yield* SeenReceipts;
+    return yield* receipts.send(
+      new SeenReceiptDraft({
+        to: peer,
+        sinceSec: UnixSeconds.make(receiptsEnabledAtSec),
+        seenUpToSec: UnixSeconds.make(newestSeenMessageSec),
+      }),
+    );
+  }),
+);
+```
+
+React:
+
+```ts
+import { SeenReceiptDraft, UnixSeconds } from "@linky/linkstr";
+import { sendSeenReceiptAtom, useAtomSet } from "@linky/linkstr-react";
+import { Exit } from "effect";
+
+const sendSeenReceipt = useAtomSet(sendSeenReceiptAtom, {
+  mode: "promiseExit",
+});
+
+const exit = await sendSeenReceipt(
+  new SeenReceiptDraft({
+    to: peer,
+    sinceSec: UnixSeconds.make(receiptsEnabledAtSec),
+    seenUpToSec: UnixSeconds.make(newestSeenMessageSec),
+  }),
+);
+if (Exit.isFailure(exit)) rollBackSentCursor(peer); // the next trigger resends a superseding receipt
+```
+
+## The cursor model
+
+- `seenUpToSec` — the newest `sentAt` you have seen from this peer. It travels as the rumor content.
+- `sinceSec` — your receipts-enabled baseline, sent as the `since` tag. Messages older than it stay unmarked on the peer's side, so turning the feature on never retroactively marks history as read.
+- The decoder rejects `sinceSec >= seenUpToSec`.
+- Every receipt supersedes all earlier ones for that peer. Keep an "already reported up to" value per peer and only send when the cursor moves forward; seed that value from `OwnSeenReceiptConfirmed` so a second device or a fresh session does not resend what the peer already has.
+
+## Sending
+
+| Draft              | Fields                                                                                                           |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `SeenReceiptDraft` | `to: Pubkey`, `sinceSec: UnixSeconds`, `seenUpToSec: UnixSeconds`, `clientId?: ClientId`, `sentAt?: UnixSeconds` |
+
+| Receipt                  | Fields                                                                                   |
+| ------------------------ | ---------------------------------------------------------------------------------------- |
+| `SeenReceiptSendReceipt` | `rumorId`, `clientId`, `sentAt`, `selfCopy: WrapDelivery`, `recipientCopy: WrapDelivery` |
+
+Direct only, and silent by design:
+
+- Not through the outbox. A retried receipt would republish a cursor that a later receipt already superseded. A lost send self-heals on the next trigger (new message, tab refocus, route re-entry) because that receipt carries the newer cursor anyway.
+- No `["linky", "push"]` marker on either wrap, so a receipt never produces a notification.
+
+## Receiving
+
+| Tag                       | Fields                                                                                              | Meaning                                                      |
+| ------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `SeenReceiptReceived`     | `receiptId: RumorId`, `from: Pubkey`, `sinceSec: UnixSeconds`, `seenUpToSec: UnixSeconds`, `sentAt` | the peer has seen your messages in `(sinceSec, seenUpToSec]` |
+| `OwnSeenReceiptConfirmed` | `receiptId`, `to: Pubkey`, `sinceSec`, `seenUpToSec`, `clientId: ClientId \| null`, `sentAt`        | your own receipt echoed; `to` is the peer it was sent to     |
+
+```ts
+import type { WrapInboxEvent } from "@linky/linkstr";
+
+const onEvent = (event: WrapInboxEvent): void => {
+  switch (event._tag) {
+    case "SeenReceiptReceived":
+      // Monotonic: ignore anything that does not move the peer's cursor forward.
+      return advancePeerSeen(event.from, {
+        sinceSec: event.sinceSec,
+        seenUpToSec: event.seenUpToSec,
+      });
+    case "OwnSeenReceiptConfirmed":
+      return recordSentSeenReceipt(event.to, event.seenUpToSec);
+    default:
+      return;
+  }
+};
+```
+
+Treat `seenUpToSec` from a peer as untrusted input: the app clamps it to shortly after "now" so a far-future cursor cannot mark everything seen forever.
+
+Drop reasons: `invalid-seen-receipt` (missing `linky` tag, unparsable seconds, `since >= seenUpTo`, or own copy without a peer p-tag) and `not-addressed-to-me`.
+
+## Errors
+
+| Tag                    | When                                  | What to do                                                       |
+| ---------------------- | ------------------------------------- | ---------------------------------------------------------------- |
+| `RecipientNotReached`  | self copy landed, peer's copy did not | roll the local "sent up to" value back; the next trigger resends |
+| `NoRelayReachable`     | nothing accepted                      | same                                                             |
+| `LinkstrNotConfigured` | React only, logged out                | do not send                                                      |
+
+## Related
+
+- [chat.md](./chat.md) — the messages the cursor covers
+- [inbox.md](./inbox.md) — delivery of the facts above
+- [reactions.md](./reactions.md) — the own-echo split this codec mirrors
+- `docs/architecture.md` — "Linkstr protocol package", seen-receipts paragraph, for the design rationale

--- a/packages/linkstr/docs/testing.md
+++ b/packages/linkstr/docs/testing.md
@@ -1,0 +1,260 @@
+# Testing
+
+Two helper sets give you throwaway identities, transport stubs, an in-memory relay, and a polling helper, so a vertical test runs in milliseconds with no network:
+
+- `@linky/linkstr/testing`, a public subpath of the linkstr package, for tests in any workspace.
+- `packages/linkstr-react/src/testing`, package-internal; import it relatively (`from "./testing"`) from tests inside linkstr-react. There is no `@linky/linkstr-react/testing` subpath.
+
+Never import either from production code.
+
+## Running tests
+
+Tests are Vitest, live next to their subject as `*.test.ts`, and use globals: `describe`, `it`, `expect`, and `assert` need no import (`vitest.config.ts` sets `globals: true`; `tsconfig.test.json` adds the types).
+
+```bash
+bun run --filter @linky/linkstr test                 # one package
+cd packages/linkstr && bunx vitest run reactions     # files matching a name
+bun run test                                         # every workspace
+```
+
+## `@linky/linkstr/testing`
+
+| Helper                                             | Use                                                                                                    |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `makeIdentity()`                                   | fresh `{ pubkey, secretKey }`                                                                          |
+| `stubWrapTransport(published, accept?, options?)`  | `Layer<NostrTransport>` recording every wrap into `published`; `accept(wrap, relay)` decides per relay |
+| `stubWrapTransportService(...)`                    | the same as a service value, for custom layers                                                         |
+| `stubPlainTransport(published, accept?, options?)` | the plain-event twin (profiles, relay lists, mute list)                                                |
+| `recipientOf(event)`                               | first `p` tag of a wrap                                                                                |
+| `hasPushMarker(wrap)`                              | whether the `["linky","push"]` tag is present                                                          |
+| `FakeRelay`, `poolFor(fakes)`                      | in-memory relay behind `makeRelayPoolTransport`; you call `emit`, `eose`, `closeFromRelay`             |
+| `eventually(predicate)`                            | `expect.poll` inside an Effect                                                                         |
+| `stubStorage()`                                    | `StringStorage` over a `Map`, for `OutboxStore` / `InboxCursorStore`                                   |
+| `SignedWrapEvent`, `SignedPlainEvent` (types)      | for typing `published` arrays                                                                          |
+
+Stub transports `die` on `subscribe` and `fetch` unless you pass them in `options`; use `FakeRelay` when a test needs subscriptions.
+
+## A send test
+
+```ts
+import { Effect, Exit, Layer } from "effect";
+import {
+  ClientId,
+  Emoji,
+  LinkstrIdentity,
+  ReactionDraft,
+  Reactions,
+  RelayPolicy,
+  RelayUrl,
+  RumorId,
+} from "@linky/linkstr";
+import {
+  makeIdentity,
+  recipientOf,
+  stubWrapTransport,
+} from "@linky/linkstr/testing";
+import type { SignedWrapEvent } from "@linky/linkstr/testing";
+
+const alice = makeIdentity();
+const bob = makeIdentity();
+const relay = RelayUrl.make("wss://relay.test");
+
+it("wraps the reaction to self and to the peer", async () => {
+  const published: Array<SignedWrapEvent> = [];
+  const layer = Reactions.Default.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        LinkstrIdentity.fromSecretKey(alice.secretKey),
+        RelayPolicy.fixed({ readRelays: [relay], writeRelays: [relay] }),
+        stubWrapTransport(published),
+      ),
+    ),
+  );
+
+  const exit = await Effect.runPromiseExit(
+    Effect.flatMap(Reactions, (reactions) =>
+      reactions.react(
+        new ReactionDraft({
+          to: bob.pubkey,
+          target: RumorId.make("ab".repeat(32)),
+          targetKind: "text",
+          targetAuthor: bob.pubkey,
+          emoji: Emoji.make("🔥"),
+          clientId: ClientId.make("client-42"),
+        }),
+      ),
+    ).pipe(Effect.provide(layer)),
+  );
+
+  assert(Exit.isSuccess(exit));
+  expect(exit.value.clientId).toBe("client-42");
+  expect(published.map(recipientOf)).toEqual(
+    expect.arrayContaining([alice.pubkey, bob.pubkey]),
+  );
+});
+```
+
+To test the failure path, pass an `accept` function: `stubWrapTransport(published, (wrap) => recipientOf(wrap) === alice.pubkey)` accepts only the self copy, so `react` fails with `RecipientNotReached`.
+
+## An inbound test
+
+Build a real wrap with the public API: send from bob to alice through a recording stub and keep the copy addressed to alice. Then feed it to alice's inbox through a `FakeRelay`.
+
+```ts
+import { Duration, Effect, Layer, Stream } from "effect";
+import {
+  Emoji,
+  InboxCursorStore,
+  LinkstrIdentity,
+  makeRelayPoolTransport,
+  NostrTransport,
+  ReactionDraft,
+  Reactions,
+  RelayPolicy,
+  RelayUrl,
+  RumorId,
+  WrapInbox,
+  type WrapInboxEvent,
+} from "@linky/linkstr";
+import {
+  eventually,
+  FakeRelay,
+  makeIdentity,
+  poolFor,
+  recipientOf,
+  stubWrapTransport,
+} from "@linky/linkstr/testing";
+import type { SignedWrapEvent } from "@linky/linkstr/testing";
+
+const alice = makeIdentity();
+const bob = makeIdentity();
+const relay = RelayUrl.make("wss://relay.test");
+
+const wrapFromBob = async (): Promise<SignedWrapEvent> => {
+  const published: Array<SignedWrapEvent> = [];
+  const asBob = Reactions.Default.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        LinkstrIdentity.fromSecretKey(bob.secretKey),
+        RelayPolicy.fixed({ readRelays: [relay], writeRelays: [relay] }),
+        stubWrapTransport(published),
+      ),
+    ),
+  );
+  await Effect.runPromise(
+    Effect.flatMap(Reactions, (reactions) =>
+      reactions.react(
+        new ReactionDraft({
+          to: alice.pubkey,
+          target: RumorId.make("ab".repeat(32)),
+          targetKind: "text",
+          targetAuthor: alice.pubkey,
+          emoji: Emoji.make("🔥"),
+        }),
+      ),
+    ).pipe(Effect.provide(asBob)),
+  );
+  const wrap = published.find((event) => recipientOf(event) === alice.pubkey);
+  assert(wrap !== undefined);
+  return wrap;
+};
+
+it("routes a wrap into a typed fact", async () => {
+  const wrap = await wrapFromBob();
+  const fake = new FakeRelay();
+  const layer = WrapInbox.Default.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        LinkstrIdentity.fromSecretKey(alice.secretKey),
+        RelayPolicy.fixed({ readRelays: [relay], writeRelays: [] }),
+        Layer.succeed(
+          NostrTransport,
+          makeRelayPoolTransport(poolFor(new Map([[relay, fake]]))),
+        ),
+        InboxCursorStore.inMemory,
+      ),
+    ),
+  );
+
+  const seen = await Effect.gen(function* () {
+    const inbox = yield* WrapInbox;
+    const feed = yield* inbox.open({ resubscribeDelay: Duration.millis(10) });
+    const collected: Array<WrapInboxEvent> = [];
+    yield* Effect.forkScoped(
+      Stream.runForEach(feed.events, ({ event }) =>
+        Effect.sync(() => collected.push(event)),
+      ),
+    );
+    yield* eventually(() => fake.subscriptions.length === 1);
+    fake.eose();
+    fake.emit(wrap);
+    yield* eventually(() => collected.length === 1);
+    return collected;
+  }).pipe(Effect.scoped, Effect.provide(layer), Effect.runPromise);
+
+  expect(seen[0]?._tag).toBe("ReactionAdded");
+});
+```
+
+`fake.emit` before `fake.eose()` yields `delivery: "backfill"`; after it, `"live"`. `fake.closeFromRelay("reason")` ends the subscription so you can watch the resubscribe loop; set `fake.down = true` to make `ensureRelay` reject.
+
+## linkstr-react helpers
+
+| Helper                                                              | Use                                                                      |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `configWith(identity, transport, overrides?)`                       | a `LinkstrConfig` on one relay (`relayA`) over the given transport layer |
+| `settle(registry, fnAtom)`                                          | awaits the fn atom's `Result` as an `Exit`                               |
+| `fakeTransport(published, subscriptions, stored?, fetchedFilters?)` | accepts every publish, records subscriptions, serves `stored` to fetches |
+| `fakeTransportLayer(...)`                                           | the same as a `Layer<NostrTransport>`                                    |
+| `relayA`, `relayB`                                                  | `wss://relay-a.test`, `wss://relay-b.test`                               |
+| `makeIdentity`                                                      | re-exported                                                              |
+
+Drive atoms with a bare `Registry` instead of rendering:
+
+```ts
+import { ClientId, RetractionDraft, RumorId } from "@linky/linkstr";
+import { stubWrapTransport } from "@linky/linkstr/testing";
+import type { SignedWrapEvent } from "@linky/linkstr/testing";
+import { linkstrConfigAtom, Registry, retractReactionAtom } from "./index";
+import { configWith, makeIdentity, settle } from "./testing";
+import { Exit } from "effect";
+
+it("retracts through the configured transport", async () => {
+  const alice = makeIdentity();
+  const bob = makeIdentity();
+  const registry = Registry.make();
+  const published: Array<SignedWrapEvent> = [];
+  registry.set(
+    linkstrConfigAtom,
+    configWith(alice, stubWrapTransport(published)),
+  );
+
+  registry.set(
+    retractReactionAtom,
+    new RetractionDraft({
+      to: bob.pubkey,
+      reactionIds: [RumorId.make("ab".repeat(32))],
+      clientId: ClientId.make("client-42"),
+    }),
+  );
+  const exit = await settle(registry, retractReactionAtom);
+
+  assert(Exit.isSuccess(exit));
+  expect(published).toHaveLength(2);
+  registry.dispose();
+});
+```
+
+For stream atoms (`wrapInboxAtom`, `outboxResultsAtom`, `relayHealthAtom`), set the handler atom, then `registry.mount(atom)` and `expect.poll` on what the handler collected; unmount at the end.
+
+## Rules
+
+- Never import `@linky/linkstr/testing` or `linkstr-react/src/testing` from production code. Both packages exclude their `testing` directory from the app build.
+- Extend these helpers instead of redeclaring fixtures per test file.
+- Build inbound fixtures through the public send API where you can, as above; tests that need an independent implementation may use `nostr-tools` directly (it is a devDependency for that reason).
+
+## Related
+
+- [getting-started.md](./getting-started.md)
+- [inbox.md](./inbox.md), [outbox.md](./outbox.md) — what the fakes are driving
+- [react.md](./react.md)


### PR DESCRIPTION
## Why

Anyone new to `@linky/linkshu` or `@linky/linkstr` had only the package READMEs (design rules and rationale) and the source to learn from. There was no place that showed how to actually call the packages: what to bring, how to run them, what each operation returns, and what to do when it fails. This PR adds that documentation as markdown guides, in the spirit of the zustand and jotai docs, so a developer can use either package after reading.

## What

- `packages/linkshu/docs/` — index, getting started (core concepts plus a first run whose output was captured from a real `bun run`), concepts, ports, errors, inspector, testing, and one guide per wallet operation: receive, send, melt, top up, autoswap, validation, restore, tokens, mints, fee probe, lightning utilities.
- `packages/linkstr/docs/` — index, getting started (core concepts plus a first run executed against the local relay), concepts with a vocabulary table, React (`@linky/linkstr-react`), inbox, outbox, identity and keys, push inbox, relay health, inspector, testing, adding a vertical, and one guide per vertical: chat, reactions, seen receipts, payment notices, payment telemetry, bank offers, profiles, relay lists, mute list, HTTP auth.
- Each index explains where to start and how to find things; each getting started ends with the reader having run something.
- `AGENTS.md` in `packages/linkshu`, `packages/linkstr`, and `packages/linkstr-react`: a change to an exported surface or documented behavior updates the matching guide in the same commit. Root `AGENTS.md` points at them.
- Package READMEs and the root README link to the guides.

## How it was checked

- Every non-trivial snippet was compiled against the real package types (temporary scratch files under `src/`, since removed).
- A separate readability review pass was applied to all 40 guides; every factual claim it questioned was verified in source before the docs changed.
- All relative links and anchors across the 46 touched markdown files resolve. `bun run check-code` passes.

## Follow-ups filed

Writing the guides surfaced gaps that are documented honestly rather than papered over:

- #332 linkstr-react has no `./testing` export subpath
- #333 `runLinkstr` cannot persist the inbox cursor
- #334 no explicit way to add or forget a known mint
- #335 reserved rows from an interrupted melt have no resumer
- #336 inspector rows carry attachment encryption keys from chat drafts
