### PR TITLE
fix(wallet): stop NUT-18 POST payments failing with "empty payment proofs" on v2 keysets

### DIFF
--- a/apps/web-app/src/app/hooks/composition/useCashuWalletComposition.ts
+++ b/apps/web-app/src/app/hooks/composition/useCashuWalletComposition.ts
@@ -19,7 +19,6 @@ import {
   sendPaymentNoticeAtom,
   useAtomSet,
 } from "@linky/linkstr-react";
-import { decodeTokenText } from "@linky/linkshu";
 import { Cause, Either, Exit, Option, Schema } from "effect";
 import React, { useMemo, useState } from "react";
 import {
@@ -1358,13 +1357,10 @@ export const useCashuWalletComposition = ({
         sentMint = receipt.mint;
 
         try {
-          const decoded = decodeTokenText(receipt.tokenText);
-          if (decoded === null) throw new Error("empty payment proofs");
-
           const body: Record<string, unknown> = {
             mint: receipt.mint,
             unit: receipt.unit,
-            proofs: decoded.proofs,
+            proofs: receipt.proofs,
           };
           if (requestInfo.requestId) body.id = requestInfo.requestId;
           if (requestInfo.description) body.memo = requestInfo.description;

--- a/apps/web-app/src/app/hooks/payments/usePayContactWithCashuMessage.test.tsx
+++ b/apps/web-app/src/app/hooks/payments/usePayContactWithCashuMessage.test.tsx
@@ -74,6 +74,7 @@ const sendTokenText = buildCashuToken({
 const sendReceipt = new SendReceipt({
   rowId: TokenRowId.make("send-row"),
   tokenText: TokenText.make(sendTokenText),
+  proofs: [],
   mint: MintUrl.make(MINT_URL),
   unit: CurrencyUnit.make("sat"),
   amount: Amount.make(600),

--- a/packages/linkshu/src/internal/operations.ts
+++ b/packages/linkshu/src/internal/operations.ts
@@ -1,5 +1,6 @@
 import { Effect, Struct } from "effect";
 import type { TokenText } from "../domain/primitives";
+import type { Proof } from "../token/domain";
 import type { InspectorService } from "../inspector/Inspector";
 import { OperationFailed, OperationSucceeded } from "../inspector/events";
 
@@ -59,7 +60,12 @@ export const inspectOperation =
       (result) => result,
     )(operation);
 
-/** Token text carries proof secrets; a receipt's other fields are safe. */
-export const redactReceipt = <R extends { readonly tokenText: TokenText }>(
+/** Token text and proofs carry secrets; a receipt's other fields are safe. */
+export const redactReceipt = <
+  R extends {
+    readonly tokenText: TokenText;
+    readonly proofs?: ReadonlyArray<Proof>;
+  },
+>(
   receipt: R,
-) => Struct.omit(receipt, "tokenText");
+) => Struct.omit(receipt, "tokenText", "proofs");

--- a/packages/linkshu/src/send/Send.test.ts
+++ b/packages/linkshu/src/send/Send.test.ts
@@ -19,7 +19,7 @@ import type { StoredTokenRow } from "../ports/TokenStore";
 import { fakeWallet, KEYSET_HEX, proof } from "../testing/fakeWallet";
 import { recordingInspector } from "../testing/inspector";
 import { seedRow } from "../testing/rows";
-import { parseTokenText } from "../token/codec";
+import { decodeTokenText, parseTokenText } from "../token/codec";
 import { encodeCashuProofs } from "../token/internal/cashuProofs";
 import type { TokenState } from "../token/domain";
 import { SendDraft } from "./domain";
@@ -255,6 +255,32 @@ describe("Send.send", () => {
     // Exact spend: no change row, only the pending send row remains.
     expect(exit.value.rows).toHaveLength(1);
     expect(exit.value.rows[0]?.state).toBe("pending");
+  });
+
+  it("carries the sent proofs with full v2 keyset ids, which the token text alone loses", async () => {
+    const v2KeysetId = "01" + "ab".repeat(32);
+    const sent = [proof(4, "s1"), proof(2, "s2")].map((sentProof) => ({
+      ...sentProof,
+      id: v2KeysetId,
+    }));
+    const { wallet } = makeWallet({
+      send: () => Promise.resolve({ keep: [], send: sent }),
+    });
+    const { run } = makeHarness(wallet);
+
+    const exit = await run(sendAndInspect(draft(6, "pending"), [tokenA]));
+    assert(Exit.isSuccess(exit));
+    const { receipt } = exit.value;
+    assert(receipt._tag === "Right");
+
+    expect(receipt.right.proofs).toMatchObject([
+      { id: v2KeysetId, amount: 4, secret: "s1" },
+      { id: v2KeysetId, amount: 2, secret: "s2" },
+    ]);
+    expect(decodeTokenText(receipt.right.tokenText)).toBeNull();
+    expect(
+      decodeTokenText(receipt.right.tokenText, [v2KeysetId])?.proofs,
+    ).toEqual(receipt.right.proofs);
   });
 
   it("excludes NUT-07 spent proofs and marks fully spent rows as error", async () => {

--- a/packages/linkshu/src/send/Send.ts
+++ b/packages/linkshu/src/send/Send.ts
@@ -125,6 +125,7 @@ export class Send extends Effect.Service<Send>()("linkshu/Send", {
         return new SendReceipt({
           rowId: sendRow.id,
           tokenText: sendEncoded.tokenText,
+          proofs: sendEncoded.proofs,
           mint: draft.mint,
           unit: sat,
           amount: sendEncoded.amount,

--- a/packages/linkshu/src/send/domain.ts
+++ b/packages/linkshu/src/send/domain.ts
@@ -13,6 +13,7 @@ import {
   TokenRowId,
   TokenText,
 } from "../domain/primitives";
+import { Proof } from "../token/domain";
 
 export class SendDraft extends Schema.Class<SendDraft>("SendDraft")({
   mint: MintUrl,
@@ -30,6 +31,12 @@ export class SendReceipt extends Schema.Class<SendReceipt>("SendReceipt")({
   /** Row holding the produced send token, in the drafted state. */
   rowId: TokenRowId,
   tokenText: TokenText,
+  /**
+   * The same proofs `tokenText` encodes, with full keyset ids. v4 text
+   * shortens v2 keyset ids, so callers that need the proofs themselves
+   * (NUT-18 POST transport) take them from here instead of decoding.
+   */
+  proofs: Schema.Array(Proof),
   mint: MintUrl,
   unit: CurrencyUnit,
   amount: Amount,

--- a/packages/linkshu/src/token/internal/cashuProofs.ts
+++ b/packages/linkshu/src/token/internal/cashuProofs.ts
@@ -8,6 +8,7 @@ import { decodeTokenFields } from "./v3Json";
 
 export interface EncodedCashuProofs {
   readonly tokenText: TokenText;
+  readonly proofs: ReadonlyArray<Proof>;
   readonly amount: Amount;
 }
 
@@ -24,7 +25,11 @@ const encodeValidated = (
   const decoded = decodeTokenFields(args);
   if (decoded === null) return null;
   const total = decoded.proofs.reduce((sum, proof) => sum + proof.amount, 0);
-  return { tokenText: encodeToken(decoded), amount: Amount.make(total) };
+  return {
+    tokenText: encodeToken(decoded),
+    proofs: decoded.proofs,
+    amount: Amount.make(total),
+  };
 };
 
 const plainCashuProof = (proof: CashuProof): unknown => ({


### PR DESCRIPTION
## Problem

Paying a cashu payment request over the HTTP POST transport fails on cashu.cz with an error row showing `Error: empty payment proofs`, even though the mint and its Lightning node are fine.

The swap at the mint succeeds. The app then decodes the freshly produced token text back into proofs to build the POST body. cashu.cz has rotated to a v2 keyset (long `01…` id), and v4 token text stores those ids in shortened form. cashu-ts can only expand them when given the mint's keyset list, which this call site never passed, so the decode returned null and the payment was aborted after the swap. The catch path re-receives the pending row, so no funds were lost, but every POST-transport payment from a v2-keyset mint fails.

## Fix

- `SendReceipt` now carries the proofs the swap produced, with full keyset ids. The wallet already has them when it encodes the token, so callers that need proofs no longer re-decode text.
- The payment-request POST body uses `receipt.proofs` directly. The `decodeTokenText` call and the `"empty payment proofs"` throw are gone.
- `redactReceipt` omits `proofs` alongside `tokenText`, so proof secrets never reach inspector events. The existing "no key material in events" assertion in the Send suite covers this.

## Tests

- New Send test: a swap returning proofs on a v2 keyset yields a receipt whose proofs carry the full id, while the token text alone decodes to null without keyset ids and to the same proofs with them.
- `bun run check-code` and `bun run test` pass across all workspaces.