### PR TITLE
docs(linkshu): explain send proofs and recovery limits

### DIFF
--- a/packages/linkshu/docs/send.md
+++ b/packages/linkshu/docs/send.md
@@ -40,6 +40,10 @@ Run it with `runLinkshu` or on your `ManagedRuntime`.
 
 Linky's QR/share flow uses `issued`; contact payments over Nostr and payment-request POSTs use `pending`.
 
+For an HTTP POST payment request, use `receipt.proofs` in the JSON payload. These are the same proofs encoded in `receipt.tokenText`, with full keyset ids. Decoding v4 token text without the mint's keyset list fails for shortened v2 ids. Both fields contain spendable secrets; keep them out of logs and inspector events.
+
+If delivery fails, check the result of `Tokens.returnToWallet`: recovery is attempted, not guaranteed. Successful recovery returns fresh proofs to the spendable balance; a transient failure preserves the pending row for a retry. Linky's POST flow currently displays the original payment error even if recovery also fails, so that error alone does not confirm the funds were returned. See [tokens.md](./tokens.md#returntowallet).
+
 ### Fees
 
 Sends are exact-amount: the recipient receives `amount`. The mint's cashu input fee comes out of the change, so `receipt.feePaid = available - amount - changeAmount`. If the offered proofs cannot cover `amount` plus fees, the mint's own rejection is reported as `InsufficientFunds` (`required: amount`, `available`). There is no amount-degrade ladder in the package; the app decides whether to retry lower.
@@ -61,15 +65,16 @@ The `issued` row keeps the funds visible under "issued" but not in `balances`. T
 
 `SendReceipt`:
 
-| Field          | Type                | Notes                                                           |
-| -------------- | ------------------- | --------------------------------------------------------------- |
-| `rowId`        | `TokenRowId`        | the send row, in `produceAs` state                              |
-| `tokenText`    | `TokenText`         | v4 encoding to hand out                                         |
-| `mint`         | `MintUrl`           |                                                                 |
-| `unit`         | `CurrencyUnit`      | always `sat`                                                    |
-| `amount`       | `Amount`            | equals the drafted amount                                       |
-| `changeAmount` | `NonNegativeAmount` | persisted as a fresh `accepted` row before the receipt resolved |
-| `feePaid`      | `NonNegativeAmount` | cashu input fee the swap cost                                   |
+| Field          | Type                   | Notes                                                                        |
+| -------------- | ---------------------- | ---------------------------------------------------------------------------- |
+| `rowId`        | `TokenRowId`           | the send row, in `produceAs` state                                           |
+| `tokenText`    | `TokenText`            | v4 encoding to hand out                                                      |
+| `proofs`       | `ReadonlyArray<Proof>` | the encoded proofs with full keyset ids; use directly for HTTP POST payloads |
+| `mint`         | `MintUrl`              |                                                                              |
+| `unit`         | `CurrencyUnit`         | always `sat`                                                                 |
+| `amount`       | `Amount`               | equals the drafted amount                                                    |
+| `changeAmount` | `NonNegativeAmount`    | persisted as a fresh `accepted` row before the receipt resolved              |
+| `feePaid`      | `NonNegativeAmount`    | cashu input fee the swap cost                                                |
 
 ## Errors
 

--- a/packages/linkshu/src/token/domain.ts
+++ b/packages/linkshu/src/token/domain.ts
@@ -49,8 +49,7 @@ export class InvalidTokenTransition extends Schema.TaggedError<InvalidTokenTrans
 
 /**
  * A NUT-00 proof in linkshu's own serializable shape; `C` is the wire-format
- * field name. Appears in the public API only through the token codec — wallet
- * operations exchange token text, never proof lists.
+ * field name. The token codec and SendReceipt expose these proofs.
  */
 export class Proof extends Schema.Class<Proof>("Proof")({
   id: KeysetId,


### PR DESCRIPTION
After #342, the Send guide still omits `SendReceipt.proofs`, and the `Proof` comment incorrectly says wallet operations never expose proof lists. Document the full keyset IDs, direct use in HTTP POST payloads, and secret redaction.

Clarify that failed delivery triggers an attempted return to the wallet. Recovery can fail, and the original payment error does not confirm that funds returned to the balance. This corrects the unconditional recovery claim in #342.

Validation: `bun run check-code` passed; documentation checked against the merged send, POST, and recovery implementations. Documentation and comments only.
